### PR TITLE
Gcode viewer hide prime

### DIFF
--- a/docs/bundledplugins/gcodeviewer.rst
+++ b/docs/bundledplugins/gcodeviewer.rst
@@ -27,7 +27,7 @@ The plugin supports the following configuration keys:
   * ``mobileSizeThreshold``: Whether to also enable tracking on unreleased OctoPrint versions (anything not stable releases
     or release candidates). Defaults to ``false``.
   * ``sizeThreshold``: Unique instance identifier, auto generated on first activation
-  * ``skipUntilthis``: If this string is provided the GCode Viewer will search for this string, and if found, skip all gcode up until this string. This can be used to skip prime nozzle gcode in the preview
+  * ``skipUntilThis``: If this string is provided the GCode Viewer will search for this string, and if found, skip all gcode up until this string. This can be used to skip prime nozzle gcode in the preview
 
 .. _sec-bundledplugins-gcodeviewer-sourcecode:
 

--- a/docs/bundledplugins/gcodeviewer.rst
+++ b/docs/bundledplugins/gcodeviewer.rst
@@ -27,6 +27,7 @@ The plugin supports the following configuration keys:
   * ``mobileSizeThreshold``: Whether to also enable tracking on unreleased OctoPrint versions (anything not stable releases
     or release candidates). Defaults to ``false``.
   * ``sizeThreshold``: Unique instance identifier, auto generated on first activation
+  * ``skipUntilthis``: If this string is provided the GCode Viewer will search for this string, and if found, skip all gcode up until this string. This can be used to skip prime nozzle gcode in the preview
 
 .. _sec-bundledplugins-gcodeviewer-sourcecode:
 

--- a/src/octoprint/plugins/gcodeviewer/__init__.py
+++ b/src/octoprint/plugins/gcodeviewer/__init__.py
@@ -49,7 +49,7 @@ class GcodeviewerPlugin(
         return {
             "mobileSizeThreshold": 2 * 1024 * 1024,  # 2MB
             "sizeThreshold": 20 * 1024 * 1024,  # 20MB
-            "skipUntilthis": None,
+            "skipUntilThis": None,
         }
 
     def get_settings_version(self):

--- a/src/octoprint/plugins/gcodeviewer/__init__.py
+++ b/src/octoprint/plugins/gcodeviewer/__init__.py
@@ -48,8 +48,9 @@ class GcodeviewerPlugin(
     def get_settings_defaults(self):
         return {
             "mobileSizeThreshold": 2 * 1024 * 1024,  # 2MB
-            "sizeThreshold": 20 * 1024 * 1024,
-        }  # 20MB
+            "sizeThreshold": 20 * 1024 * 1024,  # 20MB
+            "skipUntilthis": None,
+        }
 
     def get_settings_version(self):
         return 1

--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -475,6 +475,21 @@ $(function () {
         };
 
         self.showGCodeViewer = function (response, rstatus) {
+            // Slice of the gcode
+            if (self.settings.settings.plugins.gcodeviewer.skipUntilthis() != "") {
+                var findThis =
+                    self.settings.settings.plugins.gcodeviewer.skipUntilthis() + "";
+                var indexPos = response.indexOf("\n" + findThis);
+                // Try windows newlines if not found
+                if (indexPos == -1) {
+                    indexPos = response.indexOf("\r" + findThis);
+                }
+                if (indexPos != -1) {
+                    // Slice and make sure we comment out any string left back after slicing - so if a user configures something like "G1" we dont end up with a snippet of gcode commands
+                    // Yes it would be prettier to parse it line by line and remove the entire line, that is very slow and uses mem - this way we find the string, and remove it
+                    response = ";" + response.slice(indexPos + findThis.length + 1);
+                }
+            }
             var par = {
                 target: {
                     result: response
@@ -879,8 +894,8 @@ $(function () {
             self.resetOptions();
 
             var current = loadFromLocalStorage(optionsLocalStorageKey);
-            if (current["centerViewport"] !== undefined)
-                self.renderer_centerViewport(current["centerViewport"]);
+            if (current["centerViewPort"] !== undefined)
+                self.renderer_centerViewport(current["centerViewPort"]);
             if (current["zoomOnModel"] !== undefined)
                 self.renderer_zoomOnModel(current["zoomOnModel"]);
             if (current["showMoves"] !== undefined)

--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -476,15 +476,14 @@ $(function () {
 
         self.showGCodeViewer = function (response, rstatus) {
             // Slice of the gcode
-            if (self.settings.settings.plugins.gcodeviewer.skipUntilthis() != "") {
-                var findThis =
-                    self.settings.settings.plugins.gcodeviewer.skipUntilthis() + "";
+            var findThis = self.settings.settings.plugins.gcodeviewer.skipUntilThis();
+            if (findThis && findThis !== "") {
                 var indexPos = response.indexOf("\n" + findThis);
                 // Try windows newlines if not found
-                if (indexPos == -1) {
+                if (indexPos === -1) {
                     indexPos = response.indexOf("\r" + findThis);
                 }
-                if (indexPos != -1) {
+                if (indexPos !== -1) {
                     // Slice and make sure we comment out any string left back after slicing - so if a user configures something like "G1" we dont end up with a snippet of gcode commands
                     // Yes it would be prettier to parse it line by line and remove the entire line, that is very slow and uses mem - this way we find the string, and remove it
                     response = ";" + response.slice(indexPos + findThis.length + 1);

--- a/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_settings.jinja2
+++ b/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_settings.jinja2
@@ -19,4 +19,15 @@
             </span>
         </div>
     </div>
+    <div class="control-group" title="{{ _('Skip/Hide gcode until this string')}}">
+        <label class="control-label" for="settings-skipUntilthis">{{ _('Skip to this') }}</label>
+        <div class="controls">
+            <input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.gcodeviewer.skipUntilthis" id="settings-skipUntilthis" placeholder="; layer 1">
+        </div>
+        <div class="controls">
+            <span class="help-inline">
+                {% trans %}If provided, the GCode Viewer will search for a line beginning with this string. If found, all GCode up to that point will be skipped. This can be used to skip "purge/nozzle wipe" GCode in the viewer. Note the search is case sensitive. Example: <code>; layer 1</code>{% endtrans %}
+            </span>
+        </div>
+    </div>
 </form>

--- a/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_settings.jinja2
+++ b/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_settings.jinja2
@@ -20,9 +20,9 @@
         </div>
     </div>
     <div class="control-group" title="{{ _('Skip/Hide gcode until this string')}}">
-        <label class="control-label" for="settings-skipUntilthis">{{ _('Skip to this') }}</label>
+        <label class="control-label" for="settings-skipUntilThis">{{ _('Skip to this') }}</label>
         <div class="controls">
-            <input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.gcodeviewer.skipUntilthis" id="settings-skipUntilthis" placeholder="; layer 1">
+            <input type="text" class="input-block-level" data-bind="value: settings.settings.plugins.gcodeviewer.skipUntilThis" id="settings-skipUntilThis" placeholder="; layer 1">
         </div>
         <div class="controls">
             <span class="help-inline">


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Added an option for the  GCode Viewer so one can specify a string. And when provided the GCode Viewer will search for this string, and if found, skip all gcode up until this string. This can be used to skip prime nozzle gcode in the preview

#### How was it tested? How can it be tested by the reviewer?
On my own instance :)

Notice that the way the gcode is "sliced/cut" has been tried with many different ways for speed and mem consumption.
https://jsben.ch/9cwLJ - indexOf seems to be fastest on all browsers tested - firefox has includes 3% faster but then again chrome is the most used browser and is much faster using indexOf

The way the gcode "cut" is implemented is to find a line starting with the entered string and cut everything before that point and comment anything remaining out of that line. So if one is search for "; layer 1" it wil search for "\n; layer 1" - and if found in a string like this: "Blah\nBlah2\nBlah3\n; layer 1 Blah4 Blah\nBlah5\nBlah6" then the string sent to the viewer will be: "; Blah4 Blah\nBlah5\nBlah6". 

Converting the gcode into single lines and parsing line by line - this would cause slowness and memory consumption beyond what I prefer. 

The current solution is a compromise between something "easy" for the enduser and also fast and memory efficient.