### PR TITLE
option/settingsmenuname

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -122,6 +122,7 @@ date of first contribution):
   * [Lachlan Cresswell](https://github.com/lachyc)
   * [Khoi Pham](https://github.com/osubuu)
   * [Federico Nembrini](https://github.com/FedericoNembrini)
+  * [Ollis Git](https://github.com/OllisGit)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/templates/dialogs/settings.jinja2
+++ b/src/octoprint/templates/dialogs/settings.jinja2
@@ -20,7 +20,8 @@
                                     class="{% if ns.mark_active %}active{% set ns.mark_active = False %}{% endif %} {% if "classes_link" in data %}{{ data.classes_link|join(' ') }}{% elif "classes" in data %}{{ data.classes|join(' ') }}{% endif %}"
                                     {% if "styles_link" in data %} style="{{ data.styles_link|join(', ') }}" {% elif "styles" in data %} style="{{ data.styles|join(', ') }}" {% endif %}
                                         >
-                                    <a href="#{{ data._div }}" data-toggle="tab">{{ entry|e }}</a>
+                                    {% if "settings_menu_label" not in data %}<a href="#{{ data._div }}" data-toggle="tab">{{ entry|e }}</a>{% endif %}
+                                    {% if "settings_menu_label" in data %}<a href="#{{ data._div }}" data-toggle="tab">{{ data["settings_menu_label"] }}</a>{% endif %}
                                 </li>
                                 {% if "custom_bindings" not in data or data["custom_bindings"] %}<!-- /ko -->{% endif %}
                             {% endif %}


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
In the settings menu on the left side the Link-Names are taken from the plugin_name variable. Some plugins (like my) use names like this: "SpoolManager Plugin". So, the post fix "Plugin" is redundant in the settings menu.
But if I change the plugin name to e.g. "Spool Manager", then the update manager and maybe also the stats doesn't work properly.

This PR provides the ability to adjust the settings link name via the plugin. It works like adjusting the Tab-Names.
The plugin author just overwrite the TemplatePlugin mixing like this:
```
	##~~ TemplatePlugin mixin
	def get_template_configs(self):
		return [
			dict(type="tab", name="Spools"),
			dict(type="settings", custom_bindings=True, settings_menu_label="LABEL: Spool Manager")
		]
```
If the key ```settings_menu_label```is not set, the the default way is used (plugin_name) 


#### How was it tested? How can it be tested by the reviewer?
In a sample plugin overwrite the TemplatePlugin mixing like above. Add
```
settings_menu_label="LABEL: Spool Manager"
```

#### Any background context you want to provide?
no

#### What are the relevant tickets if any?
https://github.com/OllisGit/OctoPrint-SpoolManager/issues/47

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24205767/91666052-39c29b00-eafa-11ea-9ef1-985a424f97ad.png)

#### Further notes
If excepted, then this feature must be added to the documentation ;-)