### PR TITLE
Fix typo in appkeys key response spec

### DIFF
--- a/docs/bundledplugins/appkeys.rst
+++ b/docs/bundledplugins/appkeys.rst
@@ -320,7 +320,7 @@ Key response
      - Multiplicity
      - Type
      - Description
-   * - ``apikey``
+   * - ``api_key``
      - 1
      - str
      - the API key generated for the application


### PR DESCRIPTION
The documentation labels the field as being `apikey`, but it's `api_key` on the wire.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes a doc error that affects API correctness in appkey client code.

#### How was it tested? How can it be tested by the reviewer?
Previewed the generated markdown, and looked at the raw JSON content from a granted-key response.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
