### PR TITLE
Add Plugin list export button to plugin manager

### DIFF
--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -8,7 +8,6 @@ import octoprint.plugin
 from octoprint.access import ADMIN_GROUP
 from octoprint.access.permissions import Permissions
 from octoprint.events import Events
-from octoprint.plugin.core import FolderOrigin
 from octoprint.server import NO_CONTENT
 from octoprint.server.util.flask import no_firstrun_access
 from octoprint.settings import default_settings
@@ -980,22 +979,14 @@ class BackupPlugin(
                 )
 
                 # add list of installed plugins
-                plugins = []
-                plugin_folder = settings.global_get_basefolder("plugins")
-                for plugin in plugin_manager.plugins.values():
-                    if plugin.bundled or (
-                        isinstance(plugin.origin, FolderOrigin)
-                        and plugin.origin.folder == plugin_folder
-                    ):
-                        # ignore anything bundled or from the plugins folder we already include in the backup
-                        continue
+                helpers = plugin_manager.get_helpers(
+                    "pluginmanager", "generate_plugins_json"
+                )
+                if helpers and "generate_plugins_json" in helpers:
+                    plugins = helpers["generate_plugins_json"]()
 
-                    plugins.append(
-                        {"key": plugin.key, "name": plugin.name, "url": plugin.url}
-                    )
-
-                if len(plugins):
-                    zip.writestr("plugin_list.json", json.dumps(plugins))
+                    if len(plugins):
+                        zip.writestr("plugin_list.json", json.dumps(plugins))
 
             shutil.move(temporary_path, final_path)
 

--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -983,7 +983,9 @@ class BackupPlugin(
                     "pluginmanager", "generate_plugins_json"
                 )
                 if helpers and "generate_plugins_json" in helpers:
-                    plugins = helpers["generate_plugins_json"]()
+                    plugins = helpers["generate_plugins_json"](
+                        settings=settings, plugin_manager=plugin_manager
+                    )
 
                     if len(plugins):
                         zip.writestr("plugin_list.json", json.dumps(plugins))

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -1755,6 +1755,21 @@ class PluginManagerPlugin(
 
         return result
 
+    def generate_plugins_json(self, ignore_bundled=True, ignore_plugins_folder=True):
+        plugins = []
+        plugin_folder = self._settings.getBaseFolder("plugins")
+        for plugin in self._plugin_manager.plugins.values():
+            if (ignore_bundled and plugin.bundled) or (
+                ignore_plugins_folder
+                and isinstance(plugin.origin, octoprint.plugin.core.FolderOrigin)
+                and plugin.origin.folder == plugin_folder
+            ):
+                # ignore bundled or from the plugins folder already included in the backup
+                continue
+
+            plugins.append({"key": plugin.key, "name": plugin.name, "url": plugin.url})
+        return plugins
+
     def _to_external_plugin(self, plugin):
         return {
             "key": plugin.key,
@@ -1897,4 +1912,9 @@ def __plugin_load__():
         "octoprint.ui.web.templatetypes": __plugin_implementation__.get_template_types,
         "octoprint.events.register_custom_events": _register_custom_events,
         "octoprint.access.permissions": __plugin_implementation__.get_additional_permissions,
+    }
+
+    global __plugin_helpers__
+    __plugin_helpers__ = {
+        "generate_plugins_json": __plugin_implementation__.generate_plugins_json,
     }

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -401,6 +401,22 @@ class PluginManagerPlugin(
                     )
                 )
 
+    @octoprint.plugin.BlueprintPlugin.route("/export", methods=["GET"])
+    @no_firstrun_access
+    @Permissions.PLUGIN_PLUGINMANAGER_MANAGE.require(403)
+    def export_plugin_list(self):
+        import json
+
+        import flask
+
+        plugins = self.generate_plugins_json(self._settings, self._plugin_manager)
+
+        return flask.Response(
+            json.dumps(plugins),
+            mimetype="text/plain",
+            headers={"Content-Disposition": 'attachment; filename="plugins.json"'},
+        )
+
     def is_blueprint_protected(self):
         return False
 

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -1755,10 +1755,13 @@ class PluginManagerPlugin(
 
         return result
 
-    def generate_plugins_json(self, ignore_bundled=True, ignore_plugins_folder=True):
+    @staticmethod
+    def generate_plugins_json(
+        settings, plugin_manager, ignore_bundled=True, ignore_plugins_folder=True
+    ):
         plugins = []
-        plugin_folder = self._settings.getBaseFolder("plugins")
-        for plugin in self._plugin_manager.plugins.values():
+        plugin_folder = settings.getBaseFolder("plugins")
+        for plugin in plugin_manager.plugins.values():
             if (ignore_bundled and plugin.bundled) or (
                 ignore_plugins_folder
                 and isinstance(plugin.origin, octoprint.plugin.core.FolderOrigin)

--- a/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
+++ b/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
@@ -59,6 +59,7 @@
         {{ pluginmanager_requesterror() }}
 
         <div class="pull-right">
+            <a class="btn btn-small" href="/plugin/pluginmanager/export"><i class="fas fa-download"></i> {{ _('Export') }}</a>
             <button class="btn btn-small" data-bind="click: function() { $root.showPluginSettings(); }" title="{{ _('Plugin Configuration')|edq }}"><i class="fas fa-wrench"></i></button>
         </div>
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely 
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs 
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR 
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more 
details the better!
-->

#### What does this PR do and why is it necessary?
Implements an 'export' button that downloads the same plugin list file that is exported in backups. Hence it also refactors this into the plugin manager, rather than the backup plugin, as suggested in https://github.com/OctoPrint/OctoPrint/issues/3711#issuecomment-688200604

The new endpoint for this is `/plugin/pluginmanager/export`, and it downloads a `plugins.json` file.

The plugin manager exports this function as a helper, under `generate_plugins_json` so that the backup plugin could use it.

#### How was it tested? How can it be tested by the reviewer?
Test 1: New feature
* Head to the plugin manager, find the button in the top right of the interface
* Click, observe download and show that I can make things that aren't broken!

Test 2: Existing backups
* Since the code was adjusted, I tested this too. Backups from UI and CLI still work as intended.

#### Any background context you want to provide?
#3711 

I think that this can be extended to incorporate #3763 too, to enable a way to *upload* the same file, to install all of those plugins. But that's more complicated, so potentially in another PR. Not investigated yet.

#### What are the relevant tickets if any?
Closes #3711 
#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/31997505/100281657-39536800-2f62-11eb-8670-c0afdb5c878c.png)

#### Further notes
I'm going to propose moving the 'Get more' button to the same area as this new button too, as part of #3801. New PR proposing changes there though.