### PR TITLE
Less scary message with Ctrl-C, remove gcode viewer for android

### DIFF
--- a/src/octoprint/server.py
+++ b/src/octoprint/server.py
@@ -1207,6 +1207,8 @@ class Server():
 				printer.connect(port, baudrate)
 		try:
 			IOLoop.instance().start()
+		except KeyboardInterrupt:
+			logger.info("Goodbye!")
 		except:
 			logger.fatal("Now that is embarrassing... Something really really went wrong here. Please report this including the stacktrace below in OctoPrint's bugtracker. Thanks!")
 			logger.exception("Stacktrace follows:")

--- a/src/octoprint/static/js/app/main.js
+++ b/src/octoprint/static/js/app/main.js
@@ -1,4 +1,9 @@
 $(function() {
+        //Detect mobile browsers and remove gcode pane
+        //from http://stackoverflow.com/questions/3514784/what-is-the-best-way-to-detect-a-handheld-device-in-jquery
+        if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)) {
+            $("#gcode, a[href='#gcode']").remove();
+        }
 
         //~~ Initialize view models
         var loginStateViewModel = new LoginStateViewModel();


### PR DESCRIPTION
Let's try this again, this time on the devel branch! 

On all android devices I've tried this on, the gcode viewer crashes the browser very hard because there's not enough RAM on the devices to load up large gcode files. This short snippet simply removes the gcode-related elements if it detects an android browser.

While I realize that this is sub-optimal in the off chance you're running android on a full blown computer, all devices I've tried this on from a brand new Moto X to a Nexus 10 tablet has managed to crash after loading the gcode viewer. Thoughts on this change?
