### PR TITLE
Fix firmware info splitting

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -182,7 +182,7 @@ Groups will be as follows:
   * ``value``: reported position value
 """
 
-regex_firmware_splitter = re.compile(r"\s*([A-Z0-9_]+):\s*")
+regex_firmware_splitter = re.compile(r"\s*([A-Z_]+):\s*")
 """Regex to use for splitting M115 responses."""
 
 regex_resend_linenumber = re.compile(r"(N|N:)?(?P<n>%s)" % regex_int_pattern)

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -182,7 +182,7 @@ Groups will be as follows:
   * ``value``: reported position value
 """
 
-regex_firmware_splitter = re.compile(r"\s*([A-Z_]+):\s*")
+regex_firmware_splitter = re.compile(r"\s*([A-Z][A-Z0-9_]*):\s*")
 """Regex to use for splitting M115 responses."""
 
 regex_resend_linenumber = re.compile(r"(N|N:)?(?P<n>%s)" % regex_int_pattern)

--- a/tests/util/test_comm_helpers.py
+++ b/tests/util/test_comm_helpers.py
@@ -386,15 +386,13 @@ class TestCommHelpers(unittest.TestCase):
                 "MACHINE_TYPE": "Ender 5 Pro",
                 "EXTRUDER_COUNT": "1",
                 "UUID": "cede2a2f-41a2-4748-9b12-c55c62f367ff",
-            }
+            },
         ),
         # Test that keys beginning with _ or number are ignored
         (
             "KEY1:VALUE1 _KEY2:INVALID 123:INVALID",
-            {
-                "KEY1": "VALUE1 _", "KEY2": "INVALID 123:INVALID"
-            }
-        )
+            {"KEY1": "VALUE1 _", "KEY2": "INVALID 123:INVALID"},
+        ),
     )
     @unpack
     def test_parse_firmware_line(self, line, expected):

--- a/tests/util/test_comm_helpers.py
+++ b/tests/util/test_comm_helpers.py
@@ -376,6 +376,25 @@ class TestCommHelpers(unittest.TestCase):
                 "UUID": "00000000-0000-0000-0000-000000000000",
             },
         ),
+        # Test firmware name with time created
+        (
+            "FIRMWARE_NAME:Marlin 2.0.7.2 (Nov 27 2020 14:30:11) SOURCE_CODE_URL:https://github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0 MACHINE_TYPE:Ender 5 Pro EXTRUDER_COUNT:1 UUID:cede2a2f-41a2-4748-9b12-c55c62f367ff",
+            {
+                "FIRMWARE_NAME": "Marlin 2.0.7.2 (Nov 27 2020 14:30:11)",
+                "SOURCE_CODE_URL": "https://github.com/MarlinFirmware/Marlin",
+                "PROTOCOL_VERSION": "1.0",
+                "MACHINE_TYPE": "Ender 5 Pro",
+                "EXTRUDER_COUNT": "1",
+                "UUID": "cede2a2f-41a2-4748-9b12-c55c62f367ff",
+            }
+        ),
+        # Test that keys beginning with _ or number are ignored
+        (
+            "KEY1:VALUE1 _KEY2:INVALID 123:INVALID",
+            {
+                "KEY1": "VALUE1 _", "KEY2": "INVALID 123:INVALID"
+            }
+        )
     )
     @unpack
     def test_parse_firmware_line(self, line, expected):


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke *err*
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR adjusts the regex used to split the comm layer's firmware info parsing

#### How was it tested? How can it be tested by the reviewer?
Not yet, that's why this is a draft 🙂 The current unit tests fail because they test keys with numbers in.  The regex may need to be adjusted further, for now this is draft. Tests are currently failing

#### Any background context you want to provide?
https://github.com/cp2004/OctoPrint-EEPROM-Marlin/issues/21
https://github.com/cp2004/OctoPrint-EEPROM-Marlin/issues/16#issuecomment-744716312
https://discord.com/channels/704958479194128507/705047010641838211/788136463732047932

#### What are the relevant tickets if any?
See above

#### Screenshots (if appropriate)
![](https://user-images.githubusercontent.com/4532366/102136824-ed406880-3e27-11eb-88f0-0ea6e87acc57.png)
![](https://cdn.discordapp.com/attachments/705047010641838211/788136462066515968/unknown.png)
#### Further notes


~~This PR is currently draft while I have a think (or anyone else, open to suggestions!) of a better way to work with the numbers.~~ Just here as a placeholder since I told people reporting the issue it will be fixed in OctoPrint 1.6.0 😬 