### PR TITLE
Fix typo in tracking wizard

### DIFF
--- a/src/octoprint/plugins/tracking/templates/tracking_wizard.jinja2
+++ b/src/octoprint/plugins/tracking/templates/tracking_wizard.jinja2
@@ -13,7 +13,7 @@
         <i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === false"></i>
         {{ _('Disable Anonymous Usage Tracking') }}
     </a>
-    <a href="javascript:void(0)" class="btn btn-primary span6" data-bind="click: function() { if(!setup() || !decision()){enableUsage()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision}">
+    <a href="javascript:void(0)" class="btn btn-primary span6" data-bind="click: function() { if(!setup() || !decision()){enableUsage()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision()}">
         <i class="fas fa-spinner fa-spin" style="display: none" data-bind="visible: active() && decision() === true"></i>
         {{ _('Enable Anonymous Usage Tracking') }}
     </a>


### PR DESCRIPTION
A typo was introduced in #3924 such that `decision` is not explicitly called as a function. This does not appear to impact its functionality on my machine, but it's best to fix this in order to match surrounding style and prevent any potential bugs in the future.

### Test plan
```
rm -rf ~/.octoprint
octoprint serve
```
Navigate to http://0.0.0.0:5000/ and follow prompts until Anonymous Usage Tracking. Enabling/disabling should work as expected.