### PR TITLE
Endpoint improvement: api/job#status to return PrinterState object instead of state.text

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -141,6 +141,7 @@ date of first contribution):
   * [Joe Martella](https://github.com/martellaj)
   * [Scott Lahteine](https://github.com/thinkyhead)
   * [Karthikeyan Singaravelan](https://github.com/tirkarthi)
+  * [DarkGuardsman](https://github.com/darkguardsman)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -75,9 +75,6 @@ def jobState():
     response = {
         "job": currentData["job"],
         "progress": currentData["progress"],
-        "state": currentData["state"]["text"],
+        "state": currentData["state"],
     }
-    if currentData["state"]["error"]:
-        response["error"] = currentData["state"]["error"]
-
     return jsonify(**response)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Changes the response of `api/job` to return the [PrinterState](https://docs.octoprint.org/en/master/api/datamodel.html#printer-state) object instead of state.text value. 

This allows for a cleaner response in terms of telling the state of the printer. As well provides more information from the endpoint on printer state.

#### How was it tested? How can it be tested by the reviewer?

Calling the endpoint to validate the response

#### Any background context you want to provide?

Working on a java based wrapper for the API to be used with other apps. Ran into an issue with the status field on the job response being inconsistent in it's behavior. Specifically according to the documentation I was expecting a finite list of status string code. Instead it seems the status can be any value supplied to status.text. This includes errors and other values from what I can see in the python code. 

Issue with this is getting supplied something like `Offline (Error: No more candidates to test, and no working port/baudrate combination detected.)`. Which requires parsing/regex to pull out the state of `Offline` and Error of `No more candidates to test, and no working port/baudrate combination detected`. This is also a bit confusing as its unclear if the state is `Offline` or `Error`. I can apply a best guess in the logic. However, this leads to another problem of "what if the text changes?". As this seems to be a field used in the UI to display the status to the user. In theory this means a plugin or other source could change it breaking logic. 