### PR TITLE
Add unique ID TXT record to ZeroConf service

### DIFF
--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -138,12 +138,13 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 		self.port = port
 
 		# Zeroconf
-		self.zeroconf_register("_http._tcp", self.get_instance_name(), txt_record=self._create_http_txt_record_dict())
-		self.zeroconf_register("_octoprint._tcp", self.get_instance_name(), txt_record=self._create_octoprint_txt_record_dict())
+		instance_name = self.get_instance_name()
+		self.zeroconf_register("_http._tcp", instance_name, txt_record=self._create_http_txt_record_dict())
+		self.zeroconf_register("_octoprint._tcp", instance_name, txt_record=self._create_octoprint_txt_record_dict())
 		for zc in self._settings.get(["zeroConf"]):
 			if "service" in zc:
 				self.zeroconf_register(zc["service"],
-				                       zc.get("name", self.get_instance_name()),
+				                       zc.get("name", instance_name),
 				                       port=zc.get("port"),
 				                       txt_record=zc.get("txtRecord"))
 
@@ -177,7 +178,7 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 		return octoprint.util.to_native_str(name) + octoprint.util.to_native_str(".") + service_type
 
 	def _format_zeroconf_txt(self, record):
-		result = dict()
+		result = {}
 		if not record:
 			return result
 
@@ -489,23 +490,22 @@ class DiscoveryPlugin(octoprint.plugin.StartupPlugin,
 
 		:return: a dictionary containing the defined key-value-pairs, ready to be turned into a TXT record
 		"""
-
-		entries = self._create_http_txt_record_dict()
-
 		import octoprint.server
 		import octoprint.server.api
 
-		entries.update(dict(
+		entries = self._create_http_txt_record_dict()
+		entries.update(
 			version=octoprint.server.VERSION,
 			api=octoprint.server.api.VERSION,
-			))
+			uuid=self.get_uuid()
+		)
 
 		modelName = self._settings.get(["model", "name"])
 		if modelName:
-			entries.update(dict(model=modelName))
+			entries.update(model=modelName)
 		vendor = self._settings.get(["model", "vendor"])
 		if vendor:
-			entries.update(dict(vendor=vendor))
+			entries.update(vendor=vendor)
 
 		return entries
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

It adds the discovery `uuid` as a TXT record to the ZeroConf service annoucement.
This allows to uniquely identify a instance of Octoprint, even if the name (UI config setting) or IP address (e.g., DHCP or other network influences) of the instance changes.

![image](https://user-images.githubusercontent.com/195327/94008222-ee22aa80-fda2-11ea-8112-0920d899461c.png)

#### How was it tested? How can it be tested by the reviewer?

- Checkout PR
- Start OctoPrint
- Explorer mDNS (e.g., using Discovery for macOS or the Ahavi browser)

#### Any background context you want to provide?

This is similar to how SSDP works (and is set up in OctoPrint as well).

#### What are the relevant tickets if any?

None.

#### Screenshots (if appropriate)

See above.

#### Further notes

Added some cleanup and efficiency in the process.