### PR TITLE
implement CODEOWNERS support

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,3 @@
-# These owners will be the default owners for everything in
-# the repo. Unless a later match takes precedence,
-# @OctoPrint/octoprint-maintainers will be requested for
-# review when someone opens a pull request.
-*       @OctoPrint/octoprint-maintainers
-
 # someone from the docker-maintainers team will be requested for review
 # whenever the trigger_docker workflow is changed in a Pull Request
 .github/workflows/trigger_docker.yml    @OctoPrint/docker-maintainers

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# @OctoPrint/octoprint-maintainers will be requested for
+# review when someone opens a pull request.
+*       @OctoPrint/octoprint-maintainers
+
+# someone from the docker-maintainers team will be requested for review
+# whenever the trigger_docker workflow is changed in a Pull Request
+.github/workflows/trigger_docker.yml    @OctoPrint/docker-maintainers


### PR DESCRIPTION
This PR add support for the [CODEOWNERS]() feature, allowing automatic assignment of reviewers based on the files changed in a pull request.

I was originally going to make the `OctoPrint/octoprint-maintainers` team the default reviewer for auto-assignment, but for now left that alone since we have gitIssueBot doing that work.

For now, the only files this adds auto-reviewers for is the `trigger_docker.yml` workflow. This should make sure that any changes to downstream docker workflows are reviewed by a member of the OctoPrint/docker-maintainers team prior to being implemented.