### PR TITLE
Workaround for #2166 is no longer required as of Firefox 57.0.2

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1124,12 +1124,10 @@ $(function() {
             if (enable) {
                 $(document).bind("dragenter", self._handleDragEnter);
                 $(document).bind("dragleave", self._handleDragLeave);
-                $(document).bind("dragover", self._handleDragOver);
                 log.debug("Enabled drag-n-drop");
             } else {
                 $(document).unbind("dragenter", self._handleDragEnter);
                 $(document).unbind("dragleave", self._handleDragLeave);
-                $(document).unbind("dragover", self._handleDragOver);
                 log.debug("Disabled drag-n-drop");
             }
         };
@@ -1218,33 +1216,6 @@ $(function() {
         self._handleDragLeave = function (e) {
             if (e.target !== self._dragNDropTarget) return;
             self._forceEndDragNDrop();
-        };
-
-        self._handleDragOver = function(e) {
-            // Workaround for Firefox
-            //
-            // Due to a browser bug (https://bugzilla.mozilla.org/show_bug.cgi?id=656164),
-            // if you drag a file out of the window no drag leave event will be fired. So on Firefox we check if
-            // our last dragover event was within a timeout. If not, we assume that's because the mouse
-            // cursor left the browser window and force a drag stop.
-            //
-            // Since Firefox keeps on triggering dragover events even if the mouse is not moved while over the
-            // browser window, this should work without side effects (e.g. the overlay should stay even if the user
-            // keeps the mouse perfectly still).
-            //
-            // See #2166
-            if (!OctoPrint.coreui.browser.firefox) return;
-            if (e.target !== self._dragNDropTarget) return;
-
-            if (self._dragNDropFFTimeout !== undefined) {
-                window.clearTimeout(self._dragNDropFFTimeout);
-                self._dragNDropFFTimeout = undefined;
-            }
-
-            self._dragNDropFFTimeout = window.setTimeout(function() {
-                self._forceEndDragNDrop();
-                self._dragNDropFFTimeout = undefined;
-            }, self._dragNDropFFTimeoutDelay);
         };
 
         self._handleDragEnter = function (e) {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Reverts the workaround made in 4439f5aad0 as the issue has been resolved since Firefox 57.0.2.  Current version of Firefox ESR is 68.8.0. 

#### How was it tested? How can it be tested by the reviewer?
Drag and drop files into tab

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#2166

#### Screenshots (if appropriate)

#### Further notes
With recent versions of Firefox the workaround as now causes the drag and drop UI to disappear once the mouse has stopped moving. Moving the mouse while holding drag results in the UI flashing.

Tested on Firefox 72.0.2
