### PR TITLE
Handle http errors when downloading plugin files.

### DIFF
--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -47,6 +47,8 @@ from octoprint.util.version import (
     is_python_compatible,
 )
 
+from . import exceptions
+
 try:
     from os import scandir
 except ImportError:
@@ -633,21 +635,32 @@ class PluginManagerPlugin(
                     )
 
                 else:
-                    self._logger.error(
-                        "{} is neither an archive nor a python file, can't install that.".format(
-                            source
-                        )
+                    raise exceptions.InvalidPackageFormat()
+            except requests.exceptions.HTTPError as e:
+                self._logger.error("Could not fetch plugin from server, got {}".format(e))
+                result = {
+                    "result": False,
+                    "source": source,
+                    "source_type": source_type,
+                    "reason": "Could not fetch plugin from server, got {}".format(e),
+                }
+                self._send_result_notification("install", result)
+                return result
+            except exceptions.InvalidPackageFormat:
+                self._logger.error(
+                    "{} is neither an archive nor a python file, can't install that.".format(
+                        source
                     )
-                    result = {
-                        "result": False,
-                        "source": source,
-                        "source_type": source_type,
-                        "reason": "Could not install plugin from {}, was neither "
-                        "a plugin archive nor a single file plugin".format(source),
-                    }
-                    self._send_result_notification("install", result)
-                    return result
-
+                )
+                result = {
+                    "result": False,
+                    "source": source,
+                    "source_type": source_type,
+                    "reason": "Could not install plugin from {}, was neither "
+                    "a plugin archive nor a single file plugin".format(source),
+                }
+                self._send_result_notification("install", result)
+                return result
             finally:
                 if folder is not None:
                     folder.cleanup()

--- a/src/octoprint/plugins/pluginmanager/exceptions.py
+++ b/src/octoprint/plugins/pluginmanager/exceptions.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-__author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
-__copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
+__copyright__ = "Copyright (C) 2020 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 
 class InvalidPackageFormat(Exception):

--- a/src/octoprint/plugins/pluginmanager/exceptions.py
+++ b/src/octoprint/plugins/pluginmanager/exceptions.py
@@ -1,0 +1,10 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+__author__ = "Gina Häußge <osd@foosel.net>"
+__license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
+__copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
+
+
+class InvalidPackageFormat(Exception):
+    pass


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Gracefully handles exception when plugin install via URL fails due to not being able to download.

#### How was it tested? How can it be tested by the reviewer?
1. Use URL which fails to download
2. Use valid URL with invalid file format. 

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#3886

#### Screenshots (if appropriate)

#### Further notes
