### PR TITLE
Fix events with gcode command lists not firing

### DIFF
--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -293,7 +293,7 @@ class CommandTrigger(GenericEventListener):
 	def _executeGcodeCommand(self, command):
 		commands = [command]
 		if isinstance(command, (list, tuple, set)):
-			self.logger.debug("Executing GCode commands: %r" % command)
+			self._logger.debug("Executing GCode commands: %r" % command)
 			commands = list(command)
 		else:
 			self._logger.debug("Executing GCode command: %s" % command)


### PR DESCRIPTION
I've dropped hints about this a few times in email but it still persists!

Events which invoke gcode command lists stopped working after the big re-org several months back.

```
events:
  enabled: true
  subscriptions:
  - command:
    - M81
    - M117 OctoPrint ready
    event: Connected
    type: gcode
```

The only reason is there's a typo that abends in the logging event.
