### PR TITLE
API Doc: Fix response status code for connection POST success

### DIFF
--- a/docs/api/connection.rst
+++ b/docs/api/connection.rst
@@ -114,6 +114,6 @@ Issue a connection command
                               Defaults to ``false`` if not set.
    :json boolean autoconnect: ``connect`` command: Whether to attempt to automatically connect to the printer on server
                               startup. If not set no changes will be made to the current setting.
-   :statuscode 200:           No error
+   :statuscode 204:           No error
    :statuscode 400:           If the selected `port` or `baudrate` for a ``connect`` command are not part of the available
                               options.


### PR DESCRIPTION
Successful POST to `/api/connection` returns `204` not `200`
