### PR TITLE
Add canary job for trigger docker workflow

### DIFF
--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -9,9 +9,7 @@ on:
       - maintenance
       - devel
 
-
 jobs:
-
   dispatch_releases:
     runs-on: ubuntu-latest
     if: github.event_name != 'push'
@@ -33,7 +31,7 @@ jobs:
         with:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
-          event-type: 'canary'
+          event-type: "canary"
           client-payload: '{"tag_name": "${{ github.sha }}"}'
 
   dispatch_bleeding:
@@ -45,7 +43,5 @@ jobs:
         with:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
-          event-type: 'bleeding'
+          event-type: "bleeding"
           client-payload: '{"tag_name": "${{ github.sha }}"}'
-
-

--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -6,7 +6,7 @@ on:
       - prereleased
   push:
     branches:
-      - master
+      - maintenance
 
 
 jobs:

--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -14,5 +14,5 @@ jobs:
         with:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
-          event-type: github.event.action
+          event-type: ${{ github.event_name }}
           client-payload: '{"tag_name": "${{ github.event.release.tag_name }}"}'

--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -4,10 +4,16 @@ on:
     types:
       - released
       - prereleased
+  push:
+    branches:
+      - master
+
 
 jobs:
-  trigger:
+
+  dispatch_releases:
     runs-on: ubuntu-latest
+    if: github.event_name != 'push'
     steps:
       - name: 🚀 Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
@@ -16,3 +22,16 @@ jobs:
           repository: ${{ github.repository_owner }}/octoprint-docker
           event-type: ${{ github.event_name }}
           client-payload: '{"tag_name": "${{ github.event.release.tag_name }}"}'
+
+  dispatch_canary:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push'
+    steps:
+      - name: 🚀 Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ github.repository_owner }}/octoprint-docker
+          event-type: 'canary'
+          client-payload: '{"tag_name": "${{ github.sha }}"}'
+

--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -7,6 +7,7 @@ on:
   push:
     branches:
       - maintenance
+      - devel
 
 
 jobs:
@@ -25,7 +26,7 @@ jobs:
 
   dispatch_canary:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/maintenance'
     steps:
       - name: 🚀 Repository Dispatch
         uses: peter-evans/repository-dispatch@v1
@@ -34,4 +35,17 @@ jobs:
           repository: ${{ github.repository_owner }}/octoprint-docker
           event-type: 'canary'
           client-payload: '{"tag_name": "${{ github.sha }}"}'
+
+  dispatch_bleeding:
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' && github.ref == 'refs/heads/devel'
+    steps:
+      - name: 🚀 Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
+          repository: ${{ github.repository_owner }}/octoprint-docker
+          event-type: 'bleeding'
+          client-payload: '{"tag_name": "${{ github.sha }}"}'
+
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

- changes usage of `github.event.action` to `github.event_name` in order to fix a bug with downstream release triggers
- adds a `canary` event-type repository dispatches to `OctoPrint/octoprint-docker` that runs on pushes to `maintenance`.  This enable the ability to add a `canary` tag to the docker builds for use in any testing required by OctoPrint maintainers, developers, and plugin-maintainers
- adds a 'bleeding' event-type repository dispatch to `OctoPrint/octoprint-docker` that runs on pushes to `devel`

#### How was it tested? How can it be tested by the reviewer?

I created a few test payloads in actions in the HackerHappyHour/tagging-strategy workflows, since i'm using tagging-strategy features to make use of these custom event types and turn them into tags docker tags.

View those test payloads at: https://github.com/HackerHappyHour/tagging-strategy/runs/1503771569?check_suite_focus=true

#### What are the relevant tickets if any?

https://github.com/OctoPrint/octoprint-docker/issues/119
https://github.com/OctoPrint/octoprint-docker/issues/117

closes https://github.com/OctoPrint/octoprint-docker/issues/119