### PR TITLE
Ensure connectivity check wizard comes before usage tracking

### DIFF
--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -365,7 +365,11 @@ default_settings = {
                     "plugin_pi_support",
                 ],
                 "usersettings": ["access", "interface"],
-                "wizard": ["plugin_backup", "plugin_corewizard_acl"],
+                "wizard": [
+                    "plugin_backup",
+                    "plugin_corewizard_acl",
+                    "plugin_corewizard_onlinecheck",
+                ],
                 "about": [
                     "about",
                     "plugin_pi_support",


### PR DESCRIPTION
If the server was not connected to the internet, then the AUT wizard would hang as it failed to reach https://tracking.octoprint.org.

Closes #3895

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely new feature, or maintenance if it's a bug fix or improvement of existing functionality for the current stable version (no PRs against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or devel please), e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the .less source files, not the .css files (those are generated with lessc)
  * [x] You have tested your changes (please state how!) - ideally you have added unit tests
  * [x] You have run the existing unit tests against your changes and nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Ensures that the connectivity check wizard shows before the anonymous usage tracking, so that if the server is offline AUT won't try and connect.

#### How was it tested? How can it be tested by the reviewer?
Set the `--basedir` flag to a new folder, observe the change in order

#### Any background context you want to provide?
#3895 and https://github.com/guysoft/OctoPi/issues/692#issuecomment-748156276

#### What are the relevant tickets if any?
#3895 

#### Screenshots (if appropriate)


![image](https://user-images.githubusercontent.com/31997505/103413625-51766280-4b72-11eb-904f-4611f6d5c9e8.png)


#### Further notes
