### PR TITLE
/api/files: add unselect file command

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -142,6 +142,7 @@ date of first contribution):
   * [Scott Lahteine](https://github.com/thinkyhead)
   * [Karthikeyan Singaravelan](https://github.com/tirkarthi)
   * [Yvan Rodrigues](https://github.com/TwoRedCells)
+  * [Elton Law](https://github.com/eltonlaw)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/api/files.rst
+++ b/docs/api/files.rst
@@ -585,6 +585,15 @@ Issue a file command
 
      Requires the ``FILES_SELECT`` permission.
 
+   unselect
+     Unselects the currently selected file for printing.
+
+     Upon success, a status code of :http:statuscode:`204` and an empty body is returned. If no file is selected
+     or there already is an active print job, a :http:statuscode:`409` is returned. If path isn't ``current```
+     or the filename of the current selection, a :http:statuscode:`400` is returned
+
+     Requires the ``FILES_SELECT`` permission.
+
    slice
      Slices an STL file into GCODE. Note that this is an asynchronous operation that will take place in the background
      after the response has been sent back to the client. Additional parameters are:

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -794,6 +794,7 @@ def gcodeFileCommand(filename, target):
     # valid file commands, dict mapping command name to mandatory parameters
     valid_commands = {
         "select": [],
+        "unselect": [],
         "slice": [],
         "analyse": [],
         "copy": ["destination"],
@@ -841,6 +842,26 @@ def gcodeFileCommand(filename, target):
             else:
                 filenameToSelect = fileManager.path_on_disk(target, filename)
             printer.select_file(filenameToSelect, sd, printAfterLoading, user)
+
+    elif command == "unselect":
+        with Permissions.FILES_SELECT.require(403):
+            if not printer.is_ready():
+                return make_response(
+                    "Printer is already printing, cannot unselect current file", 409
+                )
+
+            _, currentFilename = _getCurrentFile()
+            if currentFilename is None:
+                return make_response(
+                    "Cannot unselect current file when there is no file selected", 409
+                )
+
+            if filename != currentFilename and filename != "current":
+                return make_response(
+                    "Only the currently selected file can be unselected", 400
+                )
+
+            printer.unselect_file()
 
     elif command == "slice":
         with Permissions.SLICE.require(403):


### PR DESCRIPTION
#### What are the relevant tickets if any?

https://github.com/OctoPrint/OctoPrint/issues/3505

#### What does this PR do and why is it necessary?

Introduces an endpoint to unselect the selected file. The attached ticket mentions it being necessary "so that file queuing mechanisms, for example, might be written" and "to simply unselect the currently-selected file if you made a mistake" 

#### How was it tested? How can it be tested by the reviewer?
Started the server and then ran the following. Seemed to work as expected
```
>>> import requests
>>> api_token = ...
>>> my_gcode_file = ...
>>> headers = {"Authorization": "Bearer " + api_token}
>>> base_url = "http://localhost:5000/api/files"

# happy path, select and unselect
>>> print(requests.post(f"{base_url}/local/{my_gcode_file}", json={"command": "select"}, headers=headers).content)
b''
>>> print(requests.post(f"{base_url}/local/{my_gcode_file}", json={"command": "unselect"}, headers=headers).content)
b''

# unselect with no file selected
>>> print(requests.post(f"{base_url}/local/{my_gcode_file}", json={"command": "unselect"}, headers=headers).content)
b'Cannot unselect current file when there is no file selected'

# have selected file and try to unselect invalid filename
>>> print(requests.post(f"{base_url}/local/{my_gcode_file}", json={"command": "select"}, headers=headers).content)
b''
>>> print(requests.post(f"{base_url}/local/foo", json={"command": "unselect"}, headers=headers).content)
b'Only the currently selected file can be unselected'
```
