### PR TITLE
Fix URL installation of plugins

### DIFF
--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -203,6 +203,7 @@ def download_file(url, folder, max_length=None):
 		r.raise_for_status()
 		if "Content-Disposition" in r.headers.keys():
 			filename = re.findall("filename=(.+)", r.headers["Content-Disposition"])[0]
+			filename = filename.replace('"', '') # remove any double quotes in the file name
 		else:
 			filename = url.split("/")[-1]
 


### PR DESCRIPTION
… for filename in content-disposition headers

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket — Yes! [Ticket opened here](https://github.com/OctoPrint/OctoPrint/issues/3678).
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

**WHAT/WHY**
Installing (certain?) plugins via URL seems to be broken at the moment on OctoPrint 1.4.1, so users may experience this issue. This PR is to fix that.

**SOLUTION**
The solution is to remove any double quotes from the filename (if any) obtained from the `download_file` util function in `net.py`.

#### How was it tested? How can it be tested by the reviewer?

This PR was tested by successfully installing a plugin via URL. The PR is a branch off of `maintenance`.

#### Any background context you want to provide?

With the recent release of OctoPrint 1.4.1,  installing a plugin via URL in the plugin manager does not seem to work anymore. The following error is displayed on screen (**see screenshot**). 

Upon investigation, it seems the error is caused by an incorrect path, caused by leading and trailing double quotes in the name of the file (**see red blocks in screenshot**). Specifically, it seems that when there are headers, the path that is returned from the `download_file` util in `net.py` still contains the double quotes — when it should not.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

<img width="566" alt="Screen Shot 2020-08-05 at 4 36 35 PM" src="https://user-images.githubusercontent.com/34010874/89461509-12b2bc80-d73a-11ea-99ea-cded70903833.png">

#### Further notes
[HTTP Content-Disposition headers specs from Mozilla](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Disposition)
