### PR TITLE
Fix plugin install errors not being reported to the frontend

### DIFF
--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -687,11 +687,19 @@ class PluginManagerPlugin(
             and not self._settings.get_boolean(["ignore_throttled"])
         ):
             # currently throttled, we refuse to run
-            return make_response(
-                "System is currently throttled, refusing to install "
-                "anything due to possible stability issues",
-                409,
+            error_msg = (
+                "System is currently throttled, refusing to install anything"
+                " due to possible stability isssues"
             )
+            self._logger.error(error_msg)
+            result = {
+                "result": False,
+                "source": source,
+                "source_type": source_type,
+                "reason": error_msg,
+            }
+            self._send_result_notification("install", result)
+            return result
 
         try:
             # Py3
@@ -761,11 +769,20 @@ class PluginManagerPlugin(
                     "Looks like the plugin was already installed. Forcing a reinstall."
                 )
                 force = True
-        except Exception:
-            self._logger.exception("Could not install plugin from %s" % source)
-            return make_response(
-                "Could not install plugin from URL, see the log for more details", 500
-            )
+        except Exception as e:
+            self._logger.exception("Could not install plugin from {}".format(source))
+            self._logger.exception("Reason: {}".format(repr(e)))
+            result = {
+                "result": False,
+                "source": source,
+                "source_type": source_type,
+                "reason": "Could not install plugin from {}, see the log for more details".format(
+                    source
+                ),
+            }
+            self._send_result_notification("install", result)
+            return result
+
         else:
             if force:
                 # We don't use --upgrade here because that will also happily update all our dependencies - we'd rather
@@ -773,16 +790,21 @@ class PluginManagerPlugin(
                 pip_args += ["--ignore-installed", "--force-reinstall", "--no-deps"]
                 try:
                     returncode, stdout, stderr = self._call_pip(pip_args)
-                except Exception:
+                except Exception as e:
                     self._logger.exception(
                         "Could not install plugin from {}".format(source)
                     )
-                    return make_response(
-                        "Could not install plugin from source {}, see the log for more details".format(
+                    self._logger.exception("Reason: {}".format(repr(e)))
+                    result = {
+                        "result": False,
+                        "source": source,
+                        "source_type": source_type,
+                        "reason": "Could not install plugin from source {}, see the log for more details".format(
                             source
                         ),
-                        500,
-                    )
+                    }
+                    self._send_result_notification("install", result)
+                    return result
 
         try:
             result_line = list(


### PR DESCRIPTION
When plugin install went async (4cf2a673c8860304472904cf11d13e2187bc17fd) not all of the responses were caught. This PR changes the rest of the responses to become asynchronous as well.

Closes #3849

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes asynchronous reporting of plugin management errors to the frontend

#### How was it tested? How can it be tested by the reviewer?
Manually simulating the error handling functions

#### Any background context you want to provide?
#3849 

#### What are the relevant tickets if any?
Closes #3849 

#### Screenshots (if appropriate)
![tenor](https://user-images.githubusercontent.com/31997505/103177400-2fc76380-4872-11eb-9522-a4eab87724fe.gif)


#### Further notes
