### PR TITLE
change docs setting userFile to userfile

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -30,7 +30,7 @@ Use the following settings to enable access control:
      userManager: octoprint.access.users.FilebasedUserManager
 
      # The YAML user file to use. If left out defaults to users.yaml in the default configuration folder.
-     userFile: /path/to/users.yaml
+     userfile: /path/to/users.yaml
 
      # If set to true, will automatically log on clients originating from any of the networks defined in
      # "localNetworks" as the user defined in "autologinAs". Defaults to false.


### PR DESCRIPTION
changes `userFile` to `userfile` in the docs, since this setting is treated as a single word in the source code.

See https://github.com/OctoPrint/OctoPrint/blob/f67c15a9a47794a68be9aed4f2d5a12a87e70179/src/octoprint/settings.py#L388  

See https://github.com/OctoPrint/OctoPrint/blob/b94424411a72b183e3be1cc99fa00ac26f98a56c/src/octoprint/access/users.py#L508

Currently, setting `userFile` in the docs fails silently/just leaves the setting set to `None`.