### PR TITLE
Make octoprint.util.ResettableTimer daemon thread by default

### DIFF
--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1456,7 +1456,7 @@ class ResettableTimer(threading.Thread):
 	    on_reset (callable): Callback to call when the timer is reset.
 	"""
 
-	def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None):
+	def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None, daemon=True):
 		threading.Thread.__init__(self)
 		self._event = threading.Event()
 		self._mutex = threading.Lock()
@@ -1473,6 +1473,7 @@ class ResettableTimer(threading.Thread):
 		self.kwargs = kwargs
 		self.on_cancelled = on_cancelled
 		self.on_reset = on_reset
+		self.daemon = daemon
 
 
 	def run(self):


### PR DESCRIPTION
See also:
* https://github.com/j7126/OctoPrint-Dashboard/pull/219

* https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/pull/200

Affects plugins that use multiprocessing, since it blocks the shutdown (and release of server address binding), breaking the server.

Shouldn't be a breaking change, since it should be run daemon=True anyway to avoid the shutdown problems.

---

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?

Sets `daemon=True` in `octoprint.util.ResettableTimer`, to avoid issues such as
https://github.com/j7126/OctoPrint-Dashboard/issues/214
https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/issues/193
in the future.

#### How was it tested? How can it be tested by the reviewer?

1. Install OctoPrint
2. Install WS281x LED Status and use a Resettable timer
3. Observe issue with restart
4. Apply, fix, observe no issue

#### Any background context you want to provide?

See above tickets
#### What are the relevant tickets if any?
None within OctoPrint

#### Screenshots (if appropriate)

#### Further notes
