### PR TITLE
Fix issue introduced by 9e3cf58bc9 which prevents _api user from connecting to SockJS

### DIFF
--- a/src/octoprint/server/util/sockjs.py
+++ b/src/octoprint/server/util/sockjs.py
@@ -206,7 +206,7 @@ class PrinterStateConnection(octoprint.vendor.sockjs.tornado.SockJSConnection,
 				user_id, user_session = parts
 
 				if self._userManager.validate_user_session(user_id, user_session):
-					user = self._userManager.find_user(userid=user_id)
+					user = self._userManager.find_user(userid=user_id, session=user_session)
 					self._on_login(user)
 				else:
 					self._logger.warn("Unknown user/session combo: {}:{}".format(user_id, user_session))


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes issue where connecting as user **_api** to SockJS would throw an exception. Introduced by 9e3cf58bc9

#### How was it tested? How can it be tested by the reviewer?
Try connecting as a regular user and as user **_api**. 

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#3578

#### Screenshots (if appropriate)

#### Further notes
