### PR TITLE
Hint mkstemp to create directory in the destination directory.

### DIFF
--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1056,9 +1056,11 @@ def atomic_write(filename, mode="w+b", encoding="utf-8", prefix="tmp", suffix=""
 	if os.path.exists(filename):
 		permissions |= os.stat(filename).st_mode
 	permissions &= max_permissions
+	
+	targetdirectory = os.path.dirname(filename)
 
 	# NamedTemporaryFile doesn't yet have an encoding parameter in py2, so we go the long way
-	fd, path = tempfile.mkstemp(suffix=suffix, prefix=prefix)
+	fd, path = tempfile.mkstemp(suffix=suffix, prefix=prefix, dir=targetdirectory)
 	os.close(fd)
 
 	if "b" in mode:

--- a/tests/util/test_file_helpers.py
+++ b/tests/util/test_file_helpers.py
@@ -121,13 +121,76 @@ class TestAtomicWrite(unittest.TestCase):
 			f.write("test")
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="w+b")
 		mock_file.write.assert_called_once_with("test")
 		mock_file.close.assert_called_once_with()
 		mock_chmod.assert_called_once_with(path, 0o644)
 		mock_move.assert_called_once_with(path, "somefile.yaml")
+
+	@mock.patch("shutil.move")
+	@mock.patch("tempfile.mkstemp")
+	@mock.patch("io.open")
+	@mock.patch("os.close")
+	@mock.patch("os.chmod")
+	@mock.patch("os.path.exists")
+	def test_atomic_write_path_aware(self, mock_exists, mock_chmod, mock_close, mock_open, mock_mkstemp, mock_move):
+		"""Tests whether the tempoary file is to created in the same directory as the target file."""
+
+		# setup
+		fd = 0
+		tmpdirpath = "/testpath/with/subdirectories"
+		path = os.path.join(tmpdirpath, "tempfile.tmp")
+		targetpath = os.path.join(tmpdirpath, "somefile.yaml")
+
+		mock_file = mock.MagicMock()
+		mock_file.name = path
+
+		mock_mkstemp.return_value = fd, path
+		mock_open.return_value = mock_file
+		mock_exists.return_value = False
+
+		# test
+		with octoprint.util.atomic_write(targetpath) as f:
+			f.write("test")
+
+		# assert
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir=tmpdirpath)
+		mock_open.assert_called_once_with(path, mode="w+b")
+		mock_move.assert_called_once_with(path, targetpath)
+
+	@mock.patch("shutil.move")
+	@mock.patch("tempfile.mkstemp")
+	@mock.patch("io.open")
+	@mock.patch("os.close")
+	@mock.patch("os.chmod")
+	@mock.patch("os.path.exists")
+	def test_atomic_write_rel_path_aware(self, mock_exists, mock_chmod, mock_close, mock_open, mock_mkstemp, mock_move):
+		"""Tests whether the tempoary file is to created in the same directory as the target file. This time submitting a relative path. """
+
+		# setup
+		fd = 0
+		tmpdirpath = "../test"
+		path = os.path.join(tmpdirpath, "tempfile.tmp")
+		targetpath = os.path.join(tmpdirpath, "somefile.yaml")
+
+		mock_file = mock.MagicMock()
+		mock_file.name = path
+
+		mock_mkstemp.return_value = fd, path
+		mock_open.return_value = mock_file
+		mock_exists.return_value = False
+
+		# test
+		with octoprint.util.atomic_write(targetpath) as f:
+			f.write("test")
+
+		# assert
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir=tmpdirpath)
+		mock_open.assert_called_once_with(path, mode="w+b")
+		mock_move.assert_called_once_with(path, targetpath)
+
 
 	@mock.patch("shutil.move")
 	@mock.patch("tempfile.mkstemp")
@@ -159,7 +222,7 @@ class TestAtomicWrite(unittest.TestCase):
 			pass
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="w+b")
 		mock_file.close.assert_called_once_with()
@@ -195,7 +258,7 @@ class TestAtomicWrite(unittest.TestCase):
 			pass
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="w+b")
 		mock_file.close.assert_called_once_with()
@@ -227,7 +290,7 @@ class TestAtomicWrite(unittest.TestCase):
 			f.write("test")
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="foo", suffix="bar")
+		mock_mkstemp.assert_called_once_with(prefix="foo", suffix="bar", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="w", encoding="utf-8")
 		mock_file.close.assert_called_once_with()
@@ -260,7 +323,7 @@ class TestAtomicWrite(unittest.TestCase):
 			f.write("test")
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="wt", encoding="utf-8")
 		mock_file.close.assert_called_once_with()
@@ -297,7 +360,7 @@ class TestAtomicWrite(unittest.TestCase):
 			f.write("test")
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="wt", encoding="utf-8")
 		mock_file.close.assert_called_once_with()
@@ -334,7 +397,7 @@ class TestAtomicWrite(unittest.TestCase):
 			f.write("test")
 
 		# assert
-		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="")
+		mock_mkstemp.assert_called_once_with(prefix="tmp", suffix="", dir="")
 		mock_close.assert_called_once_with(fd)
 		mock_open.assert_called_once_with(path, mode="wt", encoding="utf-8")
 		mock_file.close.assert_called_once_with()


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :) 
    _(I don't consider this fix to be significant enough to earn a spot in this file)_

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

(Sorry for reporting another heisenbug, but this time I might have a patch…)

I've seen in a few occassions that my config.yaml contained only garbarge after a non-clean shutdown,
making Octoprint not wanting to start up afterwards. The garbarge looks like 0xff's, so I'm assuming
that a race occured that made the file creation work but the file content not written to flash.

My setup is:
- Bananapi (with Debian 10) hosting octorprint.
- Octoprint is installed via pip install method long ago and updated via Octoprints own update mechanism
- Octoprint runs as it own user using a systemd service file.
- /home is on its own partition; F2Fs as the file system of choice.
- /tmp is a tmpfs 
- (for completeness: / is a ext4 partition, mounted readonly)

The important part is that the home directory of octoprint is on another partition than /tmp:
Mkstemp() uses standard locations for tempfiles by default, like /tmp. As this crosses filesystem boundaries,
shutils.move() is forced to do a copy instead of a rename (which would be guraranteed by the kernel to be an
atomic operation).

The patch hints mkstemp() to use the target directory for the temporary file, so that shutils.move() can do the
atomic rename.

#### How was it tested? How can it be tested by the reviewer?

Tested by debugging in spyder and running Octoprint on my desktop PC…

Testcase added, but please review carefully (I'm not a Python person / more a C++/Linux guy…)

#### Any background context you want to provide?

This is the log extract I've got when I was experiencing the problem:
```
-- Reboot --
Jun 24 09:30:57 bananapi2 octoprint[564]: 2020-06-24 09:30:57,205 - octoprint.startup - CRITICAL - Could not initialize settings manager: Error parsing the configuration file, it appears to be invalid YAML.
Jun 24 09:30:57 bananapi2 octoprint[564]: 2020-06-24 09:30:57,209 - octoprint.startup - CRITICAL - There was a fatal error starting up OctoPrint.
Jun 24 09:30:57 bananapi2 octoprint[564]: Could not initialize settings manager: Error parsing the configuration file, it appears to be invalid YAML.
Jun 24 09:30:57 bananapi2 octoprint[564]: There was a fatal error starting up OctoPrint.
-- Reboot --
Jun 24 11:34:35 bananapi2 octoprint[563]: 2020-06-24 11:34:35,758 - octoprint.startup - CRITICAL - Could not initialize settings manager: Error parsing the configuration file, it appears to be invalid YAML.
Jun 24 11:34:35 bananapi2 octoprint[563]: 2020-06-24 11:34:35,760 - octoprint.startup - CRITICAL - There was a fatal error starting up OctoPrint.
Jun 24 11:34:35 bananapi2 octoprint[563]: Could not initialize settings manager: Error parsing the configuration file, it appears to be invalid YAML.
Jun 24 11:34:35 bananapi2 octoprint[563]: There was a fatal error starting up OctoPrint.
-- Reboot --
```
(complete log file: https://sviech.de/s/XtsCjWkfxCZFBNs/download -- but I fear it hasn't got more details)


**Why I think the patch fixes this:**

Running octoprint throuch strace shows that without the patch the file is indeed copied (after the rename failed with EXDEV) , while with the patch the rename syscall is used sucessfully. (I've deleted ~/.octoprint before each run)

a) without the patch
```
stat("/home/tobi/.octoprint", {st_mode=S_IFDIR|S_ISVTX|0777, st_size=40, ...}) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00afa120) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
getrandom("\xd0\xd0\x7a\x43\xcb\xec\x8f\x75\x58\xf1\x76\x5b\xb2\xc1\x8f\x2b", 16, 0) = 16
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00af9c60) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
getcwd("/home/tobi/workspace/tmp/OctoPrint", 1024) = 35
getpid()                                = 7367
getrandom("\xd8\x3d\xec\x11\x6d\x5b\x71\x0b\xa0\xe1\x57\xc5\xaa\x15\xce\xe7\x5c\x67\xf5\x82\x35\x75\x0a\x14\xf3\x22\xcc\xa5\x19\xf8\x6f\x3b"..., 2496, GRND_NONBLOCK) = 2496
openat(AT_FDCWD, "/tmp/0v2sywov", O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600) = 3
fstat(3, {st_mode=S_IFREG|0600, st_size=0, ...}) = 0
ioctl(3, TCGETS, 0x7fff00af94d0)        = -1 ENOTTY (Unpassender IOCTL (I/O-Control) für das Gerät)
lseek(3, 0, SEEK_CUR)                   = 0
write(3, "blat", 4)                     = 4
close(3)                                = 0
unlink("/tmp/0v2sywov")                 = 0
getpid()                                = 7367
getrandom("\x7c\x2f\xca\x54\xfc\xcd\x78\xe1\x52\xf3\x66\x0e\x7c\xf4\xaf\xb8\xe4\x50\xd1\xa2\xae\x44\xcd\x62\xcf\x42\x03\x0e\xba\x0b\x81\x0d"..., 2496, GRND_NONBLOCK) = 2496
openat(AT_FDCWD, "/tmp/octoprint-config-kl4yj4x2.yaml", O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600) = 3
close(3)                                = 0
openat(AT_FDCWD, "/tmp/octoprint-config-kl4yj4x2.yaml", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 3
fstat(3, {st_mode=S_IFREG|0600, st_size=0, ...}) = 0
ioctl(3, TCGETS, 0x7fff00af9b10)        = -1 ENOTTY (Unpassender IOCTL (I/O-Control) für das Gerät)
lseek(3, 0, SEEK_CUR)                   = 0
lseek(3, 0, SEEK_CUR)                   = 0
write(3, "api:\n    key: D0D07A43CBEC4F7598"..., 47) = 47
close(3)                                = 0
chmod("/tmp/octoprint-config-kl4yj4x2.yaml", 0600) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00af9a10) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
**rename("/tmp/octoprint-config-kl4yj4x2.yaml", "/home/tobi/.octoprint/config.yaml") = -1 EXDEV (Ungültiger Link über Gerätegrenzen hinweg)**
lstat("/tmp/octoprint-config-kl4yj4x2.yaml", {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
stat("/tmp/octoprint-config-kl4yj4x2.yaml", {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00af97c0) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
stat("/tmp/octoprint-config-kl4yj4x2.yaml", {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00af9420) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
stat("/tmp/octoprint-config-kl4yj4x2.yaml", {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7fff00af9570) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
openat(AT_FDCWD, "/tmp/octoprint-config-kl4yj4x2.yaml", O_RDONLY|O_CLOEXEC) = 3
fstat(3, {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
ioctl(3, TCGETS, 0x7fff00af9420)        = -1 ENOTTY (Unpassender IOCTL (I/O-Control) für das Gerät)
lseek(3, 0, SEEK_CUR)                   = 0
openat(AT_FDCWD, "/home/tobi/.octoprint/config.yaml", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 4
fstat(4, {st_mode=S_IFREG|0644, st_size=0, ...}) = 0
ioctl(4, TCGETS, 0x7fff00af9420)        = -1 ENOTTY (Unpassender IOCTL (I/O-Control) für das Gerät)
lseek(4, 0, SEEK_CUR)                   = 0
fstat(3, {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
sendfile(4, 3, [0] => [47], 8388608)    = 47
sendfile(4, 3, [47], 8388608)           = 0
close(4)                                = 0
close(3)                                = 0
stat("/tmp/octoprint-config-kl4yj4x2.yaml", {st_mode=S_IFREG|0600, st_size=47, ...}) = 0
utimensat(AT_FDCWD, "/home/tobi/.octoprint/config.yaml", [{tv_sec=1599488898, tv_nsec=120220008} /* 2020-09-07T16:28:18.120220008+0200 */, {tv_sec=1599488898, tv_nsec=120220008} /* 2020-09-07T16:28:18.120220008+0200 */], 0) = 0
listxattr("/tmp/octoprint-config-kl4yj4x2.yaml", "", 256) = 0
chmod("/home/tobi/.octoprint/config.yaml", 0600) = 0
unlink("/tmp/octoprint-config-kl4yj4x2.yaml") = 0
```

b) with the patch:

```
stat("/home/tobi/.octoprint", {st_mode=S_IFDIR|0755, st_size=4096, ...}) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7ffe6dfdd260) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
getrandom("\x97\x16\x81\xca\x48\xdf\x4b\x42\x0f\x08\x06\x09\xf8\x6f\xf0\x0d", 16, 0) = 16
stat("/home/tobi/.octoprint/config.yaml", 0x7ffe6dfdcda0) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
getpid()                                = 7090
getrandom("\x1a\x8c\xc7\x73\x6e\x75\xc7\x60\x35\xf4\xa0\xb4\x08\x5e\xcd\x57\x25\x8f\x43\x8b\x19\xe1\xcb\x40\xff\x0b\x44\xe3\x99\xcb\xb7\xc4"..., 2496, GRND_NONBLOCK) = 2496
openat(AT_FDCWD, "/home/tobi/.octoprint/octoprint-config-femiix9m.yaml", O_RDWR|O_CREAT|O_EXCL|O_NOFOLLOW|O_CLOEXEC, 0600) = 3
close(3)                                = 0
openat(AT_FDCWD, "/home/tobi/.octoprint/octoprint-config-femiix9m.yaml", O_WRONLY|O_CREAT|O_TRUNC|O_CLOEXEC, 0666) = 3
fstat(3, {st_mode=S_IFREG|0600, st_size=0, ...}) = 0
ioctl(3, TCGETS, 0x7ffe6dfdcc50)        = -1 ENOTTY (Unpassender IOCTL (I/O-Control) für das Gerät)
lseek(3, 0, SEEK_CUR)                   = 0
lseek(3, 0, SEEK_CUR)                   = 0
write(3, "api:\n    key: 971681CA48DF4B428F"..., 47) = 47
close(3)                                = 0
chmod("/home/tobi/.octoprint/octoprint-config-femiix9m.yaml", 0600) = 0
stat("/home/tobi/.octoprint/config.yaml", 0x7ffe6dfdcb50) = -1 ENOENT (Datei oder Verzeichnis nicht gefunden)
**rename("/home/tobi/.octoprint/octoprint-config-femiix9m.yaml", "/home/tobi/.octoprint/config.yaml") = 0**
```




#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

