### PR TITLE
💄  Remove smaller button in software update

### DIFF
--- a/src/octoprint/plugins/softwareupdate/templates/softwareupdate_settings.jinja2
+++ b/src/octoprint/plugins/softwareupdate/templates/softwareupdate_settings.jinja2
@@ -73,7 +73,7 @@
 <div class="pull-right">
     <button class="btn btn-primary" data-bind="click: function() { $root.updateAll(); }, enable: enableUpdateAll, css: {disabled: !enableUpdateAll}"><i class="fas fa-spinner fa-spin" data-bind="visible: updateInProgress"></i> {{ _('Update all') }}</button>
     <button class="btn" data-bind="click: function() { $root.performCheck(true, false, true); }, enable: !checking(), css: {disabled: checking()}"><i class="fas fa-spinner fa-spin" data-bind="visible: checking"></i> {{ _('Check for updates') }}</button>
-    <button class="btn btn-small" data-bind="click: function() { $root.showPluginSettings(); }" title="{{ _('Plugin Configuration')|edq }}"><i class="fas fa-wrench"></i></button>
+    <button class="btn" data-bind="click: function() { $root.showPluginSettings(); }" title="{{ _('Plugin Configuration')|edq }}"><i class="fas fa-wrench"></i></button>
 </div>
 
 <h3>{{ _('Current versions') }}</h3>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Adjust sizing of configuration button in software update plugin.

#### How was it tested? How can it be tested by the reviewer?

Looked at it, nothing else

#### Any background context you want to provide?

None

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

Before:
![image](https://user-images.githubusercontent.com/31997505/117510657-5e71eb00-af84-11eb-93c5-bcce9a5762f8.png)

With this change:
![image](https://user-images.githubusercontent.com/31997505/117510601-48642a80-af84-11eb-8e75-7b260e9eec08.png)

Alternative solution:
![image](https://user-images.githubusercontent.com/31997505/117510565-34202d80-af84-11eb-9193-d0fac611b667.png)

#### Further notes

Small PRs are great PRs, but in this case it annoyed me so I thought it might annoy someone else... Let's hope it's not just me.