### PR TITLE
Don't give everyone write access to octoprint data.

### DIFF
--- a/src/octoprint/daemon.py
+++ b/src/octoprint/daemon.py
@@ -28,7 +28,7 @@ class Daemon:
 		# decouple from parent environment
 		os.chdir('/') 
 		os.setsid() 
-		os.umask(022)
+		os.umask(002)
 	
 		# do second fork
 		try: 


### PR DESCRIPTION
Currently, octoprint gives write access to all files in its data
directory to everybody.

This was probably considered appropriate for the case of octoprint
running on a single-user device, but given that Unix has groups
support, it is not necessary, and can be very harmful.
