### PR TITLE
[WIP] Getting flassger up and running

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -106,7 +106,8 @@ EXTRA_REQUIRES = dict(
 		"sphinxcontrib-httpdomain",
 		"sphinxcontrib-mermaid>=0.3.1",
 		"sphinx_rtd_theme",
-		"readthedocs-sphinx-ext==0.5.17" # Later versions require Jinja >= 2.9
+		"readthedocs-sphinx-ext==0.5.17", # Later versions require Jinja >= 2.9
+		"flasgger"
 	],
 
 	# Dependencies for developing OctoPrint plugins

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -48,7 +48,6 @@ NO_CONTENT = ("", 204)
 NOT_MODIFIED = ("Not Modified", 304)
 
 app = Flask("octoprint")
-swagger = Swagger(app)
 
 assets = None
 babel = None
@@ -594,6 +593,8 @@ class Server(object):
 
 		# register API blueprint
 		self._setup_blueprints()
+
+		swagger = Swagger(app)
 
 		## Tornado initialization starts here
 

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -16,6 +16,7 @@ from babel import Locale
 from watchdog.observers import Observer
 from watchdog.observers.polling import PollingObserver
 from collections import defaultdict, OrderedDict
+from flasgger import Swagger
 
 from builtins import bytes, range
 from past.builtins import basestring, unicode
@@ -47,6 +48,7 @@ NO_CONTENT = ("", 204)
 NOT_MODIFIED = ("Not Modified", 304)
 
 app = Flask("octoprint")
+swagger = Swagger(app)
 
 assets = None
 babel = None

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -192,12 +192,43 @@ def wizardFinish():
 @api.route("/state", methods=["GET"])
 @no_firstrun_access
 def apiPrinterState():
+	"""
+	/api/state has been deprecated, use /api/printer instead
+	---
+	responses:
+		405:
+			description: The endpoint will always return
+				"/api/state has been deprecated, use /api/printer instead"
+	"""
 	return make_response(("/api/state has been deprecated, use /api/printer instead", 405, []))
 
 
 @api.route("/version", methods=["GET"])
 @Permissions.STATUS.require(403)
 def apiVersion():
+	"""
+	Retrieve information regarding server and API version.
+	Returns a JSON object with two keys,
+	api containing the API version, server containing the server version,
+	text containing the server version including the
+	prefix ``OctoPrint `` (to determine that this is indeed a genuine OctoPrint instance).
+	---
+	definitions:
+		version_struct:
+			type: object
+			properties:
+				api:
+					type: string
+				server:
+					type: string
+				text:
+					type: string
+	responses:
+		200:
+			description: The version information of the instance
+			schema:
+				$ref: '#/definitions/version_struct'
+	"""
 	return jsonify({
 		"server": octoprint.server.VERSION,
 		"api": VERSION,


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
This PR aims to get [flassger](https://github.com/flasgger/flasgger) to display all routes registered
in the Octoprint Flask application under {base address}/apidocs/

#### How was it tested? How can it be tested by the reviewer?
Start a server and look at {base address}/apidocs/
#### Any background context you want to provide?
This is the first in a series of steps to generate the API docs from docsstrings and annotations in the source code instead of having to maintain the docs by hand.
#### What are the relevant tickets if any?
#3587 
#### Screenshots (if appropriate)
Will be added once it works
#### Further notes
This is currently a WIP