### PR TITLE
Add permissions object as keys for get_settings_restricted_paths

### DIFF
--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -1746,10 +1746,10 @@ class SettingsPlugin(OctoPrintPlugin):
 
            def get_settings_restricted_paths(self):
                from octoprint.access.permissions import Permissions
-               return dict(admin=[["some", "admin_only", "path"], ["another", "admin_only", "path"],],
-                           user=[["some", "user_only", "path"],],
-                           never=[["path", "to", "never", "return"],],
-                           Permissions.WEBCAM=[["the", "webcam", "data"],])
+               return {'admin':[["some", "admin_only", "path"], ["another", "admin_only", "path"],],
+                           'user':[["some", "user_only", "path"],],
+                           'never':[["path", "to", "never", "return"],],
+                           Permissions.WEBCAM:[["the", "webcam", "data"],]}
 
            # this will make the plugin return settings on the REST API like this for an anonymous user
            #

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -1580,7 +1580,7 @@ class SettingsPlugin(OctoPrintPlugin):
 
         from flask_login import current_user
 
-        from octoprint.access.permissions import Permissions
+        from octoprint.access.permissions import OctoPrintPermission, Permissions
 
         data = copy.deepcopy(self._settings.get_all_data(merged=True))
         if self.config_version_key in data:
@@ -1632,10 +1632,17 @@ class SettingsPlugin(OctoPrintPlugin):
             "never": lambda: False,
         }
 
-        for level, condition in conditions.items():
-            paths_for_level = restricted_paths.get(level, [])
-            for path in paths_for_level:
-                restrict_path_unless(data, path, condition)
+        for level, paths in restricted_paths.items():
+            if isinstance(level, OctoPrintPermission):
+                for path in paths:
+                    condition = lambda: (
+                        current_user is not None and current_user.has_permission(level)
+                    )
+                    restrict_path_unless(data, path, condition)
+            else:
+                condition = conditions.get(level, lambda: False)
+                for path in paths:
+                    restrict_path_unless(data, path, condition)
 
         return data
 
@@ -1708,12 +1715,22 @@ class SettingsPlugin(OctoPrintPlugin):
         Retrieves the list of paths in the plugin's settings which be restricted on the REST API.
 
         Override this in your plugin's implementation to restrict whether a path should only be returned to users with
-        the SETTINGS permission, any logged in users, or never on the REST API.
+        certain permissions, or never on the REST API.
 
-        Return a ``dict`` with the keys ``admin``, ``user``, ``never`` mapping to a list of paths (as tuples or lists of
-        the path elements) for which to restrict access via the REST API accordingly. Paths returned for the ``admin``
-        key will only be available on the REST API when access with admin rights, ``user`` will only be available when accessed
-        as a logged in user. ``never`` will never be returned on the API.
+        Return a ``dict`` with one of the following keys, mapping to a list of paths (as tuples or lists of
+        the path elements) for which to restrict access via the REST API accordingly.
+
+        .. list-table::
+           :widths: 5 95
+
+           * - An octoprint permission object
+             - Paths will only be available on the REST API for users with the permission
+           * - admin
+             - Paths will only be available on the REST API for users with admin rights (any user with the SETTINGS permission)
+           * - user
+             - Paths will only be available on the REST API when accessed as a logged in user
+           * - never
+             - Paths will never be returned on the API
 
         Example:
 
@@ -1724,12 +1741,15 @@ class SettingsPlugin(OctoPrintPlugin):
                                      user_only=dict(path="path", bar="bar")),
                            another=dict(admin_only=dict(path="path"),
                                         field="field"),
-                           path=dict(to=dict(never=dict(return="return"))))
+                           path=dict(to=dict(never=dict(return="return"))),
+                           the=dict(webcam=dict(data="webcam")))
 
            def get_settings_restricted_paths(self):
+               from octoprint.access.permissions import Permissions
                return dict(admin=[["some", "admin_only", "path"], ["another", "admin_only", "path"],],
                            user=[["some", "user_only", "path"],],
-                           never=[["path", "to", "never", "return"],])
+                           never=[["path", "to", "never", "return"],],
+                           Permissions.WEBCAM=[["the", "webcam", "data"],])
 
            # this will make the plugin return settings on the REST API like this for an anonymous user
            #
@@ -1737,23 +1757,35 @@ class SettingsPlugin(OctoPrintPlugin):
            #                    user_only=dict(path=None, bar="bar")),
            #          another=dict(admin_only=dict(path=None),
            #                       field="field"),
-           #          path=dict(to=dict(never=dict(return=None))))
+           #          path=dict(to=dict(never=dict(return=None))),
+           #          the=dict(webcam=dict(data=None)))
            #
-           # like this for a logged in user
+           # like this for a logged in user without the webcam permission
            #
            #     dict(some=dict(admin_only=dict(path=None, foo="foo"),
            #                    user_only=dict(path="path", bar="bar")),
            #          another=dict(admin_only=dict(path=None),
            #                       field="field"),
-           #          path=dict(to=dict(never=dict(return=None))))
+           #          path=dict(to=dict(never=dict(return=None))),
+           #          the=dict(webcam=dict(data=None)))
            #
-           # and like this for an admin user
+           # like this for a logged in user with the webcam permission
+           #
+           #     dict(some=dict(admin_only=dict(path=None, foo="foo"),
+           #                    user_only=dict(path="path", bar="bar")),
+           #          another=dict(admin_only=dict(path=None),
+           #                       field="field"),
+           #          path=dict(to=dict(never=dict(return=None))),
+           #          the=dict(webcam=dict(data="webcam")))
+           #
+           # and like this for an admin user with the webcam permission
            #
            #     dict(some=dict(admin_only=dict(path="path", foo="foo"),
            #                    user_only=dict(path="path", bar="bar")),
            #          another=dict(admin_only=dict(path="path"),
            #                       field="field"),
-           #          path=dict(to=dict(never=dict(return=None))))
+           #          path=dict(to=dict(never=dict(return=None))),
+           #          the=dict(webcam=dict(data="webcam")))
 
         ..versionadded:: 1.2.17
         """


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] **(N/A)** If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] **(N/A)** If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
get_settings_restricted_paths currently only accepts keys of admin, user and never. This allows permission objects to be used as key, allowing plugin developers to restrict settings paths based on any permission, not just admin or user. 

#### How was it tested? How can it be tested by the reviewer?
I tested it by installing a plugin with the following:
```python
def get_settings_restricted_paths(self):
    return {
        Permissions.WEBCAM:[["testPath",]]
    }
```
and checking that the settings path `testPath` for the plugin is only returned for users with the webcam permission