### PR TITLE
Capture testballoon output from pip output instead of tmp file

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -130,6 +130,7 @@ date of first contribution):
   * [Sophist](https://github.com/Sophist-UK)
   * [Manuel McLure](https://github.com/ManuelMcLure)
   * ["j7126"](https://github.com/j7126)
+  * ["MichaIng"](https://github.com/MichaIng)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/piptestballoon/setup.py
+++ b/src/octoprint/util/piptestballoon/setup.py
@@ -9,52 +9,36 @@ whether the install location is writable by the current user), and for that it
 only needs to be invoked by pip, the pip call doesn't have to be successful
 however.
 
-If an environment variable "TESTBALLOON_OUTPUT" is set, it will be used as location
-to write a file with the figured out data to. Simply writing to stdout (the default
-behaviour if no such environment variable is set) is sadly not going to work out
-with versions of pip > 8.0.0, which capture all stdout output regardless of used
---verbose or --log flags.
+Any output (STDOUT and STDERR) produced by this script is captured by pip and,
+until pip v19, printed via its STDOUT, from pip v20 on, via its STDERR. The
+parsing script hence needs to capture both to support all pip versions.
 """
 
-import io
 import os
 import sys
+from distutils.command.install import install as cmd_install
+from distutils.dist import Distribution
 
+cmd = cmd_install(Distribution())
+cmd.finalize_options()
 
-def produce_output(stream):
-    from distutils.command.install import install as cmd_install
-    from distutils.dist import Distribution
+install_dir = cmd.install_lib
+virtual_env = hasattr(sys, "real_prefix") or (
+    hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
+)
+writable = os.access(install_dir, os.W_OK)
 
-    cmd = cmd_install(Distribution())
-    cmd.finalize_options()
+lines = [
+    "PIP_INSTALL_DIR={}".format(install_dir),
+    "PIP_VIRTUAL_ENV={}".format(virtual_env),
+    "PIP_WRITABLE={}".format(writable),
+]
 
-    install_dir = cmd.install_lib
-    virtual_env = hasattr(sys, "real_prefix") or (
-        hasattr(sys, "base_prefix") and sys.base_prefix != sys.prefix
-    )
-    writable = os.access(install_dir, os.W_OK)
+# write to stdout
+for line in lines:
+    print(line, file=sys.stdout)
 
-    lines = [
-        "PIP_INSTALL_DIR={}".format(install_dir),
-        "PIP_VIRTUAL_ENV={}".format(virtual_env),
-        "PIP_WRITABLE={}".format(writable),
-    ]
-
-    for line in lines:
-        print(line, file=stream)
-
-    stream.flush()
-
-
-path = os.environ.get("TESTBALLOON_OUTPUT", None)
-if path is not None:
-    # environment variable set, write to a log
-    path = os.path.abspath(path)
-    with io.open(path, "wt+", encoding="utf-8") as output:
-        produce_output(output)
-else:
-    # write to stdout
-    produce_output(sys.stdout)
+sys.stdout.flush()
 
 # fail intentionally
 sys.exit(-1)


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
`setup.py` STDOUT and STDERR are printed via `pip` STDOUT until v19 and STDERR from v20 on, which can hence be parsed by the originating script directly. This allows to avoid the fragile need for a temporary file that needs to be R/W-opened by two different processes.

#### How was it tested? How can it be tested by the reviewer?
To test, OctoPrint simply needs to be started the regular war, until `octoprint.util.pip - INFO - pip installs to ...` is printed the first time.

#### Any background context you want to provide?
Usually transferring the setup info via temporary file works fine, but the fact that OctoPrint and the pip command it calls are two different processes, possibly executed by two users (e.g. invoking pip via sudo to allow global system OctoPrint instance but unprivileged OctoPrint service user) or different environment (private /tmp mount), it is a bid fragile. I personally ran into the issue that with Debian Bullseye `sysctl fs.protected_regular=2` is the default, which does not permit any user to "O_CREAT"-write to a file inside a world-writable + sticky-bit directory that is not owned by itself. In case of "octoprint" user calling custom pip command, a script which invokes pip via sudo, permitted through strict sudoers permissions, this leads to a failure: "octoprint" pip.py pre-creates the temporary file in /tmp, which by default is 1777 (world-writable + sticky bit), and even root is not able to write it via testballoon setup.py, since the method obviously implies O_CREAT, i.e. would create the file if it did not exist yet. Jep the restriction even applies to root.

I did as well search and tested a while to get the required information directly from `pip`.  `pip debug` prints a line
```
pip._vendor.certifi.where(): /usr/local/lib/python3.7/dist-packages/pip/_vendor/certifi/cacert.pem
```
which can be used to derive the install directory, but it would require quite some guessing to derive whether it's a venv/virtualenv or not 🤔.
__________
Tested with pip versions:
- [x] 20
- [x] 19
- [x] 18
- [x] 10
- [x] 9
- [x] 8

I cannot test a lower pip version (7) as it is not compatible with other Python libraries it seems:
```
Traceback (most recent call last):
  File "/usr/local/bin/pip3", line 7, in <module>
    from pip import main
  File "/usr/local/lib/python3.7/dist-packages/pip/__init__.py", line 13, in <module>
    from pip.utils import get_installed_distributions, get_prog
  File "/usr/local/lib/python3.7/dist-packages/pip/utils/__init__.py", line 23, in <module>
    from pip._vendor import pkg_resources
  File "/usr/local/lib/python3.7/dist-packages/pip/_vendor/pkg_resources/__init__.py", line 1712, in <module>
    register_loader_type(importlib_bootstrap.SourceFileLoader, DefaultProvider)
AttributeError: module 'importlib._bootstrap' has no attribute 'SourceFileLoader'
```

But if I understand the code comments right, with pip below v8 STDOUT is preserved anyway?