### PR TITLE
Enhance jsclient-socket documentation

### DIFF
--- a/docs/jsclientlib/socket.rst
+++ b/docs/jsclientlib/socket.rst
@@ -122,7 +122,7 @@ Sample to setup an authed socket
       OctoPrint.socket.connect();
       OctoPrint.browser.login("myusername", "mypassword", true)
           .done(function(response) {
-              client.socket.sendAuth("myusername", response.session);
+              OctoPrint.socket.sendAuth("myusername", response.session);
           });
 
 .. _sec-jsclient-socket-throttling:

--- a/docs/jsclientlib/socket.rst
+++ b/docs/jsclientlib/socket.rst
@@ -64,11 +64,23 @@
 
    Sends a message of type ``type`` with the provided ``payload`` to the server.
 
-   Note that at the time of writing, OctoPrint only supports the ``throttle`` message. See
+   Note that at the time of writing, OctoPrint only supports the ``throttle`` and ``auth`` messages. See
    also the :ref:`Push API documentation <sec-api-push>`.
 
    :param string type: Type of message to send
    :param object payload: Payload to send
+
+.. js:function:: OctoPrintClient.socket.sendAuth(userId, session)
+
+   Sends an ``auth`` message with the provided ``userId`` and ``session`` to the server.
+
+   ``session`` is expected to be the ``session`` value retrieved
+   from any valid :ref:`OctoPrint.browser.login(userId,...) <sec-jsclientlib-browser>` response.
+
+   See also the :ref:`Push API documentation <sec-api-push>`.
+
+   :param string userId: An existing OctoPrint username
+   :param string session: A valid session id for the provided username
 
 .. js:function:: OctoPrintClient.socket.onRateTooLow(measured, minimum)
 
@@ -101,6 +113,17 @@
 .. js:function:: OctoPrintClient.socket.decreaseRate()
 
    Instructs the server to decrease the message rate by 500ms.
+
+Sample to setup an authed socket
+================================
+
+.. code-block:: javascript
+
+      OctoPrint.socket.connect();
+      OctoPrint.browser.login("myusername", "mypassword", true)
+          .done(function(response) {
+              client.socket.sendAuth("myusername", response.session);
+          });
 
 .. _sec-jsclient-socket-throttling:
 


### PR DESCRIPTION
Hi @foosel ,

As discussed on Discord, here is a PR to enhance the jsclient socket documentation.
It includes :
- An addition to sendMessage() doc to warns it also supports `auth` type message
- The documentation for sendAuth()
- A quick and dirty sample to setup a working authed socket

Regards,
Orel