### PR TITLE
Prevents manual commands from interupting other commands

### DIFF
--- a/octoprint/util/comm.py
+++ b/octoprint/util/comm.py
@@ -429,7 +429,9 @@ class MachineCom(object):
 
 			### Connection attempt
 			elif self._state == self.STATE_CONNECTING:
-				if (line == "" or "wait" in line) and startSeen:
+				#if (line == "" or "wait" in line) and startSeen:
+				#This modification allows more reliable initial connection.
+				if ("wait" in line) and startSeen:
 					self._sendCommand("M105")
 				elif "start" in line:
 					startSeen = True


### PR DESCRIPTION
This fixes an issue where if manual command was sent while another command was being processed they would both end up with the same line number. Octoprint couldn't recover and the print would fail. 
