### PR TITLE
Improve/ignored commands

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -144,6 +144,7 @@ date of first contribution):
   * [Yvan Rodrigues](https://github.com/TwoRedCells)
   * [Elton Law](https://github.com/eltonlaw)
   * ["sparxooo"](https://github.com/sparxooo)
+  * ["Stevil Knevil"](https://github.com/StevilKnevil)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -708,6 +708,11 @@ Use the following settings to configure the serial connection to the printer:
      - M0
      - M1
 
+     # Commands which should not be sent to the printer and just silently ignored.
+     # An example of when you may wish to use this could be useful if you wish to manually change a filament on M600, 
+     # by using that as a Pausing command (below)
+     ignoredCommands:
+
      # Commands which should cause OctoPrint to pause any ongoing prints.
      pausingCommands:
      - M0

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -202,6 +202,7 @@ def getSettings():
             "longRunningCommands": s.get(["serial", "longRunningCommands"]),
             "checksumRequiringCommands": s.get(["serial", "checksumRequiringCommands"]),
             "blockedCommands": s.get(["serial", "blockedCommands"]),
+            "ignoredCommands": s.get(["serial", "ignoredCommands"]),
             "pausingCommands": s.get(["serial", "pausingCommands"]),
             "emergencyCommands": s.get(["serial", "emergencyCommands"]),
             "helloCommand": s.get(["serial", "helloCommand"]),
@@ -766,6 +767,10 @@ def _saveSettings(data):
             data["serial"]["blockedCommands"], (list, tuple)
         ):
             s.set(["serial", "blockedCommands"], data["serial"]["blockedCommands"])
+        if "ignoredCommands" in data["serial"] and isinstance(
+            data["serial"]["ignoredCommands"], (list, tuple)
+        ):
+            s.set(["serial", "ignoredCommands"], data["serial"]["ignoredCommands"])
         if "pausingCommands" in data["serial"] and isinstance(
             data["serial"]["pausingCommands"], (list, tuple)
         ):

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -135,6 +135,7 @@ default_settings = {
         "blacklistedBaudrates": [],
         "longRunningCommands": ["G4", "G28", "G29", "G30", "G32", "M400", "M226", "M600"],
         "blockedCommands": ["M0", "M1"],
+        "ignoredCommands": [],
         "pausingCommands": ["M0", "M1", "M25"],
         "emergencyCommands": ["M112", "M108", "M410"],
         "checksumRequiringCommands": ["M110"],

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -206,6 +206,7 @@ $(function () {
         self.serial_longRunningCommands = ko.observable(undefined);
         self.serial_checksumRequiringCommands = ko.observable(undefined);
         self.serial_blockedCommands = ko.observable(undefined);
+        self.serial_ignoredCommands = ko.observable(undefined);
         self.serial_pausingCommands = ko.observable(undefined);
         self.serial_emergencyCommands = ko.observable(undefined);
         self.serial_helloCommand = ko.observable(undefined);
@@ -1057,6 +1058,9 @@ $(function () {
                     blockedCommands: function () {
                         return splitTextToArray(self.serial_blockedCommands(), ",", true);
                     },
+                    ignoredCommands: function () {
+                        return splitTextToArray(self.serial_ignoredCommands(), ",", true);
+                    },
                     pausingCommands: function () {
                         return splitTextToArray(self.serial_pausingCommands(), ",", true);
                     },
@@ -1258,6 +1262,9 @@ $(function () {
                     },
                     blockedCommands: function (value) {
                         self.serial_blockedCommands(value.join(", "));
+                    },
+                    ignoredCommands: function (value) {
+                        self.serial_ignoredCommands(value.join(", "));
                     },
                     pausingCommands: function (value) {
                         self.serial_pausingCommands(value.join(", "));

--- a/src/octoprint/templates/dialogs/settings/serialconnection.jinja2
+++ b/src/octoprint/templates/dialogs/settings/serialconnection.jinja2
@@ -402,6 +402,13 @@
                     </div>
                 </div>
                 <div class="control-group">
+                    <label class="control-label" for="settings-serialIgnoredCommands">{{ _('Ignored commands') }}</label>
+                    <div class="controls">
+                        <input type="text" class="input-block-level" id="settings-serialIgnoredCommands" data-bind="value: serial_ignoredCommands">
+                        <span class="help-inline">{{ _('Use this to specify commands that should be silently ignored and never be sent to the printer. Just the G or M code, comma separated. Unlike blocked commands above, there will be no warning popup when these commands are encountered.') }}</span>
+                    </div>
+                </div>
+                <div class="control-group">
                     <label class="control-label" for="settings-serialPausingCommands">{{ _('Pausing commands') }}</label>
                     <div class="controls">
                         <input type="text" class="input-block-level" id="settings-serialPausingCommands" data-bind="value: serial_pausingCommands">

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -645,6 +645,7 @@ class MachineCom(object):
             ["serial", "checksumRequiringCommands"]
         )
         self._blocked_commands = settings().get(["serial", "blockedCommands"])
+        self._ignored_commands = settings().get(["serial", "ignoredCommands"])
         self._pausing_commands = settings().get(["serial", "pausingCommands"])
         self._emergency_commands = settings().get(["serial", "emergencyCommands"])
         self._sanity_check_tools = settings().getBoolean(["serial", "sanityCheckTools"])
@@ -5294,6 +5295,21 @@ class MachineCom(object):
                         "command": cmd,
                         "message": message,
                         "severity": "warn",
+                    },
+                )
+                return (None,)
+            if gcode in self._ignored_commands:
+                message = "Not sending {} to printer, it's configured as an ignored command".format(
+                    gcode
+                )
+                self._log("Info: " + message)
+                self._logger.info(message)
+                eventManager().fire(
+                    Events.COMMAND_SUPPRESSED,
+                    {
+                        "command": cmd,
+                        "message": message,
+                        "severity": "info",
                     },
                 )
                 return (None,)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Added **Ignored Commands** to the Serial Protocol settings
This is an exact duplicate of the _Blocked Commands_ setting except that emitted event is severity `info` not `warn`. The result of this is that there isn't a red popup displayed when the GCode is encountered, the information is just logged to the logfile.

This is important if you are intentionally producing GCode that contains codes that your printer cannot handle (e.g `M600` for filament change on a printer with a single extruder - see below for further context)

#### How was it tested? How can it be tested by the reviewer?
Change the blocked commands to be `M0` and the ignored command to be `M1`. Sending `M0` and `M1` in the terminal should have exactly the same effect, except that there should be no popup for the `M1` command

#### Any background context you want to provide?
To generate multicolour prints, I can specfiy that my printer has 2 extruders so that the sliced GCode will contain command like
```
...
M600 ; Filament Change
T1 ; Tool change
...
```
The physical printer only has a single extruder, so I can set `M600` as a pausing command (with a GCODE script to move the head safe) and manually perform a filament change.
However the M600 and T1 commands in the sliced GCode will cause scary red popups to appear in the octoprint window, despite them being entirely expected and allowed for. Setting M600 and T1 as _ignored commands_ (rather than _blocked commands_) will avoid the popups being displayed

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/1076923/117337024-c8ab6280-ae94-11eb-8e25-90d3809917aa.png)

#### Further notes
Note that by default no GCode commands are set as _Ignored Commands_