### PR TITLE
Show retracts, moves, and head position only for current layer

### DIFF
--- a/src/octoprint/static/gcodeviewer/js/renderer.js
+++ b/src/octoprint/static/gcodeviewer/js/renderer.js
@@ -680,7 +680,7 @@ GCODE.renderer = (function(){
                 // neither extrusion nor move
                 if (cmd.retract == -1) {
                     // retract => draw dot if configured to do so
-                    if (renderOptions["showRetracts"]) {
+                    if (renderOptions["showRetracts"] && !isNotCurrentLayer) {
                         strokePathIfNeeded("fill");
                         ctx.fillStyle = getColorRetractForTool(tool);
                         ctx.strokeStyle = ctx.fillStyle;
@@ -689,7 +689,7 @@ GCODE.renderer = (function(){
                 }
 
                 strokePathIfNeeded("move", getColorMoveForTool(tool));
-                if(renderOptions["showMoves"]){
+                if(renderOptions["showMoves"] && !isNotCurrentLayer) {
                     // move => draw line from (prevX, prevY) to (x, y) in move color
                     ctx.lineWidth = lineWidthFactor;
                     ctx.lineTo(x,y);
@@ -713,7 +713,7 @@ GCODE.renderer = (function(){
                     }
                 } else {
                     // we were previously retracting, now we are restarting => draw dot if configured to do so
-                    if (renderOptions["showRetracts"]) {
+                    if (renderOptions["showRetracts"] && !isNotCurrentLayer) {
                         strokePathIfNeeded("fill");
                         ctx.fillStyle = getColorRestartForTool(tool);
                         ctx.strokeStyle = ctx.fillStyle;
@@ -731,7 +731,7 @@ GCODE.renderer = (function(){
             ctx.stroke();
         }
 
-        if (renderOptions["showHead"]) {
+        if (renderOptions["showHead"] && !isNotCurrentLayer) {
             var sizeHeadSpot = renderOptions["sizeHeadSpot"] * lineWidthFactor + lineWidthFactor / 2;
             var shade = tool * 0.15;
             ctx.fillStyle = pusher.color(renderOptions["colorHead"]).shade(shade).alpha(alpha).html();


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

In the GCode viewer,  turning on "also show current" or "also show previous" makes it easier to follow job progress, but showing retracts etc. for "also" layers makes too much visual noise.

I did not see a need to make this behavior optional. You could argue that at least the current layer should show moves, but it works for me.

#### How was it tested? How can it be tested by the reviewer?

Far too much time spent staring at the screen while the printer grinds away.