### PR TITLE
Added browser user agent string to tracking data

### DIFF
--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -133,6 +133,7 @@ class Events(object):
 
     # Settings
     SETTINGS_UPDATED = "SettingsUpdated"
+    SETTINGS_LOADED = "SettingsLoaded"
 
     @classmethod
     def register_event(cls, event, prefix=None):

--- a/src/octoprint/plugins/tracking/templates/snippets/plugins/tracking/trackingDescription.jinja2
+++ b/src/octoprint/plugins/tracking/templates/snippets/plugins/tracking/trackingDescription.jinja2
@@ -1,7 +1,7 @@
 {% trans %}
 <p>
     Anonymous usage tracking provides valuable insights into how many instances running what versions of OctoPrint are out there,
-    whether they are successfully completing print jobs and various other metrics.
+    whether they are successfully completing print jobs and various other metrics including what browser versions are accessing them.
 </p>
 <p>
     By enabling it you help to identify problems with new releases and release candidates early on, and to better

--- a/src/octoprint/plugins/tracking/templates/tracking_settings.jinja2
+++ b/src/octoprint/plugins/tracking/templates/tracking_settings.jinja2
@@ -26,6 +26,9 @@
                 <input type="checkbox" data-bind="checked: settings.plugins.tracking.events.pong"> {{ _('Regular pong every 24h (incl. plugin list)') }}
             </label>
             <label class="checkbox">
+                <input type="checkbox" data-bind="checked: settings.plugins.tracking.events.user_agent_collection"> {{ _('Add most recent web browser version details (user agent) to pong') }}
+            </label>
+            <label class="checkbox">
                 <input type="checkbox" data-bind="checked: settings.plugins.tracking.events.startup"> {{ _('Server startup & shutdown') }}
             </label>
             <label class="checkbox">

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -18,6 +18,7 @@ from octoprint.server import pluginManager, printer, userManager
 from octoprint.server.api import NO_CONTENT, api
 from octoprint.server.util.flask import no_firstrun_access, with_revalidation_checking
 from octoprint.settings import settings, valid_boolean_trues
+from octoprint.events import Events, eventManager
 
 # ~~ settings
 
@@ -330,6 +331,10 @@ def getSettings():
     plugin_settings = _get_plugin_settings()
     if len(plugin_settings):
         data["plugins"] = plugin_settings
+
+    eventManager().fire(
+        Events.SETTINGS_LOADED, payload={"user_agent": request.user_agent}
+    )
 
     return jsonify(data)
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [n/a] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [n/a] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [not really as I don't have access to tracking.octoprint.org to my knowledge] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [sorry, no, kind of did this one a bit blind I'm afraid and hoped interested folk wouldn't mind checking it over] You have run the existing unit tests against your changes and
    nothing broke
  * [oh... er... I hadn't really figured something so small would earn me such a credit] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR updates the pong tracking data to include the user agent of the most recent browser to have loaded the web interface.

As a plugin developer, I found myself wondering from time to time what browser compatibility coverage I should factor in.  My assumption is everyone is using modern browsers but with such a community of hackers, I wasn't sure I should make this assumption, thinking there may be some rather niche setups out there.

I tried to find this information on https://tracking.octoprint.org and https://data.octoprint.org but found that it was not available.  This is presumably because thus far only server instance information has been tracked rather than any information about the devices being used to access said instances.

Whilst this information I suppose could technically have been collected in a plugin of some form, I just couldn't see anyone really being motivated to download it with the few who did download it likely being curious developers themselves and so skewing the dataset.

#### How was it tested? How can it be tested by the reviewer?

I'm afraid I don't have the knowledge or confidence to test properly and am just hoping someone with the skill and expertise needed will be interested enough in this feature to test as appropriate... sorry :(

#### Any background context you want to provide?

#### What are the relevant tickets if any?

I couldn't see any but I may have missed something.

#### Screenshots (if appropriate)

#### Further notes

I've checked the wording of the tracking consent sections and updated where appropriate as well as ensured there is a new opt out checkbox for the user agent.

I'm also confident this won't fall foul of the EU cookie law or GDPR in any way as it doesn't collect any kind of identifiable information, nor does it use cookies in anyway.  Indeed, the only thing it collects is the user agent string, which will in almost all cases be identical to thousands of other user agent strings used daily, so unless someone has really gone out of their way to make their user own user agent utterly unique, I can't see how such data would apply to any data protection laws.
