### PR TITLE
Virtual: Resend ratio setting should be an integer

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -202,7 +202,7 @@ class VirtualPrinter(object):
 
         self._received_lines = 0
         self._resend_every_n = 0
-        self._calculate_resend_every_n(self._settings.get(["resend_ratio"]))
+        self._calculate_resend_every_n(self._settings.get_int(["resend_ratio"]))
 
         self._dont_answer = False
 


### PR DESCRIPTION
Fixes issue editing settings in the UI via VP settings plugin:
`Unexpected error while connecting to serial port VIRTUAL, baudrate 250000 from hook virtual_printer: TypeError: 'unsupported operand type(s) for //: 'int' and 'str'' @ comm.py:_open_serial:3667`

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes an issue where virtual printer settings are changes to a string by the virtual printer settings plugin.
Doesn't seem to be an easy way for me to send this back to the server as a guaranteed integer (about to try some custom bindings, see what happens...)
#### How was it tested? How can it be tested by the reviewer?
Doesn't impact the existing virtual printer, but if you run my local changes to my plugin you will notice this issue!

#### Any background context you want to provide?
[OctoPrint-VirtualPrinterSettings](https://github.com/cp2004/OctoPrint-VirtualPrinterSettings)

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
🙂 
#### Further notes
PR 3/ at least 4 this weekend 🙂 