### PR TITLE
Set LC_ALL and LANG when starting octoprint

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -118,6 +118,7 @@ date of first contribution):
   * [Jim Neill](https://github.com/jneilliii)
   * [Dustin Kerber](https://github.com/kerber)
   * [Tobias Schürg](https://github.com/tobiasschuerg)
+  * [Josh Friend](https://github.com/joshfriend)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,14 +4,36 @@ Assumes OctoPrint is installed under user pi at /home/pi/OctoPrint/venv/bin/octo
 setup you'll need to adjust octoprint.default (init) or octoprint.service (systemd) accordingly.
 
 ## init
+Download the init.d files to the locations shown:
 
 ```
 octoprint.default   => /etc/default/octoprint
 octoprint.init      => /etc/init.d/octoprint
 ```
 
+Next, enable and start the `octoprint` service:
+
+```sh
+# Enable octoprint service
+sudo update-rc.d octoprint defaults
+
+# and start it
+sudo service octoprint start
+```
+
 ## systemd
+Download the systemd files to the locations shown:
 
 ```
 octoprint.service   => /etc/systemd/system/octoprint.service
+```
+
+Next, enable and start the `octoprint` service:
+
+```sh
+# Enable octoprint service
+sudo systemctl enable octoprint
+
+# and start it
+sudo systemctl start octoprint
 ```

--- a/scripts/octoprint.service
+++ b/scripts/octoprint.service
@@ -4,6 +4,8 @@ After=network-online.target
 Wants=network-online.target
 
 [Service]
+Environment="LC_ALL=C.UTF-8"
+Environment="LANG=C.UTF-8"
 Type=simple
 User=pi
 ExecStart=/home/pi/OctoPrint/venv/bin/octoprint


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [-] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [-] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [-] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
When I tried to start the systemd service, I got the following error:

```
RuntimeError: Click will abort further execution because Python 3 was configured to use ASCII as encoding for the environment
This system supports the C.UTF-8 locale which is recommended. You might be able to resolve your issue by exporting the follow
    export LC_ALL=C.UTF-8
    export LANG=C.UTF-8
```

This PR fixes this error from Click about ASCII encoding by setting the requested environment variables to the suggested values for the service.

#### How was it tested? How can it be tested by the reviewer?

Nothing got logged when I ran `systemd start octoprint` but octoprint did not start. The error showed up when I ran `systemd status octoprint`. With these changes applied octoprint starts with no issues.

#### Any background context you want to provide?
I am running octoprint on an Odroid C1 with Ubuntu 18.04 and Python 3.6.9
