### PR TITLE
Add slicing.defaultSlicer to set/get

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -311,6 +311,7 @@ def getSettings():
             "allowFraming": s.getBoolean(["server", "allowFraming"]),
         },
         "devel": {"pluginTimings": s.getBoolean(["devel", "pluginTimings"])},
+        "slicing": {"defaultSlicer": s.get(["slicing", "defaultSlicer"])},
     }
 
     gcode_scripts = s.listScripts("gcode")
@@ -1026,6 +1027,10 @@ def _saveSettings(data):
             # enable plugin timing logging to plugintimings.log
             logging.getLogger("PLUGIN_TIMINGS").setLevel(logging.DEBUG)
             logging.getLogger("PLUGIN_TIMINGS").debug("Enabling plugin timings logging")
+
+    if "slicing" in data:
+        if "defaultSlicer" in data["slicing"]:
+            s.set(["slicing", "defaultSlicer"], data["slicing"]["defaultSlicer"])
 
     if "plugins" in data:
         for plugin in octoprint.plugin.plugin_manager().get_implementations(


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

It is currently not possible to set the value for `slicing.defaultSlicer`.  Adding this allows changing the default slicer from within the settings dialog.

#### How was it tested? How can it be tested by the reviewer?

Modify a plugin to print out the settings view model or set it.  Not easy to do.  Easier might be to just compare with the surrounding code and make sure that it looks similar.

#### Any background context you want to provide?

This would enable merging https://github.com/OctoPrint/OctoPrint-Slic3r/pull/62

#### What are the relevant tickets if any?

https://github.com/OctoPrint/OctoPrint-Slic3r/issues/61

#### Screenshots (if appropriate)

#### Further notes

The comment [here](https://github.com/OctoPrint/OctoPrint/blob/master/src/octoprint/server/api/settings.py#L100) says to update the docs with the "new" API.  However, this setting it already in the API: https://github.com/OctoPrint/OctoPrint/blame/master/docs/configuration/config_yaml.rst#L1060

So no need to update that doc.