### PR TITLE
Improve detection of virtual environment in setups with newer versions of `virtualenv`

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -128,6 +128,7 @@ date of first contribution):
   * [Charlie Powell](https://github.com/cp2004)
   * [Ollis Git](https://github.com/OllisGit)
   * [Sophist](https://github.com/Sophist-UK)
+  * [Manuel McLure](https://github.com/ManuelMcLure)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/pip.py
+++ b/src/octoprint/util/pip.py
@@ -544,7 +544,9 @@ class LocalPipCaller(PipCaller):
         import sys
         from distutils.sysconfig import get_python_lib
 
-        virtual_env = hasattr(sys, "real_prefix")
+        virtual_env = hasattr(sys, "real_prefix") or (
+            hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+        )
         install_dir = get_python_lib()
         writable = os.access(install_dir, os.W_OK)
 

--- a/src/octoprint/util/piptestballoon/setup.py
+++ b/src/octoprint/util/piptestballoon/setup.py
@@ -29,7 +29,9 @@ def produce_output(stream):
     cmd.finalize_options()
 
     install_dir = cmd.install_lib
-    virtual_env = hasattr(sys, "real_prefix")
+    virtual_env = hasattr(sys, "real_prefix") or (
+        hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+    )
     writable = os.access(install_dir, os.W_OK)
 
     lines = [


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
This fixes venv detection with newer versions of `virtualenv` that do not set `sys.real_prefix`. It does this by falling back to `sys.base_prefix` if `sys.real_prefix` is not found, and comparing it to `sys.prefix`.

#### How was it tested? How can it be tested by the reviewer?
I tested it manually on my Debian Buster/Python 3.7 installation where the original code did not work. I also ran all of the unit tests on both Python 2 and 3.

#### Further notes
The code used was taken from [https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv](https://stackoverflow.com/questions/1871549/determine-if-python-is-running-inside-virtualenv).