### PR TITLE
update gcode_scripts.rst with correct UI path for print & resume

### DIFF
--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -184,7 +184,7 @@ More nifty pause and resume
 ...........................
 
 If you do not have a multi-extruder setup, aren't printing from SD and have "Log position on pause" enabled under
-Settings > Serial > Advanced options, the following ``afterPrintPaused`` and
+Settings > Serial Connection > Behaviour > Pausing, the following ``afterPrintPaused`` and
 ``beforePrintResumed`` scripts might be interesting for you. With something like them in place, OctoPrint will move your print head
 out of the way to a safe rest position (here ``G1 X0 Y0``, you might want to adjust that) on pause and move it back
 to the persisted pause position on resume, making sure to also reset the extruder and feedrate.


### PR DESCRIPTION
Updating one line in the documentation to be coherent with the User Interface

  * [X ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X ] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [no code] Your changes follow the existing coding style
  * [n/a] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [n/a] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [n/a] You have run the existing unit tests against your changes and
    nothing broke
  * [n/a] You have added yourself to the AUTHORS.md file :)


#### What does this PR do and why is it necessary?
Small update to the docs to be coherent with the octoprint Settings UI for the `Log position on pause` option.

#### How was it tested? How can it be tested by the reviewer?
n/a

#### Any background context you want to provide?
n/a

#### What are the relevant tickets if any?
n/a

#### Screenshots (if appropriate)
n/a

#### Further notes
n/a