### PR TITLE
Make about button always open 'About OctoPrint'

### DIFF
--- a/src/octoprint/templates/dialogs/settings.jinja2
+++ b/src/octoprint/templates/dialogs/settings.jinja2
@@ -48,7 +48,7 @@
         </div>
     </div>
     <div class="modal-footer">
-        <button class="btn aboutlink" data-bind="click: about.show"><i class="fas fa-info-circle"></i> {{ _('About OctoPrint') }}</button>
+        <button class="btn aboutlink" data-bind="click: function() { about.show('about_about') }"><i class="fas fa-info-circle"></i> {{ _('About OctoPrint') }}</button>
         <button class="btn systeminfolink" data-bind="click: function() { about.show('about_systeminfo') }"><i class="fas fa-flag-checkered"></i> {{ _('System info') }}</button>
         <button class="btn" data-test-id="settings-close-button" data-bind="click: function() { cancelData() }" aria-hidden="true">{{ _('Close') }}</button>
         <button class="btn btn-primary" data-test-id="settings-save" data-bind="click: function() { saveData(undefined, $root.hide) }, enable: !exchanging(), css: {disabled: exchanging()}"><i class="fas fa-spinner fa-spin" data-bind="visible: sending"></i> {{ _('Save') }}</button>


### PR DESCRIPTION
While the 'About OctoPrint' button opened the dialog, it creates confusing behaviour if a user clicks the new 'System info' button first, since 'About OctoPrint' will then open the system info too.

This PR adjusts this, to force 'About OctoPrint' to open to the about page.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
See above

#### How was it tested? How can it be tested by the reviewer?
Press 'System info' button, followed by 'About OctoPrint' - notice the two different pages that are opened.

#### Any background context you want to provide?
Change necessary as a result of a58e02940d0c3f101c735b1bc06fd0bf1ebe894e, with the new 'System Info' button

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
None

#### Further notes
None
