### PR TITLE
Add support for subfolders in the watched folder list

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -830,7 +830,7 @@ class Server(object):
 		else:
 			# use os default
 			observer = Observer()
-		observer.schedule(watchdog_handler, watched)
+		observer.schedule(watchdog_handler, watched, recursive=True)
 		observer.start()
 
 		# run our startup plugins


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
This PR adds recursive scanning of the watched folder and moving files in subfolders of the watched folder to a subfolder of the uploads folder with the same name.

Contributes to https://github.com/OctoPrint/OctoPrint/issues/2451

#### How was it tested? How can it be tested by the reviewer?
* create a subfolder named "test123" in the watched folder
* copy a gcode file to it from another location
-> the file  is moved to a new folder named "test123" in the uploads folder, and analysis is started

#### Any background context you want to provide?

#### What are the relevant tickets if any?
https://github.com/OctoPrint/OctoPrint/issues/2451

#### Screenshots (if appropriate)

#### Further notes
I consider this a new feature, so I opted to base my branch off the devel branch, but I can easily rebase to the maintenance branch instead.
