### PR TITLE
 Add plugin helpers to backup plugin

### DIFF
--- a/docs/bundledplugins/backup.rst
+++ b/docs/bundledplugins/backup.rst
@@ -177,6 +177,30 @@ octoprint.plugin.backup.additional_excludes
    :return: A list of paths to exclude, relative to your plugin's data folder
    :rtype: list
 
+Helpers
+-------
+
+.. _sec-bundledplugins-backup-helpers:
+
+The Backup plugin exports two helpers that can be used by other plugins or internal methods
+from within OctoPrint, without going via the API.
+
+.. _sec-bundledplugins-backup-helpers-create_backup:
+
+create_backup
++++++++++++++
+
+.. autofunction:: octoprint.plugins.backup.BackupPlugin.create_backup_helper
+
+
+.. _sec-bundledplugins-backup-helpers-delete_backup:
+
+delete_backup
++++++++++++++
+
+.. autofunction:: octoprint.plugins.backup.BackupPlugin.delete_backup_helper
+
+
 .. _sec-bundledplugins-backup-sourcecode:
 
 Source code

--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -413,7 +413,8 @@ class BackupPlugin(
         if exclude is None or not (type(exclude) == list):
             exclude = []
 
-        self._start_backup(exclude, backup_file=None)
+        self._start_backup(exclude, backup_file=backup_file)
+        return backup_file
 
     ##~~ CLI hook
 

--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -400,8 +400,10 @@ class BackupPlugin(
         Args:
              exclude (list): Identifiers of data folders to exclude
         """
-        if exclude is None or not (type(exclude) == list):
+        if exclude is None:
             exclude = []
+        if not isinstance(exclude, list):
+            exclude = list(exclude)
 
         self._start_backup(exclude, filename=filename)
         return filename

--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -396,9 +396,32 @@ class BackupPlugin(
     # Exported plugin helpers
     def create_backup_helper(self, exclude=None, filename=None):
         """
-        Trigger a backup from a plugin or other internal call
-        Args:
-             exclude (list): Identifiers of data folders to exclude
+        .. versionadded:: 1.6.0
+
+        Create a backup from a plugin or other internal call
+
+        This helper is exported as ``create_backup`` and can be used from the plugin
+        manager's ``get_helpers`` method.
+
+        **Example**
+
+        The following code snippet can be used from within a plugin, and will create a backup
+        excluding two folders (``timelapse`` and ``uploads``)
+
+        .. code-block:: python
+
+            helpers = self._plugin_manager.get_helpers("backup", "create_backup")
+
+            if helpers and "create_backup" in helpers:
+                helpers["create_backup"](exclude=["timelapse", "uploads"])
+
+        By using the ``if helpers [...]`` clause, plugins can fall back to other methods
+        when they are running under versions where these helpers did not exist.
+
+
+        :param list exclude: Names of data folders to exclude, defaults to None
+        :param str filename: Name of backup to be created, if None (default) the backup
+            name will be auto-generated. This should use a ``.zip`` extension.
         """
         if exclude is None:
             exclude = []
@@ -406,9 +429,38 @@ class BackupPlugin(
             exclude = list(exclude)
 
         self._start_backup(exclude, filename=filename)
-        return filename
 
     def delete_backup_helper(self, filename):
+        """
+        .. versionadded:: 1.6.0
+
+        Delete the specified backup from a plugin or other internal call
+
+        This helper is exported as ``delete_backup`` and can be used through the plugin
+        manager's ``get_helpers`` method.
+
+        **Example**
+        The following code snippet can be used from within a plugin, and will attempt to
+        delete the backup named ``ExampleBackup.zip``.
+
+        .. code-block:: python
+
+            helpers = self._plugin_manager.get_helpers("backup", "delete_backup")
+
+            if helpers and "delete_backup" in helpers:
+                helpers["delete_backup"]("ExampleBackup.zip")
+
+        By using the ``if helpers [...]`` clause, plugins can fall back to other methods
+        when they are running under versions where these helpers did not exist.
+
+        .. warning::
+
+            This method will fail silently if the backup does not exist, and so
+            it is recommended that you make sure the name comes from a verified source,
+            for example the name from the events or other helpers.
+
+        :param str filename: The name of the backup to delete
+        """
         self._delete_backup(filename)
 
     ##~~ CLI hook


### PR DESCRIPTION
cc @jneilliii 
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Exports helpers from the backup plugin that can be used to create backups. Necessary because the global API key is removed in OctoPrint 2.0.0, and I felt nice so did this one for @jneilliii & [Backup Scheduler](https://plugins.octoprint.org/plugins/backupscheduler/) since it currently uses server side API calls, using the global API key.

#### How was it tested? How can it be tested by the reviewer?

Used this single file plugin:
https://gist.github.com/cp2004/9f4e02dd1e5bb56726637412c04060ac
Creates a backup a minute after startup, then deletes it a minute later.

Also tested UI backup is still functional, and that CLI backup was still functional.

#### Any background context you want to provide?
Backup Scheduler plugin.

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
None

#### Further notes
PR 4 of the day 🙂 