### PR TITLE
sockJS include when playing with jsclient lib

### DIFF
--- a/docs/jsclientlib/index.rst
+++ b/docs/jsclientlib/index.rst
@@ -40,6 +40,12 @@ because the library depends on those to be available (as ``$`` and ``_``). You c
    <script src="{{ url_for("static", filename="js/lib/jquery/jquery.min.js") }}"></script>
    <script src="{{ url_for("static", filename="js/lib/lodash.min.js") }}"></script>
 
+Moreover, if you need to use the socket module, you'll need to include sockJS. You can embedded it like this:
+
+.. code-block:: html+jinja
+
+   <script src="{{ url_for("static", filename="js/lib/sockjs.min.js") }}"></script>
+
 Note that all components depend on the ``base`` component to be present, so if you are only including a select
 number of components, make sure to at the very least include that one to be able to utilize the client.
 

--- a/docs/jsclientlib/index.rst
+++ b/docs/jsclientlib/index.rst
@@ -40,7 +40,7 @@ because the library depends on those to be available (as ``$`` and ``_``). You c
    <script src="{{ url_for("static", filename="js/lib/jquery/jquery.min.js") }}"></script>
    <script src="{{ url_for("static", filename="js/lib/lodash.min.js") }}"></script>
 
-Moreover, if you need to use the socket module, you'll need to include sockJS. You can embedded it like this:
+Moreover, if you need to use the socket module, you'll need to include sockJS. You can embed it like this:
 
 .. code-block:: html+jinja
 


### PR DESCRIPTION
Hi again @foosel ,

To complete the previous PR i sent regarding js client socket documentation and according to the [js_client bundle](https://github.com/OctoPrint/OctoPrint/blob/master/src/octoprint/server/__init__.py#L1961), i think it could be useful to add the sockJS lib include in the documentation, if needed.

Regards,
Orel