### PR TITLE
Fix button state in connectivity check subwizard

### DIFF
--- a/src/octoprint/plugins/corewizard/templates/corewizard_onlinecheck_wizard.jinja2
+++ b/src/octoprint/plugins/corewizard/templates/corewizard_onlinecheck_wizard.jinja2
@@ -11,7 +11,7 @@
     OctoPrint comes preconfigured to perform the connectivity check every 15 minutes. You may change the value here.
 {% endtrans %}</p>
 
-<form class="form-horizontal" data-bind="with: settingsViewModel, enable: !setup(), css {disabled: setup()}" onsubmit="return false;">
+<form class="form-horizontal" data-bind="with: settingsViewModel" onsubmit="return false;">
     {% include "snippets/settings/server/serverOnlineCheckInterval.jinja2" %}
 </form>
 
@@ -21,7 +21,7 @@
     trust and that has a high availability.
 {% endtrans %}</p>
 
-<form class="form-horizontal" data-bind="with: settingsViewModel, enable: !setup(), css {disabled: setup()}" onsubmit="return false;">
+<form class="form-horizontal" data-bind="with: settingsViewModel" onsubmit="return false;">
     {% include "snippets/settings/server/serverOnlineCheckHost.jinja2" %}
     {% include "snippets/settings/server/serverOnlineCheckPort.jinja2" %}
     {% include "snippets/settings/server/serverOnlineCheckTestConnectivity.jinja2" %}
@@ -34,7 +34,7 @@
     side with the general connectivity check, leave the field empty.
 {% endtrans %}</p>
 
-<form class="form-horizontal" data-bind="with: settingsViewModel, enable: !setup(), css {disabled: setup()}" onsubmit="return false;">
+<form class="form-horizontal" data-bind="with: settingsViewModel" onsubmit="return false;">
     <div class="control-group">
         {% include "snippets/settings/server/serverOnlineCheckName.jinja2" %}
         {% include "snippets/settings/server/serverOnlineCheckTestResolution.jinja2" %}
@@ -47,8 +47,12 @@
 {% endtrans %}</p>
 
 <div class="row-fluid">
-    <a href="#" class="btn span6" data-bind="click: function() { if(!setup()){disableOnlineCheck()}}, enable: !setup(), css: {disabled: setup()}">{{ _('Disable Connectivity Check') }}</a>
-    <a href="#" class="btn btn-primary span6" data-bind="click: function() { if(!setup()){enableOnlineCheck()}}, enable: !setup(), css: {disabled: setup()}">{{ _('Enable Connectivity Check') }}</a>
+    <a href="#" class="btn span6" data-bind="click: function() { if(!setup() || decision()){disableOnlineCheck()}}, enable: !setup() || decision(), css: {disabled: setup() && !decision()}">
+        {{ _('Disable Connectivity Check') }}
+    </a>
+    <a href="#" class="btn btn-primary span6" data-bind="click: function() { if(!setup() || !decision()){enableOnlineCheck()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision()}">
+        {{ _('Enable Connectivity Check') }}
+    </a>
 </div>
 
 <div class="onlinecheck_decision" style="display: none" data-bind="visible: setup()">


### PR DESCRIPTION
* Similar to #3924, fix button state so that the connectivity check can be enabled/disabled after
selecting one of the options for the first time.
* Improve formatting in the connectivity check wizard template to improve code readability.

### Test plan
```
rm -rf ~/.octoprint
octoprint serve
```
Navigate to http://0.0.0.0:5000/ and follow prompts until Online Connectivity Check.
With this patch applied, you should be able to change your decision.