### PR TITLE
Center Viewport on gcode viewer is cased wrong

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -879,8 +879,8 @@ $(function () {
             self.resetOptions();
 
             var current = loadFromLocalStorage(optionsLocalStorageKey);
-            if (current["centerViewport"] !== undefined)
-                self.renderer_centerViewport(current["centerViewport"]);
+            if (current["centerViewPort"] !== undefined)
+                self.renderer_centerViewport(current["centerViewPort"]);
             if (current["zoomOnModel"] !== undefined)
                 self.renderer_zoomOnModel(current["zoomOnModel"]);
             if (current["showMoves"] !== undefined)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
The case of the local storage parameter for gcode viewer was wrong when reading it compared to when saving it.
I decided to change the load instead of the save so it will work with people who has it stored prev. :)

#### How was it tested? How can it be tested by the reviewer?
On my own installation
