### PR TITLE
Use G0 for jogging.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -141,6 +141,7 @@ date of first contribution):
   * [Joe Martella](https://github.com/martellaj)
   * [Scott Lahteine](https://github.com/thinkyhead)
   * [Karthikeyan Singaravelan](https://github.com/tirkarthi)
+  * [Yvan Rodrigues](https://github.com/TwoRedCells)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -516,7 +516,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
                     )
                 )
 
-        command = "G1 {}".format(
+        command = "G0 {}".format(
             " ".join(["{}{}".format(axis.upper(), amt) for axis, amt in axes.items()])
         )
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
When one uses the jog buttons in the control tab, OctoPrint currently issues a `G1` command. This is contrary to best practices for use of the `G0/G1` g-code commands.

By convention `G1` is used for cutting/burning/extruding moves at normal speed, and `G0` is intended for rapid moves that do not invoke tooling. 
e.g. https://marlinfw.org/docs/gcode/G000-G001.html
e.g. https://www.cnccookbook.com/g00-g01-cnc-g-code
e.g. https://machmotion.com/downloads/GCode/Mach4-G-and-M-Code-Reference-Manual.pdf
e.g. http://linuxcnc.org/docs/html/gcode/g-code.html#gcode:g0

Using `G1` can have adverse effects in many environments. For example in Marlin the laser may be turned on for `G1` moves and off for `G0` (`LASER_MOVE_G0_OFF`) and it is easy to unintentionally turn on the laser when not wearing eye protection such as when jogging to load material.

#### How was it tested? How can it be tested by the reviewer?

I have been using it on my CNC router and my 3D printer without issue for over 1 month.

#### Any background context you want to provide?

`G0` has been around since the beginning of g-code itself. As such the risk of incompatibility for any user is very low. For the average user, the worst effect would be nothing at all. Particularly for CNC users, the benefit is hardware acting as it was intended.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
