### PR TITLE
🔧 Adapt issue forms to breaking change

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Report a bug
 description: Create a bug report to help improve OctoPrint
 title: ""
-issue_body: true
 body:
   - type: markdown
     attributes:
@@ -130,7 +129,6 @@ body:
         - label: Contents of the JavaScript browser console (always include in cases of issues with the user interface)
         - label: Screenshots and/or videos showing the problem (always include in case of issues with the user interface)
         - label: GCODE file with which to reproduce (always include in case of issues with GCODE analysis or printing behaviour)
-  - type: markdown
+  - type: textarea
     attributes:
-      value: |
-        ## Additional information & file uploads
+      label: Additional information & file uploads

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: ✨ Request a feature
 description: Request a new feature to implement in OctoPrint
 title: "[Request]"
-issue_body: true
 body:
   - type: markdown
     attributes:
@@ -29,9 +28,7 @@ body:
     attributes:
       label: Describe alternatives you've considered
       description: A clear and concise description of any alternative solutions or features you've considered.
-  - type: markdown
+  - type: textarea
     attributes:
-      value: >
-        **Additional context**
-
-        Add any other context or screenshots about the feature request here.
+      label: Additional context
+      description: Add any other context or screenshots about the feature request here.


### PR DESCRIPTION
`issue_body` is about to be removed from the schema, `textarea` fields are about to get WYSIWYG attached.

Not to be merged before go-live, approx. Thursday April 9th 2021
