### PR TITLE
⬆️ Upgrade Tornado for Python 3 only

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,6 @@ INSTALL_REQUIRES = [
     # introduce backwards incompatible changes that might affect plugins, or due to
     # other observed problems
     "markupsafe>=1.1,<2.0",  # Jinja dependency, newer versions require Python 3
-    "tornado==5.1.1",  # newer versions require Python 3
     "markdown>=3.1,<3.2",  # newer versions require Python 3
     "regex!=2018.11.6",  # avoid broken 2018.11.6. See #2874
     # anything below this should be checked on releases for new versions
@@ -70,6 +69,7 @@ INSTALL_REQUIRES = [
 # Python 2 specific requirements
 INSTALL_REQUIRES_PYTHON2 = [
     "feedparser>=5.2.1,<6",  # newer versions require Python 3
+    "tornado==5.1.1",  # newer versions require Python 3
     "futures>=3.3,<4",
     "monotonic>=1.5,<2",
     "scandir>=1.10,<2",
@@ -82,6 +82,7 @@ INSTALL_REQUIRES_PYTHON2 = [
 # Python 3 specific requirements
 INSTALL_REQUIRES_PYTHON3 = [
     "feedparser>=6.0.2,<7",
+    "tornado>=6,<7",  # tornado < 6 is incompatible with Python 3.10
     "zeroconf>=0.24,<0.25",
     "immutabledict>=1.2.0,<2",
     "pathvalidate>=2.4.1,<3",


### PR DESCRIPTION
Python 3.10 introduces a backwards incompatible change around collections and collections.abcs, which tornado was impacted by.

According to Tornado's release notes https://www.tornadoweb.org/en/stable/releases/v6.0.0.html seem like there is not much else to worry about, and the devel branch has already  upgraded it.

Would be good to get this tested by someone else using Python 3.10 and some plugins, and also some Python 2 installs.

See also #4043 for the other collections-related changes.

#### What does this PR do and why is it necessary?

Upgrade tornado for Python 3 only

#### How was it tested? How can it be tested by the reviewer?

Installing Python 3.10 beta 3, installing OctoPrint, running the server

#### Any background context you want to provide?

#4043, [Tornado's release notes](https://www.tornadoweb.org/en/stable/releases/v6.0.0.html), and [Python 3.10's changes](https://docs.python.org/3.10/whatsnew/3.10.html), [bpo-37324](https://bugs.python.org/issue37324). Been a long time coming but it is on it's way...

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

None

#### Further notes

None