### PR TITLE
fix NoneType comparison error, closes #3493

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2537,7 +2537,7 @@ class MachineCom(object):
 
 		tools = self.last_temperature.tools
 		for temp in [tools[k][1] for k in tools.keys()]:
-			if temp > self._temperatureTargetSetThreshold:
+			if temp and temp > self._temperatureTargetSetThreshold:
 				return get("temperatureTargetSet", target_default)
 
 		bed = self.last_temperature.bed


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Ensures that a NoneType comparison doesn't throw an exception while checking tool temperatures.

#### How was it tested? How can it be tested by the reviewer?

It wasn't tested. Even without finding the replication conditions, this should be safer.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#3493

#### Screenshots (if appropriate)

#### Further notes

I assume you'll want this in master and propagated to other branches, but it's easy to cherrypick or manually patch.