### PR TITLE
Implement printer control by WIImote 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ mock>=1.0.1
 nose>=1.3.0
 watchdog
 sarge
+cwiid
 
 sphinxcontrib-httpdomain
 sphinx_rtd_theme

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -42,6 +42,7 @@ import octoprint.util as util
 import octoprint.users as users
 import octoprint.events as events
 import octoprint.timelapse
+import octoprint.wii
 
 
 UI_API_KEY = ''.join('%02X' % ord(z) for z in uuid.uuid4().bytes)
@@ -145,6 +146,7 @@ class Server():
 
 		# configure timelapse
 		octoprint.timelapse.configureTimelapse()
+		octoprint.wii.configureWii(printer=printer)
 
 		# setup command triggers
 		events.CommandTrigger(printer)

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -137,6 +137,9 @@ default_settings = {
 		{ "name": "Suppress M105 requests/responses", "regex": "(Send: M105)|(Recv: ok T\d*:)" },
 		{ "name": "Suppress M27 requests/responses", "regex": "(Send: M27)|(Recv: SD printing byte)" }
 	],
+	"wii": {
+		"enabled": True,
+	},		
 	"devel": {
 		"stylesheet": "css",
 		"virtualPrinter": {

--- a/src/octoprint/wii.py
+++ b/src/octoprint/wii.py
@@ -1,0 +1,126 @@
+# coding=utf-8
+
+__author__ = "Andrew 'Nceromant' Andrianov <andrew@ncrmnt.org>"
+__license__ = 'GNU Affero General Public License http://www.gnu.org/licenses/agpl.html'
+
+import logging
+import os
+import threading
+import urllib
+import time
+import subprocess
+import fnmatch
+import datetime
+import sys
+import cwiid
+
+import octoprint.util as util
+
+from octoprint.settings import settings
+from octoprint.events import eventManager
+
+global current
+
+def configureWii(config=None, persist=False, printer=None):
+    global current
+    if settings().getBoolean(["wii", "enabled"]):
+        current = Wii(printer);
+
+
+class Wii(object):
+    	def __init__(self,printer):
+		self._logger = logging.getLogger(__name__)
+                self.printer = printer;
+                eventManager().subscribe("PrintStarted", self.onPrintStarted)
+                eventManager().subscribe("PrintFailed", self.onPrintDone)
+                eventManager().subscribe("PrintDone", self.onPrintDone)
+                eventManager().subscribe("PrintResumed", self.onPrintResumed)
+                #TODO: Settings...
+                self.ThreadRunning = True;
+                self.handleInput = True;
+		self._logger.info("WII now enabled, connect at will by holding 1+2")
+                self._WiiThread = threading.Thread(target=self.WatchForWii)
+                self._WiiThread.daemon = True
+                self._WiiThread.start()
+
+	def WatchForWii(self):
+            while True:
+                try:
+                    self.wm = cwiid.Wiimote()
+                    self.wm.rumble = 1;
+                    time.sleep(0.5);
+                    self.wm.rumble = 0;
+                    
+                    self.wm.rpt_mode = cwiid.RPT_BTN | cwiid.RPT_STATUS;
+                    self.wm.enable(cwiid.FLAG_MESG_IFC);
+                    self.wm.led = 0;
+                    self.wm.mesg_callback = self.HandleWiiMessage;
+                    led = 1;
+                    while self.ThreadRunning:
+                        self.wm.led = led;
+                        led ^= 1;
+                        time.sleep(1);
+                except (RuntimeError, AttributeError):
+                    pass
+
+
+	def unload(self):
+		if self._inTimelapse:
+			self.stopTimelapse(doCreateMovie=False)
+
+		# unsubscribe events
+		eventManager().unsubscribe("PrintStarted", self.onPrintStarted)
+		eventManager().unsubscribe("PrintFailed", self.onPrintDone)
+		eventManager().unsubscribe("PrintDone", self.onPrintDone)
+		eventManager().unsubscribe("PrintResumed", self.onPrintResumed)
+		for (event, callback) in self.eventSubscriptions():
+			eventManager().unsubscribe(event, callback)
+                self.ThreadRunning = True;
+                self._WiiThread.join();
+
+        def HandleWiiMessage(self, mesg_list, time):
+            if bool(self.wm.state['buttons'] & cwiid.BTN_HOME):
+                self.printer.commands(settings().get(["wii", "BTN_HOME"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_A):
+                self.printer.commands(settings().get(["wii", "BTN_A"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_PLUS):
+                self.printer.commands(settings().get(["wii", "BTN_PLUS"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_MINUS):
+                self.printer.commands(settings().get(["wii", "BTN_MINUS"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_UP):
+                self.printer.commands(settings().get(["wii", "BTN_UP"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_DOWN):
+                self.printer.commands(settings().get(["wii", "BTN_DOWN"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_LEFT):
+                self.printer.commands(settings().get(["wii", "BTN_LEFT"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_RIGHT):
+                self.printer.commands(settings().get(["wii", "BTN_RIGHT"]));
+
+            if bool(self.wm.state['buttons'] & cwiid.BTN_B):
+                self.printer.commands(settings().get(["wii", "BTN_B"]));
+            
+	def onPrintStarted(self, event, payload):
+		"""
+		Override this to perform additional actions upon start of a print job.
+		"""
+		self.HandleInput = True;
+
+	def onPrintDone(self, event, payload):
+		"""
+		Override this to perform additional actions upon the stop of a print job.
+		"""
+		self.HandleInput = False;
+
+	def onPrintResumed(self, event, payload):
+		"""
+		Override this to perform additional actions upon the pausing of a print job.
+		"""
+		self.HandleInput = False;
+


### PR DESCRIPTION
This patch enables octoprint to allow you to control you 3d-printer by a wiimote. All you need is wiimote, a cheap usb-bluetooth dongle in your host pc, python-cwiid ( I guess, windows users are out of luck)

While now neither nunchuck, nor classic controller are supported - just basic functionality that allows you to bind any wiimote key to send any gcode to the printer, that comes in handy when you are messing with the mechanics/calibrating it.  

I'm not a big python expert (actually, that's the biggest code in python I've ever written - mostly code linux kernel drivers for a living), so you might want to refactor it yourself/or give me a little advice how to better integrate it along with octoprint. This is just a very quick hack. 

How to use: 
- Add the following to your octoprint config: 

``` yaml
wii:
  enabled: true
  BTN_DOWN:
  - G91
  - G1 Y-5 F1000
  BTN_HOME:
  - G28 X0 Y0 Z0
  BTN_RIGHT:
  - G91
  - G1 X5 F1000
  BTN_LEFT:
  - G91
  - G1 X-5 F1000
  BTN_UP:
  - G91
  - G1 Y5 F1000
  BTN_PLUS:
  - G91
  - G1 Z5 F200
  BTN_MINUS:
  - G91
  - G1 Z-5 F200
  BTN_1: 
  - G91
  - G1 E1 F300
  BTN_2: 
  - G91
  - G1 E-1 F300
  BTN_A:
  - M18
```
- Start octoprint
- Pree 1+2 on a wiimote 
- Wait till the first led starts blinking once a second
- Use it. 

When done you can turn wiimote off, and once needed just reconnect it by pressing 1+2 again. 
