### PR TITLE
[maintenance] Fix logging download

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -766,13 +766,9 @@ class Server(object):
             )
         }
 
-        valid_log = (
-            lambda path: not octoprint.util.is_hidden_path(path)
-            and path.endswith(".log")
-            and os.path.realpath(os.path.abspath(path)).startswith(
-                settings().getBaseFolder("logs")
-            )
-        )
+        valid_log = lambda path: not octoprint.util.is_hidden_path(
+            path
+        ) and path.endswith(".log")
         log_path_validator = {
             "path_validation": util.tornado.path_validation_factory(
                 valid_log,


### PR DESCRIPTION
`path` in this context is just `octoprint.log`, so the path validation is useless - it will always look in the basedir, because that is where Tornado has been told to look.

No other validators do the same as far as I can see (timelapse and files).

Closes #4045
