### PR TITLE
Install the run script as part of the setup.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,6 +38,7 @@ def params():
 	include_package_data = True
 	zip_safe = False
 	install_requires = open("requirements.txt").read().split("\n")
+	scripts = ['run']
 
 	return locals()
 


### PR DESCRIPTION
OctoPrint is shipped with a run script which can be used to launch it
more easily. However, the script is not installed by default. This patch
changes that.
