### PR TITLE
Update to Tornado 5.1.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ INSTALL_REQUIRES = [
 	"Jinja2>=2.8.1,<2.9",        # Jinja 2.9 has breaking changes WRT template scope - we can't
 	                             # guarantee backwards compatibility for plugins and such with that
 	                             # version, hence we need to pin to a lower version for now. See #1697
-	"tornado==4.5.3",            # a memory leak was observed in tornado >= 5, see #2585
+	"tornado==5.1.1",            # a memory leak was observed in tornado >= 5, see #2585
 	"regex!=2018.11.6",          # avoid broken 2018.11.6. See #2874
 
 	# anything below this should be checked on releases for new versions

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -111,7 +111,7 @@ class CorsSupportMixin(tornado.web.RequestHandler):
 		if self.request.method != "OPTIONS" and origin and self.ENABLE_CORS:
 			self.set_header("Access-Control-Allow-Origin", origin)
 
-	@tornado.web.asynchronous
+	@tornado.gen.coroutine
 	def options(self, *args, **kwargs):
 		if self.ENABLE_CORS:
 			origin = self.request.headers.get("Origin")
@@ -1114,7 +1114,7 @@ class UrlProxyHandler(RequestlessExceptionLoggingMixin,
 		self._basename = basename
 		self._access_validation = access_validation
 
-	@tornado.web.asynchronous
+	@tornado.gen.coroutine
 	def get(self, *args, **kwargs):
 		if self._access_validation is not None:
 			self._access_validation(self.request)

--- a/src/octoprint/vendor/sockjs/tornado/basehandler.py
+++ b/src/octoprint/vendor/sockjs/tornado/basehandler.py
@@ -12,7 +12,8 @@ import datetime
 import socket
 import logging
 
-from tornado.web import asynchronous, RequestHandler
+from tornado.web import RequestHandler
+from tornado.gen import coroutine
 
 try:
     # python 3
@@ -105,7 +106,7 @@ class BaseHandler(RequestHandler):
 class PreflightHandler(BaseHandler):
     """CORS preflight handler"""
 
-    @asynchronous
+    @coroutine
     def options(self, *args, **kwargs):
         """XHR cross-domain OPTIONS handler"""
         self.enable_cache()

--- a/src/octoprint/vendor/sockjs/tornado/router.py
+++ b/src/octoprint/vendor/sockjs/tornado/router.py
@@ -109,12 +109,11 @@ class SockJSRouter(object):
 
         check_interval = self.settings['session_check_interval'] * 1000
         self._sessions_cleanup = ioloop.PeriodicCallback(self._sessions.expire,
-                                                         check_interval,
-                                                         self.io_loop)
+                                                         check_interval)
         self._sessions_cleanup.start()
 
         # Stats
-        self.stats = stats.StatsCollector(self.io_loop)
+        self.stats = stats.StatsCollector()
 
         # Initialize URLs
         base = prefix + r'/[^/.]+/(?P<session_id>[^/.]+)'

--- a/src/octoprint/vendor/sockjs/tornado/static.py
+++ b/src/octoprint/vendor/sockjs/tornado/static.py
@@ -13,7 +13,7 @@ import hashlib
 import random
 import sys
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado.basehandler import BaseHandler, PreflightHandler
 from octoprint.vendor.sockjs.tornado.proto import json_encode
@@ -85,7 +85,7 @@ class ChunkingTestHandler(PreflightHandler):
         self.step = 0
         self.io_loop = server.io_loop
 
-    @asynchronous
+    @coroutine
     def post(self):
         self.preflight()
         self.set_header('Content-Type', 'application/javascript; charset=UTF-8')

--- a/src/octoprint/vendor/sockjs/tornado/stats.py
+++ b/src/octoprint/vendor/sockjs/tornado/stats.py
@@ -54,7 +54,7 @@ class MovingAverage(object):
 
 
 class StatsCollector(object):
-    def __init__(self, io_loop):
+    def __init__(self):
         # Sessions
         self.sess_active = 0
 
@@ -70,8 +70,7 @@ class StatsCollector(object):
         self.pack_recv_ps = MovingAverage()
 
         self._callback = ioloop.PeriodicCallback(self._update,
-                                                 1000,
-                                                 io_loop)
+                                                 1000)
         self._callback.start()
 
     def _update(self):

--- a/src/octoprint/vendor/sockjs/tornado/transports/eventsource.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/eventsource.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
     EventSource transport implementation.
 """
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado.transports import streamingbase
 
@@ -16,7 +16,7 @@ from octoprint.vendor.sockjs.tornado.transports import streamingbase
 class EventSourceTransport(streamingbase.StreamingTransportBase):
     name = 'eventsource'
 
-    @asynchronous
+    @coroutine
     def get(self, session_id):
         # Start response
         self.preflight()

--- a/src/octoprint/vendor/sockjs/tornado/transports/htmlfile.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/htmlfile.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
     HtmlFile transport implementation.
 """
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado import proto
 from octoprint.vendor.sockjs.tornado.transports import streamingbase
@@ -38,7 +38,7 @@ class HtmlFileTransport(streamingbase.StreamingTransportBase):
     def initialize(self, server):
         super(HtmlFileTransport, self).initialize(server)
 
-    @asynchronous
+    @coroutine
     def get(self, session_id):
         # Start response
         self.preflight()

--- a/src/octoprint/vendor/sockjs/tornado/transports/jsonp.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/jsonp.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 """
 import logging
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado import proto
 from octoprint.vendor.sockjs.tornado.transports import pollingbase
@@ -20,7 +20,7 @@ LOG = logging.getLogger("tornado.general")
 class JSONPTransport(pollingbase.PollingTransportBase):
     name = 'jsonp'
 
-    @asynchronous
+    @coroutine
     def get(self, session_id):
         # Start response
         self.handle_session_cookie()

--- a/src/octoprint/vendor/sockjs/tornado/transports/streamingbase.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/streamingbase.py
@@ -11,7 +11,7 @@ class StreamingTransportBase(pollingbase.PollingTransportBase):
         self.amount_limit = self.server.settings['response_limit']
 
         # HTTP 1.0 client might send keep-alive
-        if hasattr(self.request, 'connection') and not self.request.supports_http_1_1():
+        if hasattr(self.request, 'connection') and not self.request.version == 'HTTP/1.1':
             self.request.connection.no_keep_alive = True
 
     def notify_sent(self, data_len):

--- a/src/octoprint/vendor/sockjs/tornado/transports/xhr.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/xhr.py
@@ -9,7 +9,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 """
 import logging
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado import proto
 from octoprint.vendor.sockjs.tornado.transports import pollingbase
@@ -21,7 +21,7 @@ class XhrPollingTransport(pollingbase.PollingTransportBase):
     """xhr-polling transport implementation"""
     name = 'xhr'
 
-    @asynchronous
+    @coroutine
     def post(self, session_id):
         # Start response
         self.preflight()

--- a/src/octoprint/vendor/sockjs/tornado/transports/xhrstreaming.py
+++ b/src/octoprint/vendor/sockjs/tornado/transports/xhrstreaming.py
@@ -8,7 +8,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
     Xhr-Streaming transport implementation
 """
 
-from tornado.web import asynchronous
+from tornado.gen import coroutine
 
 from octoprint.vendor.sockjs.tornado.transports import streamingbase
 
@@ -16,7 +16,7 @@ from octoprint.vendor.sockjs.tornado.transports import streamingbase
 class XhrStreamingTransport(streamingbase.StreamingTransportBase):
     name = 'xhr_streaming'
 
-    @asynchronous
+    @coroutine
     def post(self, session_id):
         # Handle cookie
         self.preflight()


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Updates Tornado to the latest version that supports python 2.7 and 3.x. Not really necessary for any specific reason that I am aware of.

#### How was it tested? How can it be tested by the reviewer?
Tested on both python 2.7 and 3.6:
- API calls
- WebUI functionality
- Ran pytest

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
Tornado 6.x dropped support for python 2.7 so this is the latest version that can be used at this time. 
