### PR TITLE
add serial types for OpenBSD

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -48,6 +48,7 @@ def serialList():
 			   + glob.glob("/dev/ttyAMA*") \
 			   + glob.glob("/dev/tty.usb*") \
 			   + glob.glob("/dev/cu.*") \
+			   + glob.glob("/dev/cuaU*") \
 			   + glob.glob("/dev/rfcomm*")
 
 	additionalPorts = settings().get(["serial", "additionalPorts"])


### PR DESCRIPTION
Teach OctoPrint how to list serial devices on OpenBSD

Any chance this can get back ported?
