### PR TITLE
added G4 hook to increase the timeout for serial communication

### DIFF
--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -62,6 +62,7 @@ class Events(object):
 	HOME = "Home"
 	Z_CHANGE = "ZChange"
 	WAITING = "Waiting"
+	DWELL = "Dwelling"
 	COOLING = "Cooling"
 	ALERT = "Alert"
 	CONVEYOR = "Conveyor"


### PR DESCRIPTION
This patch addresses the failure mode outlined in #658.  Since the [G4](http://reprap.org/wiki/G-code#G4:_Dwell) command instructs the printer to sleep some number of milliseconds/seconds, this patch parses the command and adjusts the serial timeout to match.  One side effect of this patch is changing the accessibility of the `timeout` variable: `timeout` was a local variable to `_monitor()`, but this patch converts it to a member variable.  I have tested this patch, and it does successfully circumvent the problem, but I am not entirely happy with the side effect of converting the `timeout` variable to a member.  I think the correct solution is to introduce a new state that facilitates variable pauses during printing.  I would be happy to implement this, but before I do the work, I wanted to get your feedback first.
