### PR TITLE
Terminal Filters - Updated temperature regex

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -139,6 +139,7 @@ date of first contribution):
   * [Miroslav Šedivý](https://github.com/eumiro)
   * [Costas Basdekis](https://github.com/costas-basdekis)
   * [Joe Martella](https://github.com/martellaj)
+  * [Scott Lahteine](https://github.com/thinkyhead)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1132,9 +1132,9 @@ Use `Javascript regular expressions <https://developer.mozilla.org/en/docs/Web/J
    # A list of filters to display in the terminal tab. Defaults to the filters shown below
    terminalFilters:
    - name: Suppress temperature messages
-     regex: '(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+)?.*(B|T\d*):\d+)'
+     regex: '(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+([PBN]\d+\s+)*)?([BCLPR]|T\d*):-?\d+)'
    - name: Suppress SD status messages
-     regex: '(Send: (N\d+\s+)?M27)|(Recv: SD printing byte)'
+     regex: '(Send: (N\d+\s+)?M27)|(Recv: SD printing byte)|(Recv: Not SD printing)'
    - name: Suppress wait responses
      regex: 'Recv: wait'
    - name: Suppress processing responses

--- a/docs/development/environment.rst
+++ b/docs/development/environment.rst
@@ -74,7 +74,7 @@ If you also want to be able to build the documentation that resides in the ``doc
 the *Python 3* environment and install the docs dependencies as well:
 
   * ``source venv3/bin/activate`` (Linux, macOS) or ``source venv3/Scripts/activate`` (Git Bash under Windows, see below)
-  * ``pip install -e .[develop,plugins,docs]``
+  * ``pip install -e '.[develop,plugins,docs]'``
 
 Go to the directory `docs` and you can then build the documentation:
 
@@ -116,10 +116,10 @@ Then:
    virtualenv --python=python3 venv3
    source ./venv2/bin/activate
    pip install --upgrade pip
-   pip install -e .[develop,plugins]
+   pip install -e '.[develop,plugins]'
    source ./venv3/bin/activate
    pip install --upgrade pip
-   pip install -e .[develop,plugins,docs]
+   pip install -e '.[develop,plugins,docs]'
    pre-commit install
    git config blame.ignoreRevsFile .git-blame-ignore-revs
 
@@ -162,10 +162,10 @@ Open the Git Bash you just installed and in that:
    virtualenv --python=C:\Python38\python.exe venv3
    source ./venv2/Scripts/activate
    python -m pip install --upgrade pip
-   pip install -e .[develop,plugins]
+   pip install -e '.[develop,plugins]'
    source ./venv3/Scripts/activate
    pip install --upgrade pip
-   python -m pip install -e .[develop,plugins,docs]
+   python -m pip install -e '.[develop,plugins,docs]'
    pre-commit install
    git config blame.ignoreRevsFile .git-blame-ignore-revs
 
@@ -241,7 +241,7 @@ You'll need a user account with administrator privileges.
        virtualenv venv
        source venv/bin/activate
        pip install --upgrade pip
-       pip install -e .[develop,plugins]
+       pip install -e '.[develop,plugins]'
        pre-commit install
        git config blame.ignoreRevsFile .git-blame-ignore-revs
 
@@ -291,7 +291,7 @@ PyCharm
 
       * Name: Update OctoPrint dependencies
       * Program: ``$ModuleSdkPath$``
-      * Parameters: ``-m pip install -e .[develop,plugins]``
+      * Parameters: ``-m pip install -e '.[develop,plugins]'``
       * Working directory: ``$ProjectFileDir$``
 
       Note that sadly that seems to cause some hiccups on current PyCharm versions due to ``$PyInterpreterDirectory$``
@@ -320,7 +320,7 @@ PyCharm
       the documentation, see above on how to set this up.
 
     Note that this requires you to also have installed the additional ``docs`` dependencies into the Python 3 venv as
-    described above via ``pip install -e .[develop,plugins,docs]``.
+    described above via ``pip install -e '.[develop,plugins,docs]'``.
 
   - Settings > Tools > File Watchers (you might have to enable this, it's a bundled plugin), add new:
 

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -423,7 +423,7 @@ default_settings = {
     "terminalFilters": [
         {
             "name": "Suppress temperature messages",
-            "regex": r"(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+((P|B|N)\d+\s+)*)?(B|T\d*):\d+)",
+            "regex": r"(Send: (N\d+\s+)?M105)|(Recv:\s+(ok\s+([PBN]\d+\s+)*)?([BCLPR]|T\d*):-?\d+)",
         },
         {
             "name": "Suppress SD status messages",

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -406,7 +406,8 @@ $(function () {
         self.addTerminalFilter = function () {
             self.terminalFilters.push({
                 name: "New",
-                regex: "(Send:\\s+(N\\d+\\s+)?M105)|(Recv:\\s+(ok\\s+)?.*(B|T\\d*):\\d+)"
+                regex:
+                    "(Send:\\s+(N\\d+\\s+)?M105)|(Recv:\\s+(ok\\s+([PBN]\\d+\\s+)*)?.*([BCLPR]|T\\d*):-?\\d+)"
             });
         };
 


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely new feature, or maintenance if it's a bug fix or improvement of existing functionality for the current stable version (no PRs against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or devel please), e.g., dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the .less source files, not the .css files (those are generated with lessc)
  * [x] You have tested your changes (please state how!) - ideally you have added unit tests
  * [x] You have run the existing unit tests against your changes and nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

This PR updates the default Terminal Filters regular expression for Temperature messages for Marlin 2.0.8 additions.

- Recognize the temperatures of **C**hamber, **P**robe, **R**edundant, and **L**aser cooler.
- Recognize temperature messages with negative temperatures (for a disconnected thermistor).

#### How was it tested? How can it be tested by the reviewer?

Tested and refined the filter in-place by modifying it on the running instance of OctoPrint.

#### Any background context you want to provide?

Marlin has lately added support for more heaters (and a cooler) so the letters 'C', 'P', and 'L' are now possible in temperature messages. The 'R' heater has been in Marlin since version 1.x.

#### What are the relevant tickets if any?

n/a

#### Screenshots (if appropriate)

n/a

#### Further notes

Have a nice day!