### PR TITLE
Automatically add logger when one is selected

### DIFF
--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -108,6 +108,8 @@ $(function () {
 
             // loggers
             var availableLoggers = _.without(response.loggers, configuredLoggers);
+            availableLoggers.push("");
+            self.availableLoggersName("");
             self.availableLoggers(availableLoggers);
         };
 
@@ -180,6 +182,9 @@ $(function () {
             }
 
             var component = self.availableLoggersName();
+            if (component == "") {
+                return;
+            }
             var level = self.availableLoggersLevel();
 
             self.configuredLoggers.push({

--- a/src/octoprint/plugins/logging/static/js/logging.js
+++ b/src/octoprint/plugins/logging/static/js/logging.js
@@ -21,13 +21,6 @@ $(function () {
             return _.sortBy(self.availableLoggers());
         });
 
-        self.configuredLoggersSorted = ko.computed(function () {
-            return _.sortBy(self.configuredLoggers(), function (o) {
-                o.level();
-                return o.component;
-            });
-        });
-
         // initialize list helper
         self.listHelper = new ItemListHelper(
             "logFiles",
@@ -103,6 +96,9 @@ $(function () {
                 });
                 levels.push(item);
                 configuredLoggers.push(logger);
+            });
+            let sortedLevels = _.sortBy(levels, function (o) {
+                return o.component;
             });
             self.configuredLoggers(levels);
 

--- a/src/octoprint/plugins/logging/templates/logging_settings.jinja2
+++ b/src/octoprint/plugins/logging/templates/logging_settings.jinja2
@@ -69,7 +69,7 @@
         <div class="span8"><h5>{{ _('Name') }}</h5></div>
         <div class="span2"><h5>{{ _('Level') }}</h5></div>
     </div>
-    <div data-bind="foreach: configuredLoggersSorted">
+    <div data-bind="foreach: configuredLoggers">
         <div class="row-fluid" style="margin-bottom: 5px">
             <div class="span8">
                 <span data-bind="text: component"></span>
@@ -91,7 +91,7 @@
     <div>
         <div class="row-fluid" style="margin-bottom: 5px">
             <div class="span8">
-                <select class="input-block-level" data-bind="options: availableLoggersSorted, value: availableLoggersName"></select>
+                <select class="input-block-level" data-bind="options: availableLoggersSorted, value: availableLoggersName, event: { change: addLogger }"></select>
             </div>
             <div class="span3">
                 <select class="input-medium" data-bind="value: availableLoggersLevel">
@@ -101,9 +101,6 @@
                     <option value="ERROR">ERROR</option>
                     <option value="CRITICAL">CRITICAL</option>
                 </select>
-            </div>
-            <div class="span1">
-                <a title="{{ _('Add')|edq }}" class="btn btn-primary" data-bind="click: $root.addLogger"><i class="icon-plus"></i></a>
             </div>
         </div>
     </div>


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This fixes #3947 

#### How was it tested? How can it be tested by the reviewer?

I did a lot of adding and removing of log levels, sometimes closing without saving, sometimes saving.  I also sometimes would reload in the middle.

#### What are the relevant tickets if any?

This fixes #3947 

Notice that it depends on merging #3949 and also merging #3951 . Merge those PRs before merging this one.

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/109809/104509700-43c7d080-55a7-11eb-8b94-3c711b6f1f69.png)

Notice that there is no blue plus symbol to the right of the final row (under the red garbage can).  Notice also that the name of the logger is blank.  When a logger is select there, for example, `octoprint`, here's what it will look like:

![image](https://user-images.githubusercontent.com/109809/104509850-7d004080-55a7-11eb-983d-5a645caa59e4.png)

The row is added immediately a new blank one is available.

#### Further notes

As usual, changes only apply after pressing "Save".  Pressing "Close" causes no changes.