### PR TITLE
🐛 Missed dialog for fade in

### DIFF
--- a/src/octoprint/templates/dialogs/settings.jinja2
+++ b/src/octoprint/templates/dialogs/settings.jinja2
@@ -55,7 +55,7 @@
     </div>
 </div>
 
-<div id="settings_dialog_update_detected" class="modal hide fade" data-keyboard="false">
+<div id="settings_dialog_update_detected" class="modal hide fade-in" data-keyboard="false">
     <div class="modal-header">
         <h3>{{ _('Settings update detected') }}</h3>
     </div>


### PR DESCRIPTION
Missed the 'reload settings' dialog when sorting out the animations, seems I just missed the one so far in testing

#### What does this PR do and why is it necessary?

Updates the animation so it is not a stuttering mess

#### How was it tested? How can it be tested by the reviewer?

Making the dialog open manually using it's selector in the console

#### Any background context you want to provide?

#4103 & #4085 

#### What are the relevant tickets if any?

Above

#### Screenshots (if appropriate)

#### Further notes
