### PR TITLE
Fixes for couple bugs

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -1003,6 +1003,12 @@ class MachineCom(object):
 
 		self._serial = None
 
+		# fix for send_thread leak
+		# this two commands is just for unblocking send_thread
+		# nothing will be sended because send queue is deactivated at this point
+		self._enqueue_for_sending(self._hello_command)
+		self._clear_to_send.set()
+
 		# if we are printing, this will also make sure of firing PRINT_FAILED
 		if is_error:
 			self._changeState(self.STATE_CLOSED_WITH_ERROR)


### PR DESCRIPTION
Hi, sorry for my english. I have 3d printer with fw Marlin 2.0.6.1, board - skr 1.3. Octoprint runs on orange pi and when octoprint starts - printer is always off (it is turned on later by SSR relay). At first i was connect board and orange pi with usb and connect/disconnect button in octoprint works fine and without bugs. But then i moved connection from usb to gpio/uart logic and that is where bugs comes. I think this bug appears because direct uart connection is faster than usb. Sometime octoprint hangs when connecting to board, everytime in the same place, see first attached screenshot. After a day of remote debugging i was able to find cause of this deadlock. First two commands that octoprint sends is sayHello commands, inside sayHello you are incrementing clear_to_send counter that checked by sender_thread. By default clear_to_send has max value = 1, so after second sayHello call clear_to_send will have value = 1. Inside sender_thread you have clear_to_send.wait() before send cycle, so if both sayHello call will be executed before this clear_to_send.wait() call, then later in send cycle it will hang forever in second clear_to_send.wait(). So it is race condition. Forgot to say that monitor thread is alive, only sender_thread is deadlocked, i can't send anything, but i receive temperature messages from board. I was able to workaround this bug by setting ok buffer to 2, but i think it is ugly solution, so i fixed it in another way (see commit). Also i found that after disconnecting from printer sender_thread not closed properly and every connect/disconnect cycle causes sender_threads amount to grow up. I fixed this too, see commits. Sorry for my bad english again.

![11111](https://user-images.githubusercontent.com/26410750/92973610-bff1c080-f4ae-11ea-9c04-a7313840adc4.jpg)
![22222](https://user-images.githubusercontent.com/26410750/92973613-c1bb8400-f4ae-11ea-9f9f-4c214d3d9197.jpg)

