### PR TITLE
Show meaningful message when software update is blocked

### DIFF
--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -1086,10 +1086,14 @@ class SoftwareUpdatePlugin(
             and not self._settings.get_boolean(["ignore_throttled"])
         ):
             # currently throttled, we refuse to run
+            message = (
+                "System is currently throttled, refusing to update "
+                "anything due to possible stability issues"
+            )
+            self._logger.error(message)
             flask.abort(
                 409,
-                description="System is currently throttled, refusing to update "
-                "anything due to possible stability issues",
+                description=message,
             )
 
         if self._printer.is_printing() or self._printer.is_paused():

--- a/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
+++ b/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
@@ -680,13 +680,20 @@ $(function () {
                         gettext("Updating, please wait.")
                     );
                 })
-                .fail(function () {
+                .fail(function (response) {
                     self.updateInProgress = false;
+                    var message =
+                        "<p>" +
+                        gettext(
+                            "The update could not be started. Is it already active? Please consult octoprint.log for details."
+                        ) +
+                        "</p><pre>" +
+                        _.escape(response.responseJSON.error) +
+                        "</pre>";
+
                     self._showPopup({
                         title: gettext("Update not started!"),
-                        text: gettext(
-                            "The update could not be started. Is it already active? Please consult octoprint.log for details."
-                        ),
+                        text: message,
                         type: "error",
                         hide: false,
                         buttons: {


### PR DESCRIPTION
...and log when it is undervoltage.

The problem here was twofold: first, a very generic message asking to check the log confused users. Second, there was nothing logged when it said check the logs.

So, this changes that so the message is escaped and displayed in the pnotify and when the update is blocked for undervoltage this is logged.

This does not add logging for other errors, since it seems unnecessary to me.

Closes #4024
