### PR TITLE
Send events for gcode scripts

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -133,6 +133,7 @@ date of first contribution):
   * ["coliss86"](https://github.com/coliss86)
   * ["MichaIng"](https://github.com/MichaIng)
   * ["jasonbcox"](https://github.com/jasonbcox)
+  * ["shadycuz"](https://github.com/shadycuz)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -539,7 +539,7 @@ PrintResumed
 
    .. versionchanged:: 1.4.0
 
-${ScriptName}Running
+GcodeScript${ScriptName}Running
    A custom :ref:`GCODE script <sec-features-gcode_scripts>` has started running.
 
    Payload:
@@ -551,9 +551,9 @@ ${ScriptName}Running
      * ``owner``: the user who started the print job (if available)
      * ``time``: the time needed for the print, in seconds (float)
 
-   .. versionadded:: X.X.X
+   .. versionadded:: 1.6.0
 
-${ScriptName}Finished
+GcodeScript${ScriptName}Finished
    A custom :ref:`GCODE script <sec-features-gcode_scripts>` has finished running.
 
    Payload:
@@ -565,7 +565,7 @@ ${ScriptName}Finished
      * ``owner``: the user who started the print job (if available)
      * ``time``: the time needed for the print, in seconds (float)
 
-   .. versionadded:: X.X.X
+   .. versionadded:: 1.6.0
 
 .. _sec-events-available_events-gcode_processing:
 

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -539,6 +539,34 @@ PrintResumed
 
    .. versionchanged:: 1.4.0
 
+${ScriptName}Running
+   A custom :ref:`GCODE script <sec-features-gcode_scripts>` has started running.
+
+   Payload:
+
+     * ``name``: the file's name
+     * ``path``: the file's path within its storage location
+     * ``origin``: the origin storage location of the file, either ``local`` or ``sdcard``
+     * ``size``: the file's size in bytes (if available)
+     * ``owner``: the user who started the print job (if available)
+     * ``time``: the time needed for the print, in seconds (float)
+
+   .. versionadded:: X.X.X
+
+${ScriptName}Finished
+   A custom :ref:`GCODE script <sec-features-gcode_scripts>` has finished running.
+
+   Payload:
+
+     * ``name``: the file's name
+     * ``path``: the file's path within its storage location
+     * ``origin``: the origin storage location of the file, either ``local`` or ``sdcard``
+     * ``size``: the file's size in bytes (if available)
+     * ``owner``: the user who started the print job (if available)
+     * ``time``: the time needed for the print, in seconds (float)
+
+   .. versionadded:: X.X.X
+
 .. _sec-events-available_events-gcode_processing:
 
 GCODE processing

--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -43,6 +43,15 @@ The following GCODE scripts are sent by OctoPrint automatically:
 
    Plugins may extend these scripts through :ref:`a hook <sec-plugins-hook-comm-protocol-scripts>`.
 
+.. _sec-features-gcode_scripts-events:
+
+Events
+------
+
+Every GCODE script that is executed will emit two events. The events will start with the capitalized name of the script.
+When ``afterPrintDone`` has started the event will be ``AfterPrintDoneRunning`` and once it has completed the last event
+will be ``AfterPrintDoneFinished``. You can find more details in the :ref:`Events <sec-events-available_events-printing>` documentation.
+
 .. _sec-features-gcode_scripts-snippets:
 
 Snippets

--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -48,9 +48,9 @@ The following GCODE scripts are sent by OctoPrint automatically:
 Events
 ------
 
-Every GCODE script that is executed will emit two events. The events will start with the capitalized name of the script.
-When ``afterPrintDone`` has started the event will be ``AfterPrintDoneRunning`` and once it has completed the last event
-will be ``AfterPrintDoneFinished``. You can find more details in the :ref:`Events <sec-events-available_events-printing>` documentation.
+Every GCODE script that is executed will emit two events. The event name will start with 'GcodeScript' followed by the capitalized name
+of the script. When ``afterPrintDone`` has started the event will be ``GcodeScriptAfterPrintDoneRunning`` and once it has completed the last event
+will be ``GcodeScriptAfterPrintDoneFinished``. You can find more details in the :ref:`Events <sec-events-available_events-printing>` documentation.
 
 .. _sec-features-gcode_scripts-snippets:
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -444,6 +444,12 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         if name is None or not name:
             raise ValueError("name must be set")
 
+        event_name = name[0].upper() + name[1:]
+        event_start = "{}{}".format(event_name, "GcodeRunning")
+        payload = context.get("event", None) if isinstance(context, dict) else None
+
+        eventManager().fire(event_start, payload)
+
         result = self._comm.sendGcodeScript(
             name,
             part_of_job=part_of_job,
@@ -452,6 +458,9 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         )
         if not result and must_be_set:
             raise UnknownScript(name)
+
+        event_end = "{}{}".format(event_name, "GcodeFinished")
+        eventManager().fire(event_end, payload)
 
     def jog(self, axes, relative=True, speed=None, *args, **kwargs):
         if isinstance(axes, basestring):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -444,8 +444,11 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         if name is None or not name:
             raise ValueError("name must be set")
 
+        # .capitalize() will lowercase all letters but the first
+        # this code preserves existing CamelCase
         event_name = name[0].upper() + name[1:]
-        event_start = "{}{}".format(event_name, "GcodeRunning")
+
+        event_start = "GcodeScript{}Running".format(event_name)
         payload = context.get("event", None) if isinstance(context, dict) else None
 
         eventManager().fire(event_start, payload)
@@ -459,7 +462,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         if not result and must_be_set:
             raise UnknownScript(name)
 
-        event_end = "{}{}".format(event_name, "GcodeFinished")
+        event_end = "GcodeScript{}Finished".format(event_name)
         eventManager().fire(event_end, payload)
 
     def jog(self, axes, relative=True, speed=None, *args, **kwargs):

--- a/tests/printer/test_script.py
+++ b/tests/printer/test_script.py
@@ -1,6 +1,5 @@
-__author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
-__copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
+__copyright__ = "Copyright (C) 2021 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 import unittest
 from unittest.mock import ANY, MagicMock, call, patch

--- a/tests/printer/test_script.py
+++ b/tests/printer/test_script.py
@@ -1,0 +1,77 @@
+__author__ = "Gina Häußge <osd@foosel.net>"
+__license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
+__copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
+
+import unittest
+from unittest.mock import ANY, MagicMock, call, patch
+
+from octoprint.printer.standard import Printer
+
+
+class ScriptsTestCase(unittest.TestCase):
+    def setUp(self):
+        # mock comm
+        self.comm = MagicMock()
+
+        # mock event manager
+        self.event_manager = MagicMock()
+
+        self.event_manager_patcher = patch("octoprint.printer.standard.eventManager")
+        self.event_manager_getter = self.event_manager_patcher.start()
+        self.event_manager_getter.return_value = self.event_manager
+
+        # mock plugin manager
+        self.plugin_manager = MagicMock()
+        self.plugin_manager.get_hooks.return_value = {}
+
+        self.plugin_manager_patcher = patch("octoprint.printer.standard.plugin_manager")
+        self.plugin_manager_getter = self.plugin_manager_patcher.start()
+        self.plugin_manager_getter.return_value = self.plugin_manager
+
+        # mock settings
+        self.settings = MagicMock()
+        self.settings.getInt.return_value = 1
+        self.settings.getBoolean.return_value = False
+
+        self.settings_patcher = patch("octoprint.printer.standard.settings")
+        self.settings_getter = self.settings_patcher.start()
+        self.settings_getter.return_value = self.settings
+
+        self.printer = Printer(MagicMock(), MagicMock(), MagicMock())
+        self.printer._comm = self.comm
+
+    def tearDown(self):
+        self.settings_patcher.stop()
+        self.plugin_manager_patcher.stop()
+        self.event_manager_patcher.stop()
+
+    def test_event_name(self):
+        self.printer.script("testEvent")
+
+        self.event_manager.fire.assert_any_call("GcodeScriptTestEventRunning", ANY)
+
+    def test_event_order(self):
+        self.printer.script("EventOrder")
+
+        expected_order = [
+            call("GcodeScriptEventOrderRunning", ANY),
+            call("GcodeScriptEventOrderFinished", ANY),
+        ]
+
+        self.event_manager.fire.assert_has_calls(expected_order)
+
+    def test_payload_handling(self):
+        expected_paylod = {"payloadKey": "payloadValue"}
+        context = {"event": expected_paylod}
+
+        self.printer.script("GetPayload", context)
+
+        self.event_manager.fire.assert_called_with(ANY, expected_paylod)
+
+        self.printer.script("WrongPayload", [])
+
+        self.event_manager.fire.assert_called_with(ANY, None)
+
+        self.printer.script("WrongContext", {"noEvent": {}})
+
+        self.event_manager.fire.assert_called_with(ANY, None)


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR creates an event for each of the predefined GCODE scripts and any custom scripts the user might add. The main purpose of this PR was to allow people to do something when a print was complete. The problem is that currently, the last event to fire is `PrintDone` even if some "printing" was left in the `afterPrintDone` gcode. When implementing this fix/feature I thought it made sense to handle all predefined gcode and custom gcode. 

#### How was it tested? How can it be tested by the reviewer?
I tested this by sending a print to the virtual printer while running octoprint in debug and looking for events for the predefined gcode execution. I did not test putting gcode in `~/.octoprint/scripts/`. I also built the docs and made sure they looked good.

```
2020-12-24 05:49:38,180 - octoprint.events.fire - DEBUG - Firing event: BeforePrintStartedGcodeRunning (Payload: {'name': 'test.gcode', 'path': 'test.gcode', 'origin': 'local', 'size': 56, 'owner': 'shadycuz', 'user': 'shadycuz'})
...
2020-12-24 05:49:38,195 - octoprint.events.fire - DEBUG - Firing event: BeforePrintStartedGcodeFinished (Payload: {'name': 'test.gcode', 'path': 'test.gcode', 'origin': 'local', 'size': 56, 'owner': 'shadycuz', 'user': 'shadycuz'})
...
2020-12-24 05:49:38,202 - octoprint.events.fire - DEBUG - Firing event: PrinterStateChanged (Payload: {'state_id': 'PRINTING', 'state_string': 'Printing'})
...
2020-12-24 05:49:38,210 - octoprint.events.fire - DEBUG - Firing event: PrinterStateChanged (Payload: {'state_id': 'FINISHING', 'state_string': 'Finishing'})
...
2020-12-24 05:49:38,220 - octoprint.events.fire - DEBUG - Firing event: PrintDone (Payload: {'name': 'test.gcode', 'path': 'test.gcode', 'origin': 'local', 'size': 56, 'owner': 'shadycuz', 'time': 0.03355369999917457})
...
2020-12-24 05:49:38,227 - octoprint.events.fire - DEBUG - Firing event: AfterPrintDoneGcodeRunning (Payload: {'name': 'test.gcode', 'path': 'test.gcode', 'origin': 'local', 'size': 56, 'owner': 'shadycuz', 'time': 0.03355369999917457})
...
2020-12-24 05:49:38,234 - octoprint.events.fire - DEBUG - Firing event: AfterPrintDoneGcodeFinished (Payload: {'name': 'test.gcode', 'path': 'test.gcode', 'origin': 'local', 'size': 56, 'owner': 'shadycuz', 'time': 0.03355369999917457})
```

#### Any background context you want to provide?

My specific use case is that users of [Octoprint-Twilio](https://github.com/taxilian/OctoPrint-Twilio) want to send themselves a picture after the print is complete. On some printers or specific print jobs, the gantry might be in between the finished print and the camera. With this PR merged users could add `afterPrintDone` GCODE to move the printer around in order to compose a nice shot for the camera. 

#### What are the relevant tickets if any?

Closes #3871 

#### Screenshots (if appropriate)

located further down as a separate comment