### PR TITLE
Use _.difference instead of _.without for arrays

### DIFF
--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -107,7 +107,7 @@ $(function () {
             self.configuredLoggers(levels);
 
             // loggers
-            var availableLoggers = _.without(response.loggers, configuredLoggers);
+            var availableLoggers = _.difference(response.loggers, configuredLoggers);
             self.availableLoggers(availableLoggers);
         };
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Fixes the available loggers list to not include any loggers that are already listed.

#### How was it tested? How can it be tested by the reviewer?

Follow instructions in bug

#### What are the relevant tickets if any?

#3954

#### Further notes

An alternative to my change is to continue to use `_.without` and use javascript spread operator (`...`) on the second param.  This works because _.without can take a variable number of arguments.

I didn't choose this because I didn't see other uses of the spread operator in the code and the spread operator is new-ish in javascript.