### PR TITLE
Add a serial.autoconnect setting to connect to the printer on startup

### DIFF
--- a/octoprint/server.py
+++ b/octoprint/server.py
@@ -824,6 +824,8 @@ class Server():
 		self._server.listen(self._port, address=self._host)
 
 		eventManager.fire("Startup")
+		if settings().getBoolean(["serial", "autoconnect"]):
+			printer.connect(settings().get(["serial", "port"]), settings().getInt(["serial", "baudrate"]))
 		IOLoop.instance().start()
 
 	def _createSocketConnection(self, session, endpoint=None):

--- a/octoprint/settings.py
+++ b/octoprint/settings.py
@@ -25,7 +25,8 @@ def settings(init=False, configfile=None, basedir=None):
 default_settings = {
 	"serial": {
 		"port": None,
-		"baudrate": None
+		"baudrate": None,
+		"autoconnect": False
 	},
 	"server": {
 		"host": "0.0.0.0",


### PR DESCRIPTION
Any reason there isn't an "autoconnect" option for connecting to the printer when octoprint is started? Quick implementation proof of concept attached (works).
