### PR TITLE
Fix AJAX controls in iOS 6

### DIFF
--- a/octoprint/static/js/ui.js
+++ b/octoprint/static/js/ui.js
@@ -1391,6 +1391,12 @@ $(function() {
             webcamViewModel,
             gcodeViewModel
         );
+        
+        //work around a stupid iOS6 bug where ajax requests get cached and only work once, as described at http://stackoverflow.com/questions/12506897/is-safari-on-ios-6-caching-ajax-results
+        $.ajaxSetup({
+		    type: 'POST',
+		    headers: { "cache-control": "no-cache" }
+		});
 
         //~~ Show settings - to ensure centered
         $('#navbar_show_settings').click(function() {


### PR DESCRIPTION
This uses a workaround for [this bug](http://stackoverflow.com/questions/12506897/is-safari-on-ios-6-caching-ajax-results) to make sure AJAX requests get sent every time. The bug caused AJAX requests to be cached so buttons in OctoPrint would only work the first time you clicked them on an iOS device.
