### PR TITLE
changes to get octoprint accessible behind a reverse-proxy

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -94,6 +94,23 @@ def load_user(id):
 	return users.DummyUser()
 
 
+class ProxyWrapper(object):
+	path_headername='HTTP_X_PATH'
+	
+	def __init__(self, app):
+		self.app = app
+
+	def __call__(self, environ, start_response):
+		if self.path_headername in environ:
+			environ['SCRIPT_NAME']=environ[self.path_headername]
+			"""
+			print(environ)
+			if environ['PATH_INFO'].find(environ['HTTP_ORIG_PATH'])!=-1:
+				environ['PATH_INFO']=environ['PATH_INFO'][len(environ['HTTP_ORIG_PATH']):]
+				print(environ['PATH_INFO'])
+			"""
+		return self.app(environ, start_response)
+			 
 #~~ startup code
 
 
@@ -154,9 +171,13 @@ class Server():
 				userManager = clazz()
 			except AttributeError, e:
 				logger.exception("Could not instantiate user manager %s, will run with accessControl disabled!" % userManagerName)
-
-		app.wsgi_app = ReverseProxied(app.wsgi_app)
-
+		
+		if settings().get(['proxy','detect']):
+			app.wsgi_app = ProxyWrapper(app.wsgi_app)
+			app.wsgi_app.path_headername=settings().get(['proxy','headername'])
+		else:
+			app.wsgi_app = ReverseProxied(app.wsgi_app)
+			
 		app.secret_key = "k3PuVYgtxNm8DXKKTw2nWmFQQun9qceV"
 		loginManager = LoginManager()
 		loginManager.session_protection = "strong"

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -151,6 +151,10 @@ default_settings = {
 			"repetierStyleTargetTemperature": False,
 			"extendedSdFileList": False
 		}
+	},
+	"proxy": {
+		"detect": True,
+		"headername": "HTTP_X_ORIG_PATH"
 	}
 }
 

--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -37,7 +37,7 @@
             var CONFIG_GCODE_SIZE_THRESHOLD = {{ gcodeThreshold }};
             var CONFIG_GCODE_MOBILE_SIZE_THRESHOLD = {{ gcodeMobileThreshold }};
 
-            var SOCKJS_URI = window.location.protocol.slice(0, -1) + "://" + (window.document ? window.document.domain : window.location.hostname) + ":" + window.location.port + "/sockjs";
+            var SOCKJS_URI = window.location.protocol.slice(0, -1) + "://" + (window.document ? window.document.domain : window.location.hostname) + ":" + window.location.port + BASEURL + "sockjs";
             var SOCKJS_DEBUG = {%  if debug -%} true; {% else %} false; {%- endif %}
 
             var UI_API_KEY = "{{ uiApiKey }}";


### PR DESCRIPTION
I've to add some changes to get octoprint accessible behind a reverse-proxy, in my case lighttpd.

The difference is, that not every proxy seems to send the "X-Script-Name" with the HTTP-request.

With this patch you can enable support for proxys who supply the sub-path. The header-field can be configured in OctoPrints config.

More info can be found here:
http://librelist.com/browser/flask/2010/7/21/running-behind-proxy-with-url-prefix-other-than/#350beec683d8fc02f50613e235e6a413
