### PR TITLE
Adding support for bearer token

### DIFF
--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -274,6 +274,13 @@ def get_api_key(request):
 	if "X-Api-Key" in request.headers:
 		return request.headers.get("X-Api-Key")
 
+	# Check Tornado and Flask headers
+	if "Authorization" in request.headers:
+		header = request.headers.get("Authorization")
+		if header.startswith("Bearer "):
+			token = header.replace("Bearer ", "", 1)
+			return token
+
 	return None
 
 


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
Adds support for accepting the api token via an `Authorization: Bearer XXXX` header 

#### How was it tested? How can it be tested by the reviewer?
comparing the output of the following curl calls, please replace the token with your own
```
curl -H 'X-Api-key: REPLACETHISWITHYOURTOKEN' http://localhost:5000/api/currentuser
curl -H 'Authorization: Bearer REPLACETHISWITHYOURTOKEN' http://localhost:5000/api/currentuser
```

#### Any background context you want to provide?
Passing the token as a bearer token is the standard for most rest/api calling software. iirc was prometheus the reason i was looking into this.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
