### PR TITLE
catch exception when M117 with no arguments is sent using virtual printer

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -745,7 +745,10 @@ class VirtualPrinter(object):
         # type: (str) -> None
         # we'll just use this to echo a message, to allow playing around with pause triggers
         if self._echoOnM117:
-            self._send("echo:%s" % re.search(r"M117\s+(.*)", data).group(1))
+            try:
+                self._send("echo:%s" % re.search(r"M117\s+(.*)", data).group(1))
+            except AttributeError:
+                self._send("echo:")
 
     def _gcode_M155(self, data):
         # type: (str) -> None


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Very small change to catch an exception when a bare `M117` is sent to the virual printer interface via Terminal from the UI.

```
File "/Users/k/work/jt/oprint/OctoPrint/src/octoprint/plugins/virtual_printer/virtual.py", line 527, in _processIncoming
    handled = getattr(self, command_handler)(data)
  File "/Users/k/work/jt/oprint/OctoPrint/src/octoprint/plugins/virtual_printer/virtual.py", line 748, in _gcode_M117
    self._send("echo:%s" % re.search(r"M117\s+(.*)", data).group(1))
AttributeError: 'NoneType' object has no attribute 'group' 
```
It's looking for "at least one space" and whatever else.  But if there's no space, then `re.search` returns None.

#### How was it tested? How can it be tested by the reviewer?

Use virtual printer interface and just type `M117` into the Terminal UI.

`pytest` seemed to pass fine as well.

#### Any background context you want to provide?

Nah

#### What are the relevant tickets if any?

None that I know of

#### Screenshots (if appropriate)

N/A

#### Further notes

It's entirely possible that a bare M117 is actually correct according to the spec.  If so, then this patch makes no sense.

Also entirely possible I've just configured something wrong in my environment.