### PR TITLE
commRefactoring-Unknown commands

### DIFF
--- a/src/octoprint/comm/protocol/reprap/__init__.py
+++ b/src/octoprint/comm/protocol/reprap/__init__.py
@@ -882,7 +882,7 @@ class RepRapProtocol(Protocol):
 
 	def _prepare_for_sending(self, command, with_line_number=None):
 		command, with_line_number = self._process_command(command, "sent", with_line_number=with_line_number)
-		if command is None:
+		if command is None or command.unknown:
 			return None, None
 
 		if self._force_checksum:


### PR DESCRIPTION
Unknown commands shouldn't be thrown away immediately after being read from the file. This allows unknown gcode commands to get farther into the processing, but ensures they don't get pushed to the printer
