### PR TITLE
Etag and refresh optimizations

### DIFF
--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1393,7 +1393,7 @@ class SettingsCheckUpdater(webassets.updater.BaseUpdater):
 			return False
 
 		cache_key = ('octo', 'settings')
-		current_hash = webassets.utils.hash_func(json.dumps(settings().effective_yaml))
+		current_hash = settings().effective_hash
 		cached_hash = ctx.cache.get(cache_key)
 		# This may seem counter-intuitive, but if no cache entry is found
 		# then we actually return "no update needed". This is because
@@ -1411,8 +1411,7 @@ class SettingsCheckUpdater(webassets.updater.BaseUpdater):
 			return
 
 		cache_key = ('octo', 'settings')
-		cache_value = webassets.utils.hash_func(json.dumps(settings().effective_yaml))
-		ctx.cache.set(cache_key, cache_value)
+		ctx.cache.set(cache_key, settings().effective_hash)
 
 ##~~ core assets collector
 def collect_core_assets(enable_gcodeviewer=True, preferred_stylesheet="css"):

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -229,19 +229,6 @@ def index():
 		def cache_key():
 			return _cache_key(key, additional_key_data=additional_key_data)
 
-		def check_etag_and_lastmodified():
-			files = collect_files()
-			lastmodified = compute_lastmodified(files)
-			lastmodified_ok = util.flask.check_lastmodified(lastmodified)
-			etag_ok = util.flask.check_etag(compute_etag(files=files,
-			                                             lastmodified=lastmodified,
-			                                             additional=[cache_key()] + additional_etag))
-			return lastmodified_ok and etag_ok
-
-		def validate_cache(cached):
-			etag_different = compute_etag(additional=[cache_key()] + additional_etag) != cached.get_etag()[0]
-			return force_refresh or etag_different
-
 		def collect_files():
 			if callable(custom_files):
 				try:
@@ -251,12 +238,10 @@ def index():
 				except Exception:
 					_logger.exception("Error while trying to retrieve tracked files for plugin {}".format(key))
 
-			templates = _get_all_templates()
-			assets = _get_all_assets()
-			translations = _get_all_translationfiles(g.locale.language if g.locale else "en",
+			files = _get_all_templates()
+			files += _get_all_assets()
+			files += _get_all_translationfiles(g.locale.language if g.locale else "en",
 			                                         "messages")
-
-			files = templates + assets + translations
 
 			if callable(additional_files):
 				try:
@@ -268,7 +253,7 @@ def index():
 
 			return sorted(set(files))
 
-		def compute_lastmodified(files=None):
+		def compute_lastmodified(files):
 			if callable(custom_lastmodified):
 				try:
 					lastmodified = custom_lastmodified()
@@ -277,11 +262,9 @@ def index():
 				except Exception:
 					_logger.exception("Error while trying to retrieve custom LastModified value for plugin {}".format(key))
 
-			if files is None:
-				files = collect_files()
 			return _compute_date(files)
 
-		def compute_etag(files=None, lastmodified=None, additional=None):
+		def compute_etag(files, lastmodified, additional=None):
 			if callable(custom_etag):
 				try:
 					etag = custom_etag()
@@ -290,10 +273,6 @@ def index():
 				except Exception:
 					_logger.exception("Error while trying to retrieve custom ETag value for plugin {}".format(key))
 
-			if files is None:
-				files = collect_files()
-			if lastmodified is None:
-				lastmodified = compute_lastmodified(files)
 			if lastmodified and not isinstance(lastmodified, basestring):
 				from werkzeug.http import http_date
 				lastmodified = http_date(lastmodified)
@@ -312,9 +291,22 @@ def index():
 				hash_update(add)
 			return hash.hexdigest()
 
+		current_files = collect_files()
+		current_lastmodified = compute_lastmodified(current_files)
+		current_etag = compute_etag(files=current_files, lastmodified=current_lastmodified,
+			                        additional=[cache_key()] + additional_etag)
+
+		def check_etag_and_lastmodified():
+			lastmodified_ok = util.flask.check_lastmodified(current_lastmodified)
+			etag_ok = util.flask.check_etag(current_etag)
+			return lastmodified_ok and etag_ok
+
+		def validate_cache(cached):
+			return force_refresh or (current_etag != cached.get_etag()[0])
+
 		decorated_view = view
-		decorated_view = util.flask.lastmodified(lambda _: compute_lastmodified())(decorated_view)
-		decorated_view = util.flask.etagged(lambda _: compute_etag(additional=[cache_key()] + additional_etag))(decorated_view)
+		decorated_view = util.flask.lastmodified(lambda _: current_lastmodified)(decorated_view)
+		decorated_view = util.flask.etagged(lambda _: current_etag)(decorated_view)
 		decorated_view = util.flask.cached(timeout=-1,
 		                                   refreshif=validate_cache,
 		                                   key=cache_key,
@@ -943,9 +935,21 @@ def _compute_date_for_i18n(locale, domain):
 
 
 def _compute_date(files):
+	# Note, we do not expect everything in 'files' to exist.
 	from datetime import datetime
-	timestamps = list(map(lambda path: os.stat(path).st_mtime, files)) + [0] if files else []
-	max_timestamp = max(*timestamps) if timestamps else None
+	import stat
+	max_timestamp = 0
+	for path in files:
+		try:
+			# try to stat file. If an exception is thrown, its because it does not exist.
+			s = os.stat(path)
+			if stat.S_ISREG(s.st_mode) and s.st_mtime > max_timestamp:
+				# is a regular file and has a newer timestamp
+				max_timestamp = s.st_mtime
+		except Exception:
+			# path does not exist.
+			continue
+
 	if max_timestamp:
 		# we set the micros to 0 since microseconds are not speced for HTTP
 		max_timestamp = datetime.fromtimestamp(max_timestamp).replace(microsecond=0)
@@ -971,22 +975,14 @@ def _get_all_templates():
 
 def _get_all_assets():
 	from octoprint.util.jinja import get_all_asset_paths
-	return get_all_asset_paths(app.jinja_env.assets_environment)
+	return get_all_asset_paths(app.jinja_env.assets_environment, verifyExist=False)
 
 
 def _get_all_translationfiles(locale, domain):
 	from flask import _request_ctx_stack
 
 	def get_po_path(basedir, locale, domain):
-		path = os.path.join(basedir, locale)
-		if not os.path.isdir(path):
-			return None
-
-		path = os.path.join(path, "LC_MESSAGES", "{domain}.po".format(**locals()))
-		if not os.path.isfile(path):
-			return None
-
-		return path
+		return os.path.join(basedir, locale, "LC_MESSAGES", "{domain}.po".format(**locals()))
 
 	po_files = []
 
@@ -998,13 +994,7 @@ def _get_all_translationfiles(locale, domain):
 	for name, plugin in plugins.items():
 		dirs = [os.path.join(user_plugin_path, name), os.path.join(plugin.location, 'translations')]
 		for dirname in dirs:
-			if not os.path.isdir(dirname):
-				continue
-
-			po_file = get_po_path(dirname, locale, domain)
-			if po_file:
-				po_files.append(po_file)
-				break
+			po_files.append(get_po_path(dirname, locale, domain))
 
 	# core translations
 	ctx = _request_ctx_stack.top
@@ -1012,10 +1002,7 @@ def _get_all_translationfiles(locale, domain):
 
 	dirs = [user_base_path, base_path]
 	for dirname in dirs:
-		po_file = get_po_path(dirname, locale, domain)
-		if po_file:
-			po_files.append(po_file)
-			break
+		po_files.append(get_po_path(dirname, locale, domain))
 
 	return po_files
 

--- a/src/octoprint/util/jinja.py
+++ b/src/octoprint/util/jinja.py
@@ -150,7 +150,7 @@ def get_all_template_paths(loader):
 	return collect_templates_for_loader(loader)
 
 
-def get_all_asset_paths(env):
+def get_all_asset_paths(env, verifyExist=True):
 	result = []
 
 	def get_paths(bundle):
@@ -163,7 +163,7 @@ def get_all_asset_paths(env):
 					r += get_paths(content[1])
 				else:
 					path = content[1]
-					if not os.path.isfile(path):
+					if verifyExist is True and not os.path.isfile(path):
 						continue
 					r.append(path)
 			except IndexError:


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
Two performance improvements that came as a result of profiling OctoPrint. My primary goal has been to reduce the CPU impact when it comes to serving /.  All performance numbers I'm reporting here are from running using python 3.7.5 on my 2016 Macbook Pro. I expect the improvements to be even more significant on a typical raspberry pi.

**1. Improve performance of etag calculation for / (root route):**
- Only compute etag once (rather than twice) per request.
- Only stat files once per request.
  - Avoid calling `isdir` or `isfile` in `collect_files`.
  - Leave it to `compute_lastmodified` to stat files, which tells us if the path exists, if it is a file, and it's last modified.
- Ultimately, this eliminates ~70% of `stat` system calls. This has a bigger impact on raspberry PI systems. 

Timing (as reported by Tornado) on my 2016 Macbook Pro when fetching / (`curl -o /dev/null http://octoprint/`):
- Before: ~50ms
- After: ~38ms


**2. Memoize settings hashes to speed up cache refresh:**
Memoize `settings.config_hash` and `settings.effective_hash`. The
hashes will only be calculated on the first call to the respective
functions. These memoized values are invalidated when the settings
object becomes dirty, or the settings are loaded from the config file.

Reason for change: During a refresh of the root route (/), the hash of
`settings.effective.yaml` is calculated 5 times. Each call lead to a
large configuration object to be serialized to a YAML string, which would
then be hashed. As it turns out, serializing to YAML is expensive.

Note: while I do not see `settings.config_hash` hit during a refresh,
but making a change to it was easy and appropriate. It's possible that
other areas of the application may see some benefit.

Performance (on my 2016 Macbook Pro:
- building of initial cache on startup:
  - before: ~3.4s
  - after:  ~2.9s
- loading `http://octoprint/?_refresh=1`
  - before: ~1100ms
  - after:  ~200ms

#### How was it tested? How can it be tested by the reviewer?
Manually.
I ran pytest, and everything passes.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
