### PR TITLE
fix: fixed cant add the firstApplication Key

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -122,6 +122,7 @@ date of first contribution):
   * [Lachlan Cresswell](https://github.com/lachyc)
   * [Khoi Pham](https://github.com/osubuu)
   * [Federico Nembrini](https://github.com/FedericoNembrini)
+  * [Leonardo Helman](https://github.com/lhelman)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/appkeys/templates/appkeys_settings.jinja2
+++ b/src/octoprint/plugins/appkeys/templates/appkeys_settings.jinja2
@@ -58,26 +58,26 @@
             <li data-bind="css: {disabled: keys.currentPage() === keys.lastPage()}"><a href="javascript:void(0)" data-bind="click: keys.nextPage">»</a></li>
         </ul>
     </div>
-
-    <legend>{{ _('Manually generate an application key') }}</legend>
-
-    <form class="form-horizontal" onsubmit="return false;">
-        <div class="control-group">
-            <label class="control-label">{{ _('User') }}</label>
-            <div class="controls">
-                <select data-bind="options: access.users.listHelper.items, optionsText: 'name', optionsValue: 'name', value: editorUser"></select>
-            </div>
-        </div>
-        <div class="control-group">
-            <label class="control-label">{{ _('Application identifier') }}</label>
-            <div class="controls">
-                <input type="text" data-bind="value: editorApp">
-            </div>
-        </div>
-        <div class="control-group">
-            <div class="controls">
-                <button class="btn btn-primary" data-bind="click: generateKey">Generate</button>
-            </div>
-        </div>
-    </form>
 </div>
+
+<legend>{{ _('Manually generate an application key') }}</legend>
+
+<form class="form-horizontal" onsubmit="return false;">
+    <div class="control-group">
+        <label class="control-label">{{ _('User') }}</label>
+        <div class="controls">
+            <select data-bind="options: access.users.listHelper.items, optionsText: 'name', optionsValue: 'name', value: editorUser"></select>
+        </div>
+    </div>
+    <div class="control-group">
+        <label class="control-label">{{ _('Application identifier') }}</label>
+        <div class="controls">
+            <input type="text" data-bind="value: editorApp">
+        </div>
+    </div>
+    <div class="control-group">
+        <div class="controls">
+            <button class="btn btn-primary" data-bind="click: generateKey">Generate</button>
+        </div>
+    </div>
+</form>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

In the OctoPrint Settings page, on the Application Keys feature,
you couldn't add any new key when there are no keys present.

After this change, it will show `Manually generate an application key`
text and it will allow you to create a new application key.

The way to replicate is, on a local OctoPrint

```bash
rm -rf ~/.octoprint
octoprint serve
```

Go in a browser to http://127.0.0.1:5000 and after configuration,
navigate to the `Application Keys` page.

Not sure why this one is not allowing, while the `template_usersettings`
has the fix.

#### How was it tested? How can it be tested by the reviewer?

* I've run octoprint serve on a clean install before and after the change
* I've run the tests and nothing broke.

#### Further notes

Best if the changes are seen without considering spaces.