### PR TITLE
Fix missing branch field in DEFAULT dict

### DIFF
--- a/versioneer.py
+++ b/versioneer.py
@@ -809,7 +809,7 @@ def get_versions(default={}, verbose=False):
 
 """
 
-DEFAULT = {"version": "unknown", "full": "unknown"}
+DEFAULT = {"version": "unknown", "full": "unknown", "branch": ""}
 
 def versions_from_file(filename):
     versions = {}


### PR DESCRIPTION
Should fix an error raised on line 951 (SHORT_VERSION_PY % DEFAULT) during Octoprint setup when there's no version info. More info here: https://groups.google.com/forum/#!topic/deltabot/8udyUsJ1c9M
