### PR TITLE
Fix button state in usage tracking wizard

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -130,6 +130,7 @@ date of first contribution):
   * [Sophist](https://github.com/Sophist-UK)
   * [Manuel McLure](https://github.com/ManuelMcLure)
   * ["j7126"](https://github.com/j7126)
+  * ["jasonbcox"](https://github.com/jasonbcox)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/tracking/templates/tracking_wizard.jinja2
+++ b/src/octoprint/plugins/tracking/templates/tracking_wizard.jinja2
@@ -9,8 +9,14 @@
 </p>
 
 <div class="row-fluid">
-    <a href="javascript:void(0)" class="btn span6" data-bind="click: function() { if(!setup()){disableUsage()}}, enable: !setup(), css: {disabled: setup()}"><i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === false"></i> {{ _('Disable Anonymous Usage Tracking') }}</a>
-    <a href="javascript:void(0)" class="btn btn-primary span6" data-bind="click: function() { if(!setup()){enableUsage()}}, enable: !setup(), css: {disabled: setup()}"><i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === true"></i> {{ _('Enable Anonymous Usage Tracking') }}</a>
+    <a href="javascript:void(0)" class="btn span6" data-bind="click: function() { if(!setup() || decision()){disableUsage()}}, enable: !setup() || decision(), css: {disabled: setup() && !decision()}">
+        <i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === false"></i>
+        {{ _('Disable Anonymous Usage Tracking') }}
+    </a>
+    <a href="javascript:void(0)" class="btn btn-primary span6" data-bind="click: function() { if(!setup() || !decision()){enableUsage()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision}">
+        <i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === true"></i>
+        {{ _('Enable Anonymous Usage Tracking') }}
+    </a>
 </div>
 
 <div class="tracking_decision" style="display: none" data-bind="visible: setup()">


### PR DESCRIPTION
* Fix button state so that the tracking can be enabled/disabled after
selecting one of the options for the first time.
* Improve formatting in tracking wizard template to improve code
readability.
* Add myself to AUTHORS file.

### Test plan
```
rm -rf ~/.octoprint
octoprint serve
```
Navigate to http://0.0.0.0:5000/ and follow prompts until Anonymous Usage Tracking.
With this patch applied, you should be able to change your decision.