### PR TITLE
Empty new logger

### DIFF
--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -108,8 +108,6 @@ $(function () {
 
             // loggers
             var availableLoggers = _.without(response.loggers, configuredLoggers);
-            availableLoggers.push("");
-            self.availableLoggersName("");
             self.availableLoggers(availableLoggers);
         };
 
@@ -182,7 +180,7 @@ $(function () {
             }
 
             var component = self.availableLoggersName();
-            if (component == "") {
+            if (!component) {
                 return;
             }
             var level = self.availableLoggersLevel();

--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -108,6 +108,8 @@ $(function () {
 
             // loggers
             var availableLoggers = _.without(response.loggers, configuredLoggers);
+            availableLoggers.push("");
+            self.availableLoggersName("");
             self.availableLoggers(availableLoggers);
         };
 
@@ -180,6 +182,9 @@ $(function () {
             }
 
             var component = self.availableLoggersName();
+            if (component == "") {
+                return;
+            }
             var level = self.availableLoggersLevel();
 
             self.configuredLoggers.push({

--- a/src/octoprint/plugins/logging/templates/logging_settings.jinja2
+++ b/src/octoprint/plugins/logging/templates/logging_settings.jinja2
@@ -91,7 +91,7 @@
     <div>
         <div class="row-fluid" style="margin-bottom: 5px">
             <div class="span8">
-                <select class="input-block-level" data-bind="options: availableLoggersSorted, value: availableLoggersName"></select>
+                <select class="input-block-level" data-bind="options: availableLoggersSorted, optionsCaption: '{{ _('Select a logger...') }}', value: availableLoggersName"></select>
             </div>
             <div class="span3">
                 <select class="input-medium" data-bind="value: availableLoggersLevel">


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

Clear confusion in logging levels by not listing a logger that isn't actually active.

#### How was it tested? How can it be tested by the reviewer?

1. Open the settings dialog.
2. Open "Logging".
3. Notice that only the loggers that are actually enabled are listed.  The combobox is empty.
4. Try clicking the blue plus.  It has no effect unless there is a valid logger in the selection.

#### What are the relevant tickets if any?

This fixes #3950

#### Screenshots (if appropriate)

See how the final row that has a combobox is blank instead of just showing the first logger alphabetically (usually `octoprint`):

![image](https://user-images.githubusercontent.com/109809/104496280-01e25e80-5596-11eb-8836-a39862a486f3.png)
