### PR TITLE
Added missing Etag comparator method

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -138,6 +138,7 @@ date of first contribution):
   * [Nils Hofmann](https://github.com/Master92)
   * [Miroslav Šedivý](https://github.com/eumiro)
   * [Costas Basdekis](https://github.com/costas-basdekis)
+  * [Bence Tamas](https://github.com/encetamasb)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -1204,6 +1204,13 @@ class LargeResponseHandler(
         else:
             return self.get_content_version(self.absolute_path)
 
+    def check_etag_header(self):
+        requested_version = self.request.headers.get("If-None-Match", None)
+        if requested_version is not None:
+            current_version = str(self.compute_etag())
+            return requested_version == current_version
+        return False
+
     # noinspection PyAttributeOutsideInit
     def get_content_type(self):
         if self._mime_type_guesser is not None:


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

When computed etag matches the request's header then tornado should respond with HTTP 304 instead of 200 (with full content). Tornado has builtin support for this but without a comparator method in the request handler its not functional.

#### How was it tested? How can it be tested by the reviewer?

Opened the web ui and checked response status codes. I have an 1.3MB packed_lib.js what gets downloaded almost every time I open the ui. After applying my changes I can see the expected status code (304) and cache works properly.

#### Any background context you want to provide?

https://www.tornadoweb.org/en/stable/web.html#tornado.web.RequestHandler.check_etag_header

#### What are the relevant tickets if any?

.

#### Screenshots (if appropriate)

.

#### Further notes

It's possible that I miss something and its intentional that this method does not exist. 