### PR TITLE
Fix stable releases not triggering docker build

### DIFF
--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
-          event-type: ${{ github.event_name }}
+          event-type: ${{ github.event.action }}
           client-payload: '{"tag_name": "${{ github.event.release.tag_name }}"}'
 
   dispatch_canary:

--- a/.github/workflows/trigger_docker.yml
+++ b/.github/workflows/trigger_docker.yml
@@ -32,7 +32,7 @@ jobs:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
           event-type: "canary"
-          client-payload: '{"tag_name": "${{ github.sha }}"}'
+          client-payload: '{"tag_name": "maintenance"}'
 
   dispatch_bleeding:
     runs-on: ubuntu-latest
@@ -44,4 +44,4 @@ jobs:
           token: ${{ secrets.DOCKER_ACCESS_TOKEN }}
           repository: ${{ github.repository_owner }}/octoprint-docker
           event-type: "bleeding"
-          client-payload: '{"tag_name": "${{ github.sha }}"}'
+          client-payload: '{"tag_name": "devel"}'


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR sends the _type_ of the release action downstream, instead of just the release event_name, which will always resolve to `release`.  The downstream Deploy Images workflow listens for `released` and `prereleased` event types for the `dispatch_releases` job of the Trigger Docker Build Workflow, and it was not matching since only `release` was being sent.

#### How was it tested? How can it be tested by the reviewer?

This time i created a repository exclusively for exploring github.event contexts, to ensure the right value was being sent downstream. You can see the relevant test log here: https://github.com/LongLiveCHIEF/github-actions-testing/runs/1542669636?check_suite_focus=true#step:2:168

#### Any background context you want to provide?

This one gave me enough trouble about docs for workflows that I finally figured out what was missing that was bugging me, so I opened an issue with github/docs [#2040 | Please provide complete reference schema for each subkey of the context accessible in a workflow](https://github.com/github/docs/issues/2040)

#### What are the relevant tickets if any?

Closes https://github.com/OctoPrint/octoprint-docker/issues/139

#### Screenshots (if appropriate)

#### Further notes
