### PR TITLE
fix issue with files api

### DIFF
--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -321,7 +321,7 @@ def _getFileList(origin, path=None, filter=None, recursive=False, allow_from_cac
                 file_or_folder["origin"] = FileDestinations.LOCAL
 
                 if file_or_folder["type"] == "folder":
-                    if "children" in file_or_folder:
+                    if "children" in file_or_folder and type(file_or_folder["children"]) is dict:
                         file_or_folder["children"] = analyse_recursively(
                             file_or_folder["children"],
                             path + file_or_folder["name"] + "/",

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -323,7 +323,7 @@ def _getFileList(origin, path=None, filter=None, recursive=False, allow_from_cac
                 if file_or_folder["type"] == "folder":
                     if "children" in file_or_folder and type(file_or_folder["children"]) is dict:
                         file_or_folder["children"] = analyse_recursively(
-                            file_or_folder["children"],
+                            file_or_folder["children"].values(),
                             path + file_or_folder["name"] + "/",
                         )
 

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -323,7 +323,7 @@ def _getFileList(origin, path=None, filter=None, recursive=False, allow_from_cac
                 if file_or_folder["type"] == "folder":
                     if "children" in file_or_folder:
                         file_or_folder["children"] = analyse_recursively(
-                            file_or_folder["children"].values(),
+                            file_or_folder["children"],
                             path + file_or_folder["name"] + "/",
                         )
 


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

Resolve issues with files api.

#### How was it tested? How can it be tested by the reviewer?

Ran in local development environment and verified error didn't exist.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#3805 

#### Screenshots (if appropriate)

#### Further notes

I'm not sure if this causes any other non-related issues, but seems to resolve the issue I opened without any obvious side effects. Maybe this is related to converting over dict/list formatting? Feel free to close if this is not a good fix.
