### PR TITLE
Display entire path to backup on CLI command

### DIFF
--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -378,7 +378,7 @@ class BackupPlugin(octoprint.plugin.SettingsPlugin,
 			if not os.path.isdir(datafolder):
 				os.makedirs(datafolder)
 
-			click.echo("Creating backup at {}, please wait...".format(backup_file))
+			click.echo("Creating backup at {}{}, please wait...".format(datafolder, backup_file))
 			self._create_backup(backup_file,
 			                    exclude=exclude,
 			                    settings=settings,


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests 
**(Run backup command, verify that the path is now the complete path)**
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->
Just remembered that you mentioned this, would make my Upgrade to Py3 script easier as users wouldn't have to provide path to config direrctory.

Not really a required change, but made the PR so it got added to the list :)

#### What does this PR do and why is it necessary?
As mentioned on discord, backup/restore plugin only outputs the filename, not the full path. Useful for scripts such as my [Upgrade to Python 3](https://github.com/cp2004/Octoprint-Upgrade-To-Py3)

#### How was it tested? How can it be tested by the reviewer?
Run the cli command `octoprint plugins backup:backup --exclude timelapse --exclude uploads`
#### Any background context you want to provide?
Mentioned by @foosel on discord
#### What are the relevant tickets if any?
None
#### Screenshots (if appropriate)
None
#### Further notes
