### PR TITLE
Fix issue where _simulateTemps may never reach target temp

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1422,9 +1422,13 @@ class VirtualPrinter(object):
 		self.lastTempAt = monotonic_time()
 
 		def simulate(actual, target, ambient):
-			if target > 0 and abs(actual - target) > delta:
+			if target > 0:
 				goal = target
-				factor = 10
+				remaining = abs(actual - target)
+				if remaining > delta:
+					factor = 10
+				elif remaining < delta:
+					factor = remaining
 			elif not target and abs(actual - ambient) > delta:
 				goal = ambient
 				factor = 2


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
When setting temperatures whilst using the Virtual Printer there is a chance the target is never truly reached but is instead within ~0.5C. This handles the condition where the temperature difference is less than the delta and makes the next temperature change equal to the difference.

#### How was it tested? How can it be tested by the reviewer?
1. Set target temperature
2. Wait (Note: It seems that target temp may be reached if sitting in a breakpoint and that is because of the timeDiff calculation)
3. Observe

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
