### PR TITLE
Fix initial temperatureHistory load not containing any data

### DIFF
--- a/octoprint/printer.py
+++ b/octoprint/printer.py
@@ -303,8 +303,10 @@ class Printer():
 	def _sendInitialStateUpdate(self, callback):
 		try:
 			data = self._stateMonitor.getCurrentData()
+			# convert the dict of deques to a dict of lists
+			temps = {k: list(v) for (k,v) in self._temps.iteritems()}
 			data.update({
-				"temperatureHistory": list(self._temps),
+				"temperatureHistory": temps,
 				"logHistory": list(self._log),
 				"messageHistory": list(self._messages)
 			})


### PR DESCRIPTION
I broke it! My patch to switch internal data structures to deques didn't convert the temperatureHistory field of data sent in the initial page load. This meant the initial graph would come up blank until there were two updates _after_ the page was fully loaded, and never showed the full 300 point history.

This just converts the dictionary of deques to a dictionary of lists before sending it. The other alternative would be to just use lists internally, but because the `_sendInitialStateUpdate()` is called only once per full page load versus once every 5 seconds all the time, it made more sense to do it here. If it were in `_addTemperatureData()`, this same overhead would be incurred every 5 seconds once the lists had grown to their full 300 point capacity.
