### PR TITLE
Fix typo in docs for octoprint.server.api.before_request

### DIFF
--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -1430,7 +1430,7 @@ octoprint.server.api.after_request
 octoprint.server.api.before_request
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-.. py:function:: after_request_handlers_hook(*args, **kwargs)
+.. py:function:: before_request_handlers_hook(*args, **kwargs)
 
    .. versionadded:: 1.3.10
 


### PR DESCRIPTION
Minor change in docs

https://docs.octoprint.org/en/master/plugins/hooks.html#octoprint-server-api-before-request