### PR TITLE
Fix: "pause" action command doesn't work with filament runout detection on Marlin

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -122,6 +122,7 @@ date of first contribution):
   * [Lachlan Cresswell](https://github.com/lachyc)
   * [Khoi Pham](https://github.com/osubuu)
   * [Federico Nembrini](https://github.com/FedericoNembrini)
+  * [Uri Shaked](https://github.com/urish)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1761,23 +1761,24 @@ class MachineCom(object):
 					debugging_output = line[2:].strip()
 					if debugging_output.startswith("action:"):
 						action_command = debugging_output[len("action:"):].strip()
+						action_command_name = action_command.split(' ')[0].strip()
 
-						if action_command == "cancel":
+						if action_command_name == "cancel":
 							self._log("Cancelling on request of the printer...")
 							self.cancelPrint()
-						elif action_command == "pause":
+						elif action_command_name == "pause":
 							self._log("Pausing on request of the printer...")
 							self.setPause(True)
-						elif action_command == "paused":
+						elif action_command_name == "paused":
 							self._log("Printer signalled that it paused, switching state...")
 							self.setPause(True, local_handling=False)
-						elif action_command == "resume":
+						elif action_command_name == "resume":
 							self._log("Resuming on request of the printer...")
 							self.setPause(False)
-						elif action_command == "resumed":
+						elif action_command_name == "resumed":
 							self._log("Printer signalled that it resumed, switching state...")
 							self.setPause(False, local_handling=False)
-						elif action_command == "disconnect":
+						elif action_command_name == "disconnect":
 							self._log("Disconnecting on request of the printer...")
 							self._callback.on_comm_force_disconnect()
 						else:


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

When Marlin pauses due the filament run out, it sends the following line:

```
//action:pause filament_runout 0
```

The current code compares the entire string with `pause`, so Marlin's action is silently ignored. 
This fix compares the first word with `pause`, so it should work correctly with Marlin filament run out detection feature.

#### How was it tested? How can it be tested by the reviewer?

I applied this fix to my local OctoPrint setup, and observed that it now detects Merlin's filament run out action correctly. Here is the output after the fix:

```
Send: N1418 G0 X111.704 Y102.247*20
Recv: //action:paused filament_runout 0
Printer signalled that it paused, switching state...
Changing monitoring state from "Printing" to "Pausing"
``` 

#### Any background context you want to provide?

Here's the [relevant code in Marlin](https://github.com/MarlinFirmware/Marlin/blob/2.0.x/Marlin/src/feature/runout.cpp#L136-L140), which prints this `filament_runout` message.


#### Most important ####

👍 Thanks for creating and maintaining OctoPrint. I love it :-)
