### PR TITLE
⚡ Don't re-render the plugin repository if notmodified

### DIFF
--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -693,11 +693,15 @@ $(function () {
             }
 
             OctoPrint.plugins.pluginmanager
-                .getRepository(!!options.refresh)
+                .getRepository(!!options.refresh, {ifModified: true})
                 .fail(function () {
                     deferred.reject();
                 })
-                .done(function (data) {
+                .done(function (data, status, xhr) {
+                    // Don't update if cached - requires ifModified: true to pass through
+                    // the 304 status, otherwise it fakes it and produces 200 all the time.
+                    if (xhr.status === 304) return;
+
                     self.fromRepositoryResponse(data.repository);
                     self.online(data.online !== undefined ? data.online : true);
                     deferred.resolveWith(data);


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Don't re-render the plugin repository if the server responds with `notmodified`. This shaves ~500ms off the total processing time, making opening the settings dialog *lightning fast* ⚡.

#### How was it tested? How can it be tested by the reviewer?

Using the performance profiler, first I identified the issue, then opened and closes the settings dialogs *several* times, to make sure this change was effective.

#### Any background context you want to provide?

General push to improve UI performance, started with the animations, onto the data processing...

#### What are the relevant tickets if any?

Closes #4131 

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/31997505/117578872-6e0a4480-b0e8-11eb-8682-b02b87b59d6e.png)
Look, barely a dropped frame...

Comparison to *before* this change:
![117578894-824e4180-b0e8-11eb-81c0-5380ecaad93a](https://user-images.githubusercontent.com/31997505/117578938-b590d080-b0e8-11eb-9902-a31a390353d4.png)


#### Further notes

Ok, now another question. I noticed some of the other endpoints that are processed repeatedly like this, and wondered if it would make sense to implement the same thing?

It *has* to be on a per-request basis, since adding `ifModified: true` to all request options breaks handlers that are not expecting an empty response.
