### PR TITLE
Fix uploading a language pack

### DIFF
--- a/src/octoprint/server/api/languages.py
+++ b/src/octoprint/server/api/languages.py
@@ -140,8 +140,10 @@ def uploadLanguagePack():
     upload_name = request.values[input_upload_name]
     upload_path = request.values[input_upload_path]
 
-    exts = filter(
-        lambda x: upload_name.lower().endswith(x), (".zip", ".tar.gz", ".tgz", ".tar")
+    exts = list(
+        filter(
+            lambda x: upload_name.lower().endswith(x), (".zip", ".tar.gz", ".tgz", ".tar")
+        )
     )
     if not len(exts):
         return make_response(


### PR DESCRIPTION
In Python 3, `filter()` returns an iterable rather than a list. Whilst this is better for performance, our list is not long and it means we can call `len()` on the list.

Tested using reproduction steps in #3814 and verified that language packs can now be installed properly.

Closes #3814

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes issue uploading language packs on Python 3. This doesn't appear to be a regression in 1.5.0rc1, and a change introduced by https://github.com/OctoPrint/OctoPrint/commit/63723baf077c1e0860a7774babe2c0356f8a05cd that removed a change introduced by https://github.com/OctoPrint/OctoPrint/commit/30359f52ab8bf21d375325780dd82a4420fa4975, both claiming to do the same thing.

#### How was it tested? How can it be tested by the reviewer?
Follow steps outlined in #3814 

#### Any background context you want to provide?
#3814 and https://github.com/OctoPrint/OctoPrint/issues/3802#issuecomment-727077364

#### What are the relevant tickets if any?
#3814 and https://github.com/OctoPrint/OctoPrint/issues/3802#issuecomment-727077364

#### Screenshots (if appropriate)

#### Further notes

Not sure if this counts as a regression, since it has been an issue since 1.4.0 was released, and only when using Python 3. *However*, since more and more users are moving to Python 3, or installing by default now (both manual and soon OctoPi) I think this *should* be included in 1.5.0. But at the end of the day, its not up to me. Change the branch to whatever you think works for this fix 🙂 
