### PR TITLE
Fix action command notification max height

### DIFF
--- a/src/octoprint/plugins/action_command_notification/static/css/action_command_notification.css
+++ b/src/octoprint/plugins/action_command_notification/static/css/action_command_notification.css
@@ -3,3 +3,9 @@
     line-height: 20px;
     border-bottom: 1px solid #ddd;
 }
+
+.sidebar_plugin_action_command_notification_scrollable  {
+    overflow-x: hidden;
+    overflow-y: scroll;
+    max-height: 306px;
+}

--- a/src/octoprint/plugins/action_command_notification/templates/action_command_notification_sidebar.jinja2
+++ b/src/octoprint/plugins/action_command_notification/templates/action_command_notification_sidebar.jinja2
@@ -1,5 +1,5 @@
 <div style="display: none" data-bind="visible: notifications().length > 0">
-    <div class="scroll-wrapper" data-bind="foreach: notifications">
+    <div class="scroll-wrapper sidebar_plugin_action_command_notification_scrollable" data-bind="foreach: notifications">
         <div class="sidebar_plugin_action_command_notification_entry">
             <div class="sidebar_plugin_action_command_notification_entry_timestamp"><small class="muted" data-bind="text: $root.toDateTimeString($data.timestamp)"></small></div>
             <div class="sidebar_plugin_action_command_notification_entry_message" data-bind="text: message"></div>


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes a max height of 306px (same as file manager) to the action command notification plugin.
I remembered this issue in the community forums: https://community.octoprint.org/t/printer-notifications-sidebar-entries-make-no-sense/23345, where the user had *loads* of notifications. If that happens, it's now scrollable with a max height.
#### How was it tested? How can it be tested by the reviewer?
Lots of `!!DEBUG: send //action: notification ` sent to the virtual printer
#### Any background context you want to provide?
https://community.octoprint.org/t/printer-notifications-sidebar-entries-make-no-sense/23345
#### What are the relevant tickets if any?
None that I know of.
#### Screenshots (if appropriate)
Now like this:
![image](https://user-images.githubusercontent.com/31997505/92312864-ea2e1480-efbc-11ea-9cd1-43626c3695c8.png)
Instead of this (user provided):
![image](https://user-images.githubusercontent.com/31997505/92312870-f3b77c80-efbc-11ea-933f-154647bf611a.png)

#### Further notes
🙂 