### PR TITLE
Add terminal filter for busy protocol

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -127,6 +127,7 @@ date of first contribution):
   * [Brian Vanderbusch](https://github.com/LongLiveCHIEF)
   * [Charlie Powell](https://github.com/cp2004)
   * [Ollis Git](https://github.com/OllisGit)
+  * [Sophist](https://github.com/Sophist-UK)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1122,6 +1122,8 @@ Use `Javascript regular expressions <https://developer.mozilla.org/en/docs/Web/J
      regex: '(Send: (N\d+\s+)?M27)|(Recv: SD printing byte)'
    - name: Suppress wait responses
      regex: 'Recv: wait'
+   - name: Suppress processing responses
+     regex: 'Recv: (echo:\s*)?busy:\s*processing'
 
 .. _sec-configuration-config_yaml-webcam:
 

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -382,7 +382,8 @@ default_settings = {
 	"terminalFilters": [
 		{ "name": "Suppress temperature messages", "regex": r"(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+((P|B|N)\d+\s+)*)?(B|T\d*):\d+)" },
 		{ "name": "Suppress SD status messages", "regex": r"(Send: (N\d+\s+)?M27)|(Recv: SD printing byte)|(Recv: Not SD printing)" },
-		{ "name": "Suppress wait responses", "regex": "Recv: wait"}
+		{ "name": "Suppress wait responses", "regex": r"Recv: wait" },
+		{ "name": "Suppress processing responses", "regex": r"Recv: (echo:\s*)?busy:\s*processing" }
 	],
 	"plugins": {
 		"_disabled": [],


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
This PR adds an additional matching string to the Suppress Wait Response terminal message filter to filter out messages of the form: "Recv:echo: processing".

#### How was it tested? How can it be tested by the reviewer?
This was tested on my 3D printer. To test it you simply need to create a move which takes a long time - say a move from one extreme to the other on the z-axis. Test this both without the filter and using the existing filter and you should see several "Recv:echo: processing" messages appear in the terminal window. Change the filter regex, reload the OctoPrint browser window, and retry and these messages should be filtered.

#### Any background context you want to provide?
No

#### What are the relevant tickets if any?
N/a