### PR TITLE
Couple of small icon fixes

### DIFF
--- a/src/octoprint/plugins/action_command_prompt/templates/action_command_prompt_navbar.jinja2
+++ b/src/octoprint/plugins/action_command_prompt/templates/action_command_prompt_navbar.jinja2
@@ -1,3 +1,3 @@
 <a id="navbar_show_prompt" class="pull-right" style="display: none" href="javascript:void(0)" data-bind="click: function() { showPrompt(); }, visible: active() && !visible()" title="{{ _('Message from your printer')|edq }}">
-    <i class="far fa-commenting-dots"></i>
+    <i class="far fa-comment-dots"></i>
 </a>

--- a/src/octoprint/plugins/announcements/static/js/announcements.js
+++ b/src/octoprint/plugins/announcements/static/js/announcements.js
@@ -31,7 +31,7 @@ $(function () {
             5
         );
 
-        self.unread = ko.observable();
+        self.unread = ko.observable(false);
         self.hiddenChannels = [];
         self.channelNotifications = {};
 


### PR DESCRIPTION
### The problem (1)

The announcements plugin doesn't have a style set initially, so it pops in later than everything else, once the feed is rendered.

### The solution to problem 1

Give it a default state, no more popping in late

### The problem (2)

Broken icon from FA5 upgrade, spotted by @LazeMSS

### The solution to problem 2

Fix icon 🙂 