### PR TITLE
BugFix to Reconnect on Debian

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -945,9 +945,12 @@ class MachineCom(object):
 			try:
 				self._log("Connecting to: %s" % self._port)
 				if self._baudrate == 0:
-					self._serial = serial.Serial(str(self._port), 115200, timeout=0.1, writeTimeout=10000)
+					self._serial = serial.Serial(str(self._port), 115200, timeout=0.1, writeTimeout=10000, parity=serial.PARITY_ODD)
 				else:
-					self._serial = serial.Serial(str(self._port), self._baudrate, timeout=settings().getFloat(["serial", "timeout", "connection"]), writeTimeout=10000)
+					self._serial = serial.Serial(str(self._port), self._baudrate, timeout=settings().getFloat(["serial", "timeout", "connection"]), writeTimeout=10000, parity=serial.PARITY_ODD)
+				self._serial.close()
+                                self._serial.parity = serial.PARITY_NONE
+                                self._serial.open()
 			except:
 				self._log("Unexpected error while connecting to serial port: %s %s" % (self._port, getExceptionString()))
 				self._errorValue = "Failed to open serial port, permissions correct?"


### PR DESCRIPTION
Solves the problems on reconnect using pyserial on Debian (I don't know if also in another distros).

Source:
http://forum.arduino.cc/index.php?topic=91291.0
