### PR TITLE
Reload logging settings when settings are viewed.

### DIFF
--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -273,7 +273,7 @@ $(function () {
             );
         };
 
-        self.onServerReconnect = self.onUserLoggedIn = self.onEventSettingsUpdated = function () {
+        self.onServerReconnect = self.onUserLoggedIn = self.onEventSettingsUpdated = self.onSettingsShown = function () {
             if (
                 !self.loginState.hasPermission(
                     self.access.permissions.PLUGIN_LOGGING_MANAGE


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

This PR fetches the logging settings each time the setting dialog is opened.  This makes it so that if "Close" was previously used on the settings instead of "Save", the settings dialog will revert back to the unchanged settings the next time that the settings dialog is opened.

#### How was it tested? How can it be tested by the reviewer?

1. Open the Logging settings dialog.
2. Make some changes to the Log levels.
3. "Close" but don't "Save" the settings.
4. Re-open the Logging settings dialog and notice that the unsaved settings are reverted (previously they would not be).

#### What are the relevant tickets if any?

Fixes #3948