### PR TITLE
Gcode viewer scroll/zoom to model options work on current layer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -130,6 +130,7 @@ date of first contribution):
   * [Sophist](https://github.com/Sophist-UK)
   * [Manuel McLure](https://github.com/ManuelMcLure)
   * ["j7126"](https://github.com/j7126)
+  * [David Rifkind](https://github.com/drifkind)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/renderer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/renderer.js
@@ -103,6 +103,9 @@ GCODE.renderer = (function () {
                 " segments"
         );
 
+        applyOffsets(layerNumStore);
+        applyZoom(layerNumStore);
+
         notifyIfViewportChanged();
 
         var p1 = ctx.transformedPoint(0, 0);
@@ -143,6 +146,51 @@ GCODE.renderer = (function () {
             }
         }
     };
+
+    function getLayerBounds(layer) {
+        if (!model || !model[layer]) return;
+
+        var cmds = model[layer];
+        var i = 0;
+
+        // find bounds based on x/y moves with extrusion only
+        // if you want to change that criterion, this is the place to do it
+
+        while (i < cmds.length) {
+            if (cmds[i].extrude && (cmds[i].x !== undefined || cmds[i].y !== undefined))
+                break;
+            i++;
+        }
+
+        if (i == cmds.length) return;
+
+        // initialize with guaranteed defined values and cut out a bunch of
+        // testing for undefined cases
+        var minX = cmds[i].prevX,
+            maxX = cmds[i].prevX,
+            minY = cmds[i].prevY,
+            maxY = cmds[i].prevY;
+
+        while (i < cmds.length) {
+            if (cmds[i].extrude && (cmds[i].x !== undefined || cmds[i].y !== undefined)) {
+                minX = Math.min(minX, cmds[i].prevX);
+                maxX = Math.max(maxX, cmds[i].prevX);
+                if (cmds[i].x !== undefined) {
+                    minX = Math.min(minX, cmds[i].x);
+                    maxX = Math.max(maxX, cmds[i].x);
+                }
+                minY = Math.min(minY, cmds[i].prevY);
+                maxY = Math.max(maxY, cmds[i].prevY);
+                if (cmds[i].y !== undefined) {
+                    minY = Math.min(minY, cmds[i].y);
+                    maxY = Math.max(maxY, cmds[i].y);
+                }
+            }
+            i++;
+        }
+
+        return {minX: minX, maxX: maxX, minY: minY, maxY: maxY};
+    }
 
     function trackTransforms(ctx) {
         var svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
@@ -270,9 +318,6 @@ GCODE.renderer = (function () {
                     if (renderOptions["onDrag"] && renderOptions["onDrag"](pt) === false)
                         return;
 
-                    ctx.translate(pt.x - dragStart.x, pt.y - dragStart.y);
-                    reRender();
-
                     renderOptions["centerViewport"] = false;
                     renderOptions["zoomInOnModel"] = false;
                     renderOptions["zoomInOnBed"] = false;
@@ -282,6 +327,9 @@ GCODE.renderer = (function () {
                     offsetBedY = 0;
                     scaleX = 1;
                     scaleY = 1;
+
+                    ctx.translate(pt.x - dragStart.x, pt.y - dragStart.y);
+                    reRender();
 
                     if (renderOptions["onInternalOptionChange"] !== undefined) {
                         renderOptions["onInternalOptionChange"]({
@@ -326,9 +374,6 @@ GCODE.renderer = (function () {
             // return to old position
             ctx.translate(-pt.x, -pt.y);
 
-            // render
-            reRender();
-
             // disable conflicting options
             renderOptions["zoomInOnModel"] = false;
             renderOptions["zoomInOnBed"] = false;
@@ -338,6 +383,9 @@ GCODE.renderer = (function () {
             offsetBedY = 0;
             scaleX = 1;
             scaleY = 1;
+
+            // render
+            reRender();
 
             if (renderOptions["onInternalOptionChange"] !== undefined) {
                 renderOptions["onInternalOptionChange"]({
@@ -836,41 +884,41 @@ GCODE.renderer = (function () {
         }
     };
 
-    var applyOffsets = function () {
+    var applyOffsets = function (layerNum) {
         var canvasCenter;
 
         // determine bed and model offsets
         if (ctx) ctx.translate(-offsetModelX, -offsetModelY);
         if (renderOptions["centerViewport"] || renderOptions["zoomInOnModel"]) {
             canvasCenter = ctx.transformedPoint(canvas.width / 2, canvas.height / 2);
-            if (modelInfo) {
-                offsetModelX =
-                    canvasCenter.x -
-                    (modelInfo.boundingBox.minX + modelInfo.boundingBox.maxX) / 2;
-                offsetModelY =
-                    canvasCenter.y -
-                    (modelInfo.boundingBox.minY + modelInfo.boundingBox.maxY) / 2;
+            layerBounds = getLayerBounds(layerNum);
+            if (layerBounds) {
+                offsetModelX = canvasCenter.x - (layerBounds.minX + layerBounds.maxX) / 2;
+                offsetModelY = canvasCenter.y - (layerBounds.minY + layerBounds.maxY) / 2;
             } else {
                 offsetModelX = 0;
                 offsetModelY = 0;
             }
             offsetBedX = 0;
             offsetBedY = 0;
-        } else if (modelInfo && renderOptions["moveModel"]) {
-            offsetModelX =
-                renderOptions["bed"]["x"] / 2 -
-                (modelInfo.boundingBox.minX + modelInfo.boundingBox.maxX) / 2;
-            offsetModelY =
-                renderOptions["bed"]["y"] / 2 -
-                (modelInfo.boundingBox.minY + modelInfo.boundingBox.maxY) / 2;
-            offsetBedX =
-                -1 *
-                (renderOptions["bed"]["x"] / 2 -
-                    (modelInfo.boundingBox.minX + modelInfo.boundingBox.maxX) / 2);
-            offsetBedY =
-                -1 *
-                (renderOptions["bed"]["y"] / 2 -
-                    (modelInfo.boundingBox.minY + modelInfo.boundingBox.maxY) / 2);
+        } else if (renderOptions["moveModel"]) {
+            layerBounds = getLayerBounds(layerNum);
+            if (layerBounds) {
+                offsetModelX =
+                    renderOptions["bed"]["x"] / 2 -
+                    (layerBounds.minX + layerBounds.maxX) / 2;
+                offsetModelY =
+                    renderOptions["bed"]["y"] / 2 -
+                    (layerBounds.minY + layerBounds.maxY) / 2;
+                offsetBedX =
+                    -1 *
+                    (renderOptions["bed"]["x"] / 2 -
+                        (layerBounds.minX + layerBounds.maxX) / 2);
+                offsetBedY =
+                    -1 *
+                    (renderOptions["bed"]["y"] / 2 -
+                        (layerBounds.minY + layerBounds.maxY) / 2);
+            }
         } else if (
             renderOptions["bed"]["circular"] ||
             renderOptions["bed"]["centeredOrigin"]
@@ -889,7 +937,7 @@ GCODE.renderer = (function () {
         if (ctx) ctx.translate(offsetModelX, offsetModelY);
     };
 
-    var applyZoom = function () {
+    var applyZoom = function (layerNum) {
         // get middle of canvas
         var pt = ctx.transformedPoint(canvas.width / 2, canvas.height / 2);
 
@@ -904,28 +952,36 @@ GCODE.renderer = (function () {
             transform = ctx.getTransform();
         }
 
-        if (modelInfo && renderOptions["zoomInOnModel"]) {
-            // if we need to zoom in on model, scale factor is calculated by longer side of object in relation to that axis of canvas
-            var width = modelInfo.boundingBox.maxX - modelInfo.boundingBox.minX;
-            var length = modelInfo.boundingBox.maxY - modelInfo.boundingBox.minY;
+        if (renderOptions["zoomInOnModel"]) {
+            var layerBounds = getLayerBounds(layerNum);
+            if (layerBounds) {
+                // if we need to zoom in on model, scale factor is calculated by longer side of object in relation to that axis of canvas
+                // limited arbitrarily to 50 x extrusion width, to prevent extreme disorienting zoom
+                var width = Math.max(
+                    layerBounds.maxX - layerBounds.minX,
+                    renderOptions["extrusionWidth"] * 50
+                );
+                var length = Math.max(
+                    layerBounds.maxY - layerBounds.minY,
+                    renderOptions["extrusionWidth"] * 50
+                );
 
-            var scaleF =
-                width > length
-                    ? (canvas.width - 10) / width
-                    : (canvas.height - 10) / length;
-            if (transform.a && transform.d) {
-                scaleX =
-                    (scaleF / transform.a) * (renderOptions["invertAxes"]["x"] ? -1 : 1);
-                scaleY =
-                    (scaleF / transform.d) * (renderOptions["invertAxes"]["y"] ? 1 : -1);
-                ctx.translate(pt.x, pt.y);
-                ctx.scale(scaleX, scaleY);
-                ctx.translate(-pt.x, -pt.y);
+                var scaleF =
+                    width > length
+                        ? (canvas.width - 10) / width
+                        : (canvas.height - 10) / length;
+                if (transform.a && transform.d) {
+                    scaleX =
+                        (scaleF / transform.a) *
+                        (renderOptions["invertAxes"]["x"] ? -1 : 1);
+                    scaleY =
+                        (scaleF / transform.d) *
+                        (renderOptions["invertAxes"]["y"] ? 1 : -1);
+                    ctx.translate(pt.x, pt.y);
+                    ctx.scale(scaleX, scaleY);
+                    ctx.translate(-pt.x, -pt.y);
+                }
             }
-        } else {
-            // reset scale to 1
-            scaleX = 1;
-            scaleY = 1;
         }
     };
 
@@ -1067,6 +1123,7 @@ GCODE.renderer = (function () {
             this.doRender([], 0);
         },
         doRender: function (mdl, layerNum) {
+            console.log("doRender", layerNum);
             model = mdl;
             modelInfo = undefined;
 
@@ -1085,8 +1142,8 @@ GCODE.renderer = (function () {
             }
 
             applyInversion();
-            applyOffsets();
-            applyZoom();
+            scaleX = 1;
+            scaleY = 1;
 
             this.render(layerNum, 0, toProgress);
         },


### PR DESCRIPTION
...instead of entire model.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket

Does not apply.

  * [X] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)

Does not apply.

  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

:-D

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This change causes the "center viewport on model" and "zoom in on model" options in the gcode viewer to use the current layer's bounding box rather than the entire model's. It was originally meant to make those options ignore the priming extrusions that the slicer adds at the start of the code. It helps particularly on touchscreen devices, where manual panning and zooming do not work.

See also [issue 3595](https://github.com/OctoPrint/OctoPrint/issues/3595) and maybe others. Does not seem (to me) worth having a separate set of options.

#### How was it tested? How can it be tested by the reviewer?

Nah. What could possibly go wrong?

I mean, tested manually.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
