### PR TITLE
Less scary message with Ctrl-C, remove gcode viewer for android

### DIFF
--- a/octoprint/server.py
+++ b/octoprint/server.py
@@ -1162,6 +1162,8 @@ class Server():
 				printer.connect(port, baudrate)
 		try:
 			IOLoop.instance().start()
+		except KeyboardInterrupt:
+			logger.info("Goodbye!")
 		except:
 			logger.fatal("Now that is embarrassing... Something really really went wrong here. Please report this including the stacktrace below in OctoPrint's bugtracker. Thanks!")
 			logger.exception("Stacktrace follows:")

--- a/octoprint/static/js/app/main.js
+++ b/octoprint/static/js/app/main.js
@@ -1,4 +1,9 @@
 $(function() {
+        //Detect mobile browsers and remove gcode pane
+        //from http://stackoverflow.com/questions/3514784/what-is-the-best-way-to-detect-a-handheld-device-in-jquery
+        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            $("#gcode, a[href='#gcode']").remove();
+        }
 
         //~~ Initialize view models
         var loginStateViewModel = new LoginStateViewModel();


### PR DESCRIPTION
On all of the android devices I own, Octoprint crashes the browser very hard if there's a large gcode file being downloaded and parsed. Presumably, this is due to the relatively meager amount of memory. This makes controlling the printer using an older android tablet nearly impossible. This little snippet simply removes the gcode view if it detects a mobile browser.

I realize that this is a terrible solution in the off chance you have an Android device with multiple gigabytes of ram, but every android device I've tried from a brand new Moto X to a Nexus 10 tablet crashes with a big enough gcode file. Thoughts?
