### PR TITLE
Indicate ResettableTimer as daemonizable

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -123,6 +123,7 @@ date of first contribution):
   * [Khoi Pham](https://github.com/osubuu)
   * [Federico Nembrini](https://github.com/FedericoNembrini)
   * [Brian Vanderbusch](https://github.com/LongLiveCHIEF)
+  * [Christopher Brown](https://github.com/snecklifter)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ For information about how to go about submitting bug reports or pull requests, p
 Installation instructions for installing from source for different operating
 systems can be found [on the forum](https://community.octoprint.org/tags/c/support/guides/15/setup).
 
-If you want to run OctoPrint on a Raspberry Pi, you might want to take a look at [OctoPi](https://github.com/guysoft/OctoPi)
+If you want to run OctoPrint on a Raspberry Pi, you really should take a look at [OctoPi](https://github.com/guysoft/OctoPi)
 which is a custom SD card image that includes OctoPrint plus dependencies.
 
 The generic steps that should basically be done regardless of operating system
@@ -75,13 +75,6 @@ you already have Python 2.7, 3.6 or 3.7, pip and virtualenv and their dependenci
    to use instead of whatever version your system defaults to, you can also explicitly require that via the `--python`
    parameter, e.g. `virtualenv --python=python3 venv`.
 2. Install OctoPrint *into that virtual environment*: `./venv/bin/pip install OctoPrint`
-
-Or alternatively, for an install from source:
-
-1. Checkout OctoPrint: `git clone https://github.com/OctoPrint/OctoPrint.git`
-2. Change into the OctoPrint folder: `cd OctoPrint`
-3. Create a user-owned virtual environment therein: `virtualenv venv`
-4. Install OctoPrint *into that virtual environment*: `./venv/bin/pip install .`
 
 You may then start the OctoPrint server via `/path/to/OctoPrint/venv/bin/octoprint`, see [Usage](#usage)
 for details.

--- a/docs/api/files.rst
+++ b/docs/api/files.rst
@@ -319,7 +319,8 @@ Upload file or create folder
    Upload a file to the selected ``location`` or create a new empty folder on it.
 
    Other than most of the other requests on OctoPrint's API which are expected as JSON, this request is expected as
-   ``Content-Type: multipart/form-data`` due to the included file upload.
+   ``Content-Type: multipart/form-data`` due to the included file upload. A ``Content-Length`` header specifying
+   the full length of the request body is required as well.
 
    To upload a file, the request body must at least contain the ``file`` form field with the
    contents and file name of the file to upload.
@@ -341,6 +342,7 @@ Upload file or create folder
       Host: example.com
       X-Api-Key: abcdef...
       Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryDeC2E3iWbTv1PwMC
+      Content-Length: 430
 
       ------WebKitFormBoundaryDeC2E3iWbTv1PwMC
       Content-Disposition: form-data; name="file"; filename="whistle_v2.gcode"
@@ -350,7 +352,7 @@ Upload file or create folder
       T0
       G21
       G90
-      ...
+
       ------WebKitFormBoundaryDeC2E3iWbTv1PwMC
       Content-Disposition: form-data; name="select"
 
@@ -400,6 +402,7 @@ Upload file or create folder
       Host: example.com
       X-Api-Key: abcdef...
       Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryDeC2E3iWbTv1PwMC
+      Content-Length: 263
 
       ------WebKitFormBoundaryDeC2E3iWbTv1PwMC
       Content-Disposition: form-data; name="file"; filename*=utf-8''20mm-%C3%BCml%C3%A4ut-b%C3%B6x.gcode
@@ -409,7 +412,7 @@ Upload file or create folder
       T0
       G21
       G90
-      ...
+
       ------WebKitFormBoundaryDeC2E3iWbTv1PwMC--
 
    .. sourcecode:: http
@@ -440,6 +443,7 @@ Upload file or create folder
       Host: example.com
       X-Api-Key: abcdef...
       Content-Type: multipart/form-data; boundary=----WebKitFormBoundaryDeC2E3iWbTv1PwMD
+      Content-Length: 246
 
       ------WebKitFormBoundaryDeC2E3iWbTv1PwMD
       Content-Disposition: form-data; name="foldername"

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1424,9 +1424,10 @@ class ResettableTimer(threading.Thread):
 	    kwargs (dict): The keyword arguments for the ``function`` call. Defaults to an empty dict.
 	    on_cancelled (callable): Callback to call when the timer finishes due to being cancelled.
 	    on_reset (callable): Callback to call when the timer is reset.
+	    daemon (bool): daemon flag to set on underlying thread.
 	"""
 
-	def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None):
+	def __init__(self, interval, function, args=None, kwargs=None, on_reset=None, on_cancelled=None, daemon=True):
 		threading.Thread.__init__(self)
 		self._event = threading.Event()
 		self._mutex = threading.Lock()
@@ -1443,6 +1444,7 @@ class ResettableTimer(threading.Thread):
 		self.kwargs = kwargs
 		self.on_cancelled = on_cancelled
 		self.on_reset = on_reset
+		self.daemon = daemon
 
 
 	def run(self):

--- a/tests/util/test_resettable_timer.py
+++ b/tests/util/test_resettable_timer.py
@@ -20,6 +20,7 @@ class ResettableTimerTest(unittest.TestCase):
 		timer_task = mock.MagicMock()
 
 		timer = ResettableTimer(10, timer_task)
+		timer.daemon = True
 		timer.start()
 
 		# wait for it


### PR DESCRIPTION


#### What does this PR do and why is it necessary?

Whilst RepeatedTimer is indicated in the documentation as daemonizable, ResettableTimer is not.

#### How was it tested? How can it be tested by the reviewer?

I have enabled this in unit tests.

#### Any background context you want to provide?

This has been consumed for a while by the following plugin:

https://github.com/jneilliii/OctoPrint-TPLinkSmartplug

at

https://github.com/jneilliii/OctoPrint-TPLinkSmartplug/blob/master/octoprint_tplinksmartplug/__init__.py#L684

#### What are the relevant tickets if any?

N/A

#### Screenshots (if appropriate)

N/A

#### Further notes

N/A