### PR TITLE
Gcode viewer updates

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -91,6 +91,7 @@ date of first contribution):
   * [Ganey](https://github.com/ganey)
   * [Sven Lohrmann](https://github.com/malnvenshorn)
   * [Andy Castille](https://github.com/klikini)
+  * [Brad Fisher](https://github.com/bradcfisher)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This is a set of updates I've made to the gcode viewer for use by my Exclude Region plugin.  I though it'd be nice if I didn't have to hack OctoPrint to get the plugin to work, so thought I'd submit a PR.

Contains the following changes:

1) Rendering speed enhancements.  Speed improvements should be noticeable when compared side-by-side with the original version, even for relatively simple gcode files.  Essentially I applied the following optimizations:
  * y-axis inversion and the zoomFactor scaling applied to the context's transformation matrix instead of being applied to each coordinate value in the JavaScript
  * store commonly used array and object property lookups in local variables to avoid lookup overhead (e.g. var cmd = cmds[i])
  * when determining the last x,y position from the previous layer, exit the loop as soon as both values have been identified instead of scanning every command on the layer
  * compute as much as possible outside the layer rendering loop (colors, sizes, etc)
  * ensure paths are as long as possible before calling stroke(), instead of calling stroke() for every individual move

2) New event hooks:
  * 'onDragStart' - Invoked when the user presses the mouse button down.  Passed the point clicked on (in printer bed coordinates).  Return false to prevent dragging
  * 'onDrag' - Invoked when the user drags/pans the viewer.  Passed the current point the mouse is over (in printer bed coordinates).  Return false to prevent dragging
  * 'onDragStop' - Invoked when the user stops dragging.  Passed the point where the mouse button was released (in printer bed coordinates).
  * 'onViewportChange' - Invoked when a property of the canvas context's transformation matrix changes.  Passed the new transformation matrix.  Can be used to apply the same transformation to a different context (e.g. for layering multiple canvases over each other).  A future update could potentially apply this technique to optimize rendering previous/next layers and further reduce redraw times in certain circumstances by using two or three canvases instead of just one.

3) Consolidated reRender and render methods to removed redundancy (render now calls reRender instead of duplicating code).  This also addresses some potential range-checking issues that reRender had by applying some additional checks that render was already doing.

3) Bugfix to correct refresh() and refresh(0) both causing redraw of last drawn layer instead of refresh(0) drawing layer 0

#### How was it tested? How can it be tested by the reviewer?

Just tested by me so far.

To test rendering speed enhancements, select a file and pull up the gcode tab.  Zoom, pan, switch layers, etc.  Side-by-side comparison of the output generated by two instances of OctoPrint (one with the enhancement and one without) are helpful for ensuring both look identical.

The 'onDragStart' and 'onViewportChange' events are utilized by the Exclude Region plugin, so have been tested to the extent that I'm currently satisfied with how they function.

#### What are the relevant tickets if any?

#1973 may be related to the refresh()/refresh(0) bugfix.
#2143 has a comment on it related to the functionality provided by the exclude region plugin, though the original request itself isn't directly relevant

#### Screenshots (if appropriate)

See https://github.com/bradcfisher/OctoPrint-ExcludeRegionPlugin/raw/master/excluderegion-gcode-viewer.png
