### PR TITLE
Fix whitespace issue reporting M145 material heatup on M501/3

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1137,7 +1137,7 @@ class VirtualPrinter(object):
         config = self._virtual_eeprom.eeprom["material"]
         lines = []
         for material in ["0", "1"]:
-            line = "echo: " + config["command"] + "S" + material
+            line = "echo: " + config["command"] + " S" + material
             for param, saved_value in config["params"][material].items():
                 line = line + " " + param + str(saved_value)
             lines.append(line)


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes issue with no space between `M145` and `S`

#### How was it tested? How can it be tested by the reviewer?
Run command `M501` or `M503` against virtual, observe correct output.

#### Any background context you want to provide?
#3772 #3787 

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
I'll leave it up to you whether to cherry pick this into a final release, since it *probably* only impacts me, and I use the maintenance branch anyway 🙂 