### PR TITLE
Resend gcode does not resend the correct line

### DIFF
--- a/octoprint/util/comm.py
+++ b/octoprint/util/comm.py
@@ -779,7 +779,7 @@ class MachineCom(object):
 
 		if lineToResend is not None:
 			self._resendDelta = self._currentLine - lineToResend
-			if self._resendDelta > len(self._lastLines):
+			if self._resendDelta >= len(self._lastLines):
 				self._errorValue = "Printer requested line %d but history is only available up to line %d" % (lineToResend, self._currentLine - len(self._lastLines))
 				self._changeState(self.STATE_ERROR)
 				self._logger.warn(self._errorValue)
@@ -834,13 +834,13 @@ class MachineCom(object):
 		# Make sure we are only handling one sending job at a time
 		with self._sendingLock:
 			self._logger.debug("Resending line %d, delta is %d, history log is %s items strong" % (self._currentLine - self._resendDelta, self._resendDelta, len(self._lastLines)))
-			cmd = self._lastLines[-self._resendDelta]
+			cmd = self._lastLines[-(self._resendDelta+1)]
 			lineNumber = self._currentLine - self._resendDelta
 
 			self._doSendWithChecksum(cmd, lineNumber)
 
 			self._resendDelta -= 1
-			if self._resendDelta <= 0:
+			if self._resendDelta < 0:
 				self._resendDelta = None
 
 	def _sendCommand(self, cmd, sendChecksum=False):


### PR DESCRIPTION
Due to a larger issue, Octoprint gets out of sync with my printer and has to start replaying lines:

```
Send: N71 G1 X40.650 Y158.460 E20.96895*84
Recv: ok
Send: N72 G1 X39.790 Y158.260 E21.01634*88
Recv: ok
Send: N73 G1 X38.490 Y157.860 E21.08934*88
Recv: ok
Send: N74 G1 X37.720 Y157.570 E21.13350*86
Recv: Error:checksum mismatch, Last Line: 70
Recv: Resend: 71
Send: N71 G1 X39.790 Y158.260 E21.01634*91
Recv: ok
Send: N72 G1 X38.490 Y157.860 E21.08934*89
Recv: Error:Line Number is not Last Line Number+1, Last Line: 70
Recv: Resend: 71
Recv: ok
Send: N72 G1 X38.490 Y157.860 E21.08934*89
Recv: ok
Send: N73 G1 X37.720 Y157.570 E21.13350*81
Recv: ok
Send: N75 G1 X36.980 Y157.180 E21.17840*87
Recv: ok
Send: N76 G1 X35.810 Y156.480 E21.25158*90
Recv: Error:Line Number is not Last Line Number+1, Last Line: 73
Recv: Resend: 74
```

Note that when it resends line 71 it is actually resending 72. Then, once it syncs back up it is actually skipping the resend of line 74 and going right on to 75. It is a simple Obiwan in the resend function due to the one-based natured of negative array indexes.
