### PR TITLE
✨  Add option to disable cache busting on webcam URL

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -139,6 +139,7 @@ def getSettings():
             "flipH": s.getBoolean(["webcam", "flipH"]),
             "flipV": s.getBoolean(["webcam", "flipV"]),
             "rotate90": s.getBoolean(["webcam", "rotate90"]),
+            "cacheBuster": s.getBoolean(["webcam", "cacheBuster"]),
         },
         "feature": {
             "temperatureGraph": s.getBoolean(["feature", "temperatureGraph"]),
@@ -593,6 +594,8 @@ def _saveSettings(data):
             s.setBoolean(["webcam", "flipV"], data["webcam"]["flipV"])
         if "rotate90" in data["webcam"]:
             s.setBoolean(["webcam", "rotate90"], data["webcam"]["rotate90"])
+        if "cacheBuster" in data["webcam"]:
+            s.setBoolean(["webcam", "cacheBuster"], data["webcam"]["cacheBuster"])
 
     if "feature" in data:
         if "temperatureGraph" in data["feature"]:

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -265,6 +265,7 @@ default_settings = {
             "fps": 25,
         },
         "cleanTmpAfterDays": 7,
+        "cacheBuster": False,
     },
     "gcodeAnalysis": {
         "maxExtruders": 10,

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -688,12 +688,14 @@ $(function () {
 
             var newSrc = self.settings.webcam_streamUrl();
             if (currentSrc != newSrc) {
-                if (newSrc.lastIndexOf("?") > -1) {
-                    newSrc += "&";
-                } else {
-                    newSrc += "?";
+                if (self.settings.webcam_cacheBuster()) {
+                    if (newSrc.lastIndexOf("?") > -1) {
+                        newSrc += "&";
+                    } else {
+                        newSrc += "?";
+                    }
+                    newSrc += new Date().getTime();
                 }
-                newSrc += new Date().getTime();
 
                 self.webcamLoaded(false);
                 self.webcamError(false);

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -165,6 +165,7 @@ $(function () {
         self.webcam_flipH = ko.observable(undefined);
         self.webcam_flipV = ko.observable(undefined);
         self.webcam_rotate90 = ko.observable(undefined);
+        self.webcam_cacheBuster = ko.observable(undefined);
 
         self.feature_temperatureGraph = ko.observable(undefined);
         self.feature_sdSupport = ko.observable(undefined);

--- a/src/octoprint/templates/dialogs/settings/webcam.jinja2
+++ b/src/octoprint/templates/dialogs/settings/webcam.jinja2
@@ -14,6 +14,7 @@
         <div><small><a href="#" class="muted" data-bind="toggleContent: { class: 'fa-caret-right fa-caret-down', parent: '.form-horizontal', container: '.hide' }"><i class="fas fa-caret-right"></i> {{ _('Advanced options') }}</a></small></div>
         <div class="hide">
             {% include "snippets/settings/webcam/webcamStreamTimeout.jinja2" %}
+            {% include "snippets/settings/webcam/webcamCacheBuster.jinja2" %}
         </div>
     </div>
 </form>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamCacheBuster.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamCacheBuster.jinja2
@@ -1,0 +1,11 @@
+<div class="control-group" title="{{ _('Enable the cache buster on the webcam URl')|edq }}">
+    <div class="controls">
+        <label class="checkbox">
+            <input type="checkbox" data-bind="checked: webcam_cacheBuster" id="settings-webcamCacheBuster"> {{ _('Enable Cache buster') }}
+        </label>
+        <span class="help-inline">
+            <span class="label label-warning">{{ _("Warning") }}</span>
+            {{ _("This may cause unpredicatable caching behaviour. Only disable if your webcam server is incompatible and does not work in OctoPrint's UI") }}
+        </span>
+    </div>
+</div>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamCacheBuster.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamCacheBuster.jinja2
@@ -1,11 +1,13 @@
 <div class="control-group" title="{{ _('Enable the cache buster on the webcam URl')|edq }}">
     <div class="controls">
         <label class="checkbox">
-            <input type="checkbox" data-bind="checked: webcam_cacheBuster" id="settings-webcamCacheBuster"> {{ _('Enable Cache buster') }}
+            <input type="checkbox" data-bind="checked: webcam_cacheBuster" id="settings-webcamCacheBuster">
+            {{ _('Enable Cache buster') }}
+            <span class="help-block">
+                <span class="label label-warning">{{ _("Warning") }}</span>
+                {{ _("This may cause unpredictable caching behaviour. Only disable if your webcam server is incompatible and does not work in OctoPrint's UI") }}
+            </span>
         </label>
-        <span class="help-inline">
-            <span class="label label-warning">{{ _("Warning") }}</span>
-            {{ _("This may cause unpredicatable caching behaviour. Only disable if your webcam server is incompatible and does not work in OctoPrint's UI") }}
-        </span>
+
     </div>
 </div>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamStreamUrl.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamStreamUrl.jinja2
@@ -5,6 +5,6 @@
             <input type="text" class="input-block-level" data-bind="value: webcam_streamUrl, valueUpdate: 'afterkeydown'" id="settings-webcamStreamUrl">
             <button class="btn" type="button" data-bind="click: testWebcamStreamUrl, enable: webcam_streamUrl() && !testWebcamStreamUrlBusy(), css: {disabled: !webcam_streamUrl() || testWebcamStreamUrlBusy()}"><i class="fas fa-spinner fa-spin" data-bind="visible: testWebcamStreamUrlBusy"></i> {{ _('Test') }}</button>
         </div>
-        <span class="help-inline">{% trans %}Needs to be reachable from the browser displaying the OctoPrint UI, used to embed the webcam stream into the page.{% endtrans %}</span>
+        <span class="help-block">{% trans %}Needs to be reachable from the browser displaying the OctoPrint UI, used to embed the webcam stream into the page.{% endtrans %}</span>
     </div>
 </div>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adds an advanced option to disable the cache-busting `?1620136984425` or similar added to the webcam URL.

This causes issues with several webcam streamers, notably [ustreamer](https://github.com/pikvm/ustreamer) and also with some reverse proxy setups.

#### How was it tested? How can it be tested by the reviewer?

Manually on my instance, changing the settings about.

#### Any background context you want to provide?

See tickets

#### What are the relevant tickets if any?

Resolves #4107, #3656, #3229 - and has been mentioned on community forums and discord as well.
#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/31997505/117016562-be4d6500-acea-11eb-9783-5636f882b150.png)


#### Further notes

Big thank you to @anonymousThey for funding this issue on ! Though it was a very easy one I had [already looked at doing](https://github.com/OctoPrint/OctoPrint/issues/4107#issuecomment-826399700), so @anonymousThey if you have any other favourite issues to implement feel free to let me know ❤️ 
