### PR TITLE
🐛 Fix SameSite=None cookie

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -904,9 +904,9 @@ Use the following settings to configure the server:
 
      # Settings for further configuration of the cookies that OctoPrint sets (login, remember me, ...)
      cookies:
-       # SameSite setting to use on the cookies. Possible values are None, Lax and Strict. Defaults to None but
-       # be advised that browsers will soon force this to Lax unless also being set as Secure and served over
-       # https, which will cause issues with embedding OctoPrint in frames.
+       # SameSite setting to use on the cookies. Possible values are None, Lax and Strict. Defaults to not set but
+       # be advised that many browsers now default to Lax unless set as Secure, explicitly setting the cookie type
+       # here and served over https, which causes issues with embedding OctoPrint in frames.
        #
        # See also https://www.chromestatus.com/feature/5088147346030592,
        # https://www.chromestatus.com/feature/5633521622188032 and issue #3482

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -567,8 +567,10 @@ class OctoPrintFlaskResponse(flask.Response):
         if samesite is not None:
             samesite = samesite.lower()
         if samesite == "none":
-            samesite = None
-        if samesite not in (None, "strict", "lax"):
+            # Must be string "None"
+            samesite = "None"
+        if samesite not in ("None", "strict", "lax"):
+            # If NoneType, the cookie is not set
             samesite = None
         kwargs["samesite"] = samesite
 

--- a/tests/server/util/test_flask.py
+++ b/tests/server/util/test_flask.py
@@ -503,7 +503,7 @@ class OctoPrintFlaskResponseTest(unittest.TestCase):
 
     @data(
         [None, None, False, None, None],
-        [None, None, False, "none", None],
+        [None, None, False, "none", "None"],
         [None, None, False, "lax", "lax"],
         [None, None, False, "StRiCt", "strict"],
         [None, None, False, "INVALID", None],


### PR DESCRIPTION
When passing Python's NoneType down to Werkzeug, it uses this logic:

```python
if samesite is not None:
    samesite = samesite.title()

    if samesite not in {"Strict", "Lax", "None"}:
        raise ValueError("SameSite must be 'Strict', 'Lax', or 'None'.")
```

This means that when OctoPrint converted any strings 'None' into NoneType,
they would not show up in the Set-Cookie header.

Investigation: https://community.octoprint.org/t/unable-to-log-into-octoprint-through-an-iframe-on-home-assistant/33977/20?u=charlie_powell

Link to werkzeug source: https://github.com/pallets/werkzeug/blob/1dde4b1790f9c46b7122bb8225e6b48a5b22a615/src/werkzeug/http.py#L1213-L1217

Docs, while not explicitly clear, here: https://werkzeug.palletsprojects.com/en/1.0.x/http/?highlight=dump_cookie#werkzeug.http.dump_cookie


#### What does this PR do and why is it necessary?

Adjusts the cookie-setting behaviour so that setting `SameSite=None` is possible.

#### How was it tested? How can it be tested by the reviewer?

Analysing the headers in the responses, to ensure this was visible.

The unit tests had to be adjusted, since they were testing the function worked as expected but not far enough into what the end result was.

#### Any background context you want to provide?

See links above, but also https://web.dev/samesite-cookies-explained/ which helped me to understand what I was looking for here.

#### What are the relevant tickets if any?

See forum link

#### Screenshots (if appropriate)

None

#### Further notes

I think I got this one right, but it needs a good look to double check that my logic is OK. I was never able to get the SameSite=None to show up in Set-Cookie without this change, now it should work OK.
