### PR TITLE
fix crash when getStartTime() returns None

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -672,7 +672,7 @@ class MachineCom(object):
 						"file": self._currentFile.getFilename(),
 						"filename": os.path.basename(self._currentFile.getFilename()),
 						"origin": self._currentFile.getFileLocation(),
-						"time": time.time() - self._currentFile.getStartTime()
+						"time": self.getPrintTime()
 					})
 				elif 'Done saving file' in line:
 					self.refreshSdFiles()
@@ -934,7 +934,7 @@ class MachineCom(object):
 					payload = {
 						"local": self._currentFile.getLocalFilename(),
 						"remote": self._currentFile.getRemoteFilename(),
-						"time": time.time() - self._currentFile.getStartTime()
+						"time": self.getPrintTime()
 					}
 
 					self._currentFile = None
@@ -947,7 +947,7 @@ class MachineCom(object):
 						"file": self._currentFile.getFilename(),
 						"filename": os.path.basename(self._currentFile.getFilename()),
 						"origin": self._currentFile.getFileLocation(),
-						"time": time.time() - self._currentFile.getStartTime()
+						"time": self.getPrintTime()
 					}
 					self._callback.mcPrintjobDone()
 					self._changeState(self.STATE_OPERATIONAL)


### PR DESCRIPTION
In testing the `devel` branch with a short (<100 line) gcode file, I was hitting a crash that looked like this

```
2014-02-15 04:12:11,400 - octoprint.util.comm - ERROR - Something crashed inside the serial connection loop, please report this in OctoPrint's bug tracker:
Traceback (most recent call last):
  File "/usr/local/lib/python2.7/dist-packages/OctoPrint-1.1.0_dev-py2.7.egg/octoprint/util/comm.py", line 829, in _monitor
    self._sendNext()
  File "/usr/local/lib/python2.7/dist-packages/OctoPrint-1.1.0_dev-py2.7.egg/octoprint/util/comm.py", line 950, in _sendNext
    "time": time.time() - self._currentFile.getStartTime()
TypeError: unsupported operand type(s) for -: 'float' and 'NoneType'
```

This commit fixes the crash for me.
