### PR TITLE
Enframed output video filename with quotes.

### DIFF
--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -299,7 +299,7 @@ class Timelapse(object):
 
 		# finalize command with output file
 		self._logger.debug("Rendering movie to %s" % output)
-		command.append(output)
+		command.append("\"" + output + "\"")
 		eventManager().fire(Events.MOVIE_RENDERING, {"gcode": self._gcodeFile, "movie": output, "movie_basename": os.path.basename(output)})
 
 		command_str = " ".join(command)


### PR DESCRIPTION
The files from SD card are read with names cut to 8.3 format and contain ~ symbol. It results in error creating timelapse video: "Unable to find a suitable output format for '~'"
Enframing output filename with quotes solves this bug
