### PR TITLE
Fix button state in plugin blacklist subwizard

### DIFF
--- a/src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2
+++ b/src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2
@@ -17,8 +17,12 @@
 {% endtrans %}</p>
 
 <div class="row-fluid">
-    <a href="#" class="btn btn-danger span6" data-bind="click: function() { if(!setup()){disablePluginBlacklist()}}, enable: !setup(), css: {disabled: setup()}">{{ _('Disable Plugin Blacklist Processing') }}</a>
-    <a href="#" class="btn btn-primary span6" data-bind="click: function() { if(!setup()){enablePluginBlacklist()}}, enable: !setup(), css: {disabled: setup()}">{{ _('Enable Plugin Blacklist Processing') }}</a>
+    <a href="#" class="btn btn-danger span6" data-bind="click: function() { if(!setup() || decision()){disablePluginBlacklist()}}, enable: !setup() || decision(), css: {disabled: setup() && !decision()}">
+        {{ _('Disable Plugin Blacklist Processing') }}
+    </a>
+    <a href="#" class="btn btn-primary span6" data-bind="click: function() { if(!setup() || !decision()){enablePluginBlacklist()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision()}">
+        {{ _('Enable Plugin Blacklist Processing') }}
+    </a>
 </div>
 
 <div class="pluginblacklist_decision" style="display: none" data-bind="visible: setup()">


### PR DESCRIPTION
* Similar to #3924, fix button state so that the plugin blacklist can be enabled/disabled after
selecting one of the options for the first time.
* Improve formatting in the plugin blacklist wizard template to improve code readability.

### Test plan
```
rm -rf ~/.octoprint
octoprint serve
```
Navigate to http://0.0.0.0:5000/ and follow prompts until Plugin Blacklist.
With this patch applied, you should be able to change your decision.