### PR TITLE
Fix nonce format in stream URL on control page

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -689,9 +689,9 @@ $(function () {
             var newSrc = self.settings.webcam_streamUrl();
             if (currentSrc != newSrc) {
                 if (newSrc.lastIndexOf("?") > -1) {
-                    newSrc += "&";
+                    newSrc += "&nonce=";
                 } else {
-                    newSrc += "?";
+                    newSrc += "?nonce=";
                 }
                 newSrc += new Date().getTime();
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Resolve issues with the "cache buster" appended to the stream URL on the control page.

For some streaming tools, the camera works in the settings pages but not on the control page because of the timestamp being added to the URL is not a param=value format. 

#### How was it tested? How can it be tested by the reviewer?

After changing the format of the parameters added to the query string, the streaming image appears on the control page.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

Posts on the community board related to the issue:

https://community.octoprint.org/t/another-webcam-issue-looks-like-its-changing-the-url/9440/15

https://community.octoprint.org/t/webcam-works-when-testing-but-not-in-control-tab/10847

#### Screenshots (if appropriate)


#### Further notes


