### PR TITLE
PR: This enables moving the webcam to another [its own] tab, without having to …

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -542,7 +542,7 @@ $(function () {
         };
 
         self.onTabChange = function (current, previous) {
-            if (current == "#control") {
+            if (current == "#control" || current == "#webcam") {
                 self._enableWebcam();
             } else if (previous == "#control") {
                 self._disableWebcam();

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -503,7 +503,10 @@ $(function () {
 
         self._enableWebcam = function () {
             if (
-                OctoPrint.coreui.selectedTab != "#control" ||
+                (
+                 OctoPrint.coreui.selectedTab != "#control" &&
+                 OctoPrint.coreui.selectedTab != "#webcam"
+                ) ||
                 !OctoPrint.coreui.browserTabVisible
             ) {
                 return;

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -503,11 +503,9 @@ $(function () {
 
         self._enableWebcam = function () {
             if (
-                (
-                 OctoPrint.coreui.selectedTab != "#control" &&
-                 OctoPrint.coreui.selectedTab != "#webcam"
-                ) ||
-                !OctoPrint.coreui.browserTabVisible
+                (OctoPrint.coreui.selectedTab != "#control" &&
+                    OctoPrint.coreui.selectedTab != "#webcam") ||
+                 !OctoPrint.coreui.browserTabVisible
             ) {
                 return;
             }


### PR DESCRIPTION
…clone and override `_enableWebcam()`, which although it works, makes it difficult/messy for Webcam Tab plugin to support future versions of Octoprint. Currently, Webcam Tab plugin needs to clone and override three different versions of `_enableWebcam()` to work with Octoprint v1.3, 1.4 and 1.5. Totally open to a better way to do it, if there is one. Thanks.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [Y -- technically doable via plugin but very messy. See notes below.] Your changes are not possible to do through a plugin and relevant to a large audience (ideally all users of OctoPrint)
  * [Y] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [Y] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [Y] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [Y] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [Y?] Your changes follow the existing coding style
  * [NA ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [Y -- manually. Trivial change.] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [NA -- trivial change (famous last words!)] You have run the existing unit tests against your changes and
    nothing broke
  * [N] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

#### How was it tested? How can it be tested by the reviewer?
Manually. It does not change any behaviour. The reviewer should see no apparent difference what-so-ever. 

#### Any background context you want to provide?
The plugin Webcam Tab stopped working when Octoprint migrated from v1.3 to 1.4. The cause is that the only known method to move #webcam_container to another tab is to copy/paste `_enableWebcam` and `onTabChange` methods from `control.js` and then back reference to override and change the code, as affected in this PR. (should be obvious?)  

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
N/A

#### Further notes
The original author of Webcam Tab plugin is no longer reachable. I am forking his project to get it working again with Octoprint v1.4+. (This single plugin prevented me upgrading from v1.3 until now.)

If this change is deemed inappropriate (easy to see why it might) then I am willing to copy/paste all three versions of `_enableWebcam()` from Octoprint 1.3, 1.4 and 1.5 and select the appropriate version in the plugin. Thus, _technically_, the change _could_ be done entirely in the plugin.  However, it's messy and not at all future proof. I realise this is an edge case. Obviously, it's all up to you. Thanks.

Oh and the plugin is already python3 compatible (tested).

 