### PR TITLE
✏️ 🐛 Fix a variety of doc issues

### DIFF
--- a/docs/api/access.rst
+++ b/docs/api/access.rst
@@ -81,7 +81,7 @@ Retrieve a group
 
    Retrieves an individual group record.
 
-   Will return a :http:statuscode:`200` with a :ref:`group record <sec-api-access-datamodel-groups-grouprecord>`
+   Will return a :http:statuscode:`200` with a :ref:`group record <sec-api-access-datamodel-groups-list>`
    as body.
 
    Requires the ``SETTINGS`` permission.
@@ -156,7 +156,7 @@ Retrieve a user
 
    Retrieves information about a user.
 
-   Will return a :http:statuscode:`200` with a :ref:`user record <sec-api-access-datamodel-users-userrecord>`
+   Will return a :http:statuscode:`200` with a :ref:`user record <sec-api-datamodel-access>`
    as body.
 
    Requires either the ``SETTINGS`` permission or to be logged in as the user.

--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -596,7 +596,7 @@ Permission record
      - Human readable description of the permission
    * - ``needs``
      - 1
-     - :ref:`Needs object <sec-api-access-datamodel-general-needs>`
+     - :ref:`Needs object <sec-api-datamodel-access-needs>`
      - Needs assigned to the permission
 
 .. _sec-api-datamodel-access-groups:

--- a/docs/api/general.rst
+++ b/docs/api/general.rst
@@ -44,8 +44,7 @@ For testing purposes it is also possible to supply the API key via a query param
 Please be advised that clients should use the header field variant if at all possible.
 
 If the key is missing or invalid, OctoPrint will treat the request as it would any unauthenticated anonymous request to the endpoint.
-Consequently, if the bundled :ref:`ForceLogin plugin <sec-bundledplugins-forcelogin>` is active (which is the default), that means
-that any requests without or with an invalid API key targeting other API endpoints than :ref:`Login <sec-api-general-login>`
+That means that any requests without or with an invalid API key targeting other API endpoints than :ref:`Login <sec-api-general-login>`
 will be denied with a :http:statuscode:`403`.
 
 .. warning::

--- a/docs/api/version.rst
+++ b/docs/api/version.rst
@@ -8,7 +8,7 @@ Version information
 
    Retrieve information regarding server and API version. Returns a JSON object with three keys, ``api`` containing
    the API version, ``server`` containing the server version, ``text`` containing the server version including
-   the prefix ``OctoPrint `` (to determine that this is indeed a genuine OctoPrint instance).
+   the prefix ``OctoPrint`` (to determine that this is indeed a genuine OctoPrint instance).
 
    **Example Request**
 

--- a/docs/bundledplugins/action_command_notification.rst
+++ b/docs/bundledplugins/action_command_notification.rst
@@ -39,12 +39,10 @@ Supported action commands
 notification <message>
     Displays the notification ``<message>``
 
-.. _sec-bundledplugins-action_command_prompt-example:
+.. _sec-bundledplugins-action_command_notification-example:
 
 Example communication with the firmware
 ---------------------------------------
-
-.. _sec-bundledplugins-action_command_prompt-sourcecode:
 
 To display the :ref:`above notification <fig-bundledplugins-action_command_notification-example>` the firmware sent this action command:
 

--- a/docs/bundledplugins/discovery.rst
+++ b/docs/bundledplugins/discovery.rst
@@ -118,8 +118,7 @@ Announced Services
 ZeroConf Service ``_http._tcp``
 +++++++++++++++++++++++++++++++
 
-If :ref:`pybonjour <sec-bundledplugins-discovery-firststeps-pybonjour>` is
-correctly installed, OctoPrint will announce itself on the network via ZeroConf
+OctoPrint will announce itself on the network via ZeroConf
 as service ``_http._tcp``, with the TXT record containing the standard fields.
 
 See also `this documentation of _http._tcp TXT records <http://www.dns-sd.org/txtrecords.html>`_
@@ -130,8 +129,7 @@ for more information.
 ZeroConf Service ``_octoprint._tcp``
 ++++++++++++++++++++++++++++++++++++
 
-If :ref:`pybonjour <sec-bundledplugins-discovery-firststeps-pybonjour>` is
-correctly installed, OctoPrint will announce itself on the network via ZeroConf
+OctoPrint will announce itself on the network via ZeroConf
 as service ``_octoprint._tcp``. The TXT record may contain the following fields:
 
   * ``path``: path prefix to actual OctoPrint instance, inherited from ``_http._tcp``

--- a/docs/bundledplugins/index.rst
+++ b/docs/bundledplugins/index.rst
@@ -20,6 +20,5 @@ Bundled Plugins
    gcodeviewer.rst
    logging.rst
    pluginmanager.rst
-   printer_safety_check.rst
    softwareupdate.rst
    virtual_printer.rst

--- a/docs/bundledplugins/softwareupdate.rst
+++ b/docs/bundledplugins/softwareupdate.rst
@@ -197,20 +197,24 @@ types are currently recognized:
     * ``prerelease``: ``True`` or ``False``, default ``False``, set to
       ``True`` to also include releases on Github marked as prerelease.
     * ``prerelease_branches``: Prerelease channel definitions, optional. List of:
+
       * ``branch``: Branch associated with the channel, acts as ID
       * ``name``: Human readable name of the release channel
       * ``commitish``: List of values to check against ``target_commitish``
         field in Github release data - release will only be included if the
         values match. Defaults to being unset, in which case the ``branch``
         will be matched.
+
       .. versionadded:: 1.2.16
     * ``stable_branch``: Stable channel definition, optional. Structure:
+
       * ``branch``: Branch associated with the channel, acts as ID
       * ``name``: Human readable name of the release channel
       * ``commitish``: List of values to check against ``target_commitish``
         field in Github release data - release will only be included if the
         values match. Defaults to being unset, in which case the ``branch``
         will be matched.
+
       .. versionadded:: 1.2.16
     * ``prerelease_channel``: Release channel to limit updates to. If set only
       those releases will be included if their ``target_commitish`` matches
@@ -218,6 +222,7 @@ types are currently recognized:
       included in ``prerelease_channels`` or the ``stable_channel``. Only
       taken into account if ``prerelease`` is ``true``.
       .. versionadded:: 1.2.16
+
     * ``release_compare``: Method to use to compare between current version
       information and release versions on Github. One of ``python`` (version
       comparison using ``pkg_resources.parse_version``, newer version detected

--- a/docs/bundledplugins/tracking.rst
+++ b/docs/bundledplugins/tracking.rst
@@ -35,7 +35,7 @@ The plugin supports the following configuration keys:
     * ``plugin``: Whether to track plugin related events (install, uninstall, ...)
     * ``update``: Whether to track update related events (update successful or not, ...)
     * ``printer``: Whether to track printer related events (connected, firmware, ...)
-    * ``printer_safety_check``: Whether to track warnings of the :ref:`Printer Safety Check <sec-bundledplugins-printer_safety_check>`
+    * ``printer_safety_check``: Whether to track warnings of the Printer Safety Check plugin
     * ``throttled``: Whether to track throttle events detected on the underlying system
 
 .. _sec-bundledplugins-tracking-sourcecode:

--- a/docs/jsclientlib/index.rst
+++ b/docs/jsclientlib/index.rst
@@ -89,10 +89,6 @@ connection options (``baseurl`` and ``apikey``) directly in the constructor or s
    :ref:`Application Key Plugin <sec-bundledplugins-appkeys>`
        A bundled plugin that implements an authorization workflow for third party clients. It adds various additional
        methods to the JS Client Library.
-   :ref:`ForceLogin Plugin <sec-bundledplugins-forcelogin>`
-       A bundled plugin that disables anonymous access to the regular OctoPrint UI by implementing a custom UI and
-       various hooks. Utilizes the client library's :ref:`browser component <sec-jsclientlib-browser>` to login the
-       user.
 
 .. toctree::
    :maxdepth: 3

--- a/docs/modules/plugin.rst
+++ b/docs/modules/plugin.rst
@@ -4,7 +4,6 @@ octoprint.plugin
 ----------------
 
 .. automodule:: octoprint.plugin
-   :members:
 
 .. _sec-modules-plugin-core:
 
@@ -12,7 +11,6 @@ octoprint.plugin.core
 ---------------------
 
 .. automodule:: octoprint.plugin.core
-   :members:
 
 .. _sec-modules-plugin-types:
 
@@ -20,4 +18,3 @@ octoprint.plugin.types
 ----------------------
 
 .. automodule:: octoprint.plugin.types
-   :members:

--- a/docs/modules/printer.rst
+++ b/docs/modules/printer.rst
@@ -4,7 +4,6 @@ octoprint.printer
 -----------------
 
 .. automodule:: octoprint.printer
-   :members:
 
 .. _sec-modules-printer-profile:
 
@@ -12,4 +11,3 @@ octoprint.printer.profile
 -------------------------
 
 .. automodule:: octoprint.printer.profile
-   :members:

--- a/docs/modules/settings.rst
+++ b/docs/modules/settings.rst
@@ -4,4 +4,3 @@ octoprint.settings
 ------------------
 
 .. automodule:: octoprint.settings
-   :members:

--- a/docs/modules/slicing.rst
+++ b/docs/modules/slicing.rst
@@ -4,7 +4,6 @@ octoprint.slicing
 -----------------
 
 .. automodule:: octoprint.slicing
-   :members:
 
 .. _sec-modules-slicing-exceptions:
 
@@ -12,4 +11,3 @@ octoprint.slicing.exceptions
 ----------------------------
 
 .. automodule:: octoprint.slicing.exceptions
-   :members:

--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -931,7 +931,7 @@ octoprint.comm.transport.serial.additional_port_names
    .. versionadded:: 1.4.1
 
    Return additional port names (not glob patterns!) to use as a serial connection to the printer. Expected to be
-   ``list`` of ``string``s.
+   ``list`` of ``string``.
 
    Useful in combination with :ref:`octoprint.comm.transport.serial.factory <sec-plugins-hook-comm-transport-serial-factory>`
    to implement custom serial-like ports through plugins.
@@ -1191,7 +1191,7 @@ octoprint.plugin.softwareupdate.check_config
 
 See :ref:`here <sec-bundledplugins-softwareupdate-hooks-check_config>`.
 
-.. _sec-plugins-hooks-plugin-printer-additional_state_data
+.. _sec-plugins-hooks-plugin-printer-additional_state_data:
 
 octoprint.printer.additional_state_data
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -1201,7 +1201,7 @@ octoprint.printer.additional_state_data
    .. versionadded:: 1.5.0
 
    Use this to inject additional data into the data structure returned from the printer backend to the frontend
-   on the push socket or other registered :ref:`~octoprint.printer.PrinterCallback`s. Anything you return here
+   on the push socket or other registered :class:`octoprint.printer.PrinterCallback`. Anything you return here
    will be located beneath ``plugins.<your plugin id>`` in the resulting initial and current data push structure.
 
    The ``initial`` parameter will be ``True`` if this the additional update sent to the callback. Your handler should
@@ -1600,8 +1600,6 @@ octoprint.server.sockjs.register
    Handlers should return either ``True`` or ``False``. ``True`` signals to proceed with normal registration. ``False``
    signals to not register the client.
 
-   See the bundled :ref:`Forcelogin Plugin <sec-bundledplugins-forcelogin>` for an example on how to utilize this.
-
    :param object socket: the socket object which is about to be registered
    :param object user: the user currently authenticated on the socket - might be None
    :return: whether to proceed with registration (``True``) or not (``False``)
@@ -1619,8 +1617,6 @@ octoprint.server.sockjs.emit
    Allows plugins to prevent any messages to be emitted on an existing :ref:`push connection <sec-api-push>`.
 
    Handlers should return either ``True`` to allow the message to be emitted, or ``False`` to prevent it.
-
-   See the bundled :ref:`Forcelogin Plugin <sec-bundledplugins-forcelogin>` for an example on how to utilize this.
 
    :param object socket: the socket object on which a message is about to be emitted
    :param object user: the user currently authenticated on the socket - might be None

--- a/src/octoprint/filemanager/storage.py
+++ b/src/octoprint/filemanager/storage.py
@@ -1169,7 +1169,7 @@ class LocalFileStorage(StorageInterface):
         """
         Raises a :class:`ValueError` for a ``name`` containing ``/`` or ``\\``. Otherwise
         sanitizes the given ``name`` using ``octoprint.files.sanitize_filename``. Also
-        strips leading ``.``s.
+        strips any leading ``.``.
         """
         return sanitize_filename(name, really_universal=self._really_universal)
 

--- a/src/octoprint/filemanager/util.py
+++ b/src/octoprint/filemanager/util.py
@@ -83,7 +83,7 @@ class StreamWrapper(AbstractFileWrapper):
     A wrapper allowing processing of one or more consecutive streams.
 
     Arguments:
-        *streams: One or more :py:`io.IOBase` streams to process one after another to save to storage.
+        *streams: One or more :py:class:`io.IOBase` streams to process one after another to save to storage.
     """
 
     def __init__(self, filename, *streams):
@@ -124,7 +124,7 @@ class MultiStream(io.RawIOBase):
     their contents in the order they are provided to the constructor.
 
     Arguments:
-        *streams: One or more :py:`io.IOBase` streams to concatenate.
+        *streams: One or more :py:class:`io.IOBase` streams to concatenate.
     """
 
     def __init__(self, *streams):

--- a/src/octoprint/plugin/__init__.py
+++ b/src/octoprint/plugin/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module represents OctoPrint's plugin subsystem. This includes management and helper methods as well as the
 registered plugin types.
@@ -14,6 +12,7 @@ registered plugin types.
 .. autoclass:: PluginSettings
    :members:
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 In this module resides the core data structures and logic of the plugin system.
 
@@ -20,6 +18,7 @@ In this module resides the core data structures and logic of the plugin system.
    :members:
 
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module bundles all of OctoPrint's supported plugin implementation types as well as their common parent
 class, :class:`OctoPrintPlugin`.
@@ -17,6 +15,7 @@ Please note that the plugin implementation types are documented in the section
    :members:
 
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module defines the interface for communicating with a connected printer.
 
@@ -16,6 +14,7 @@ abstracted version of the actual printer communication.
 .. autoclass:: PrinterCallback
    :members:
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module contains printer profile related code.
 
@@ -141,6 +139,7 @@ A printer profile is a ``dict`` of the following structure:
 
 .. autoclass:: InvalidProfileError
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module represents OctoPrint's settings management. Within this module the default settings for the core
 application are defined and the instance of the :class:`Settings` is held, which offers getter and setter
@@ -18,6 +16,7 @@ of various types and the configuration file itself.
    :members:
    :undoc-members:
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/slicing/__init__.py
+++ b/src/octoprint/slicing/__init__.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 In this module the slicing support of OctoPrint is encapsulated.
 
@@ -13,6 +11,7 @@ In this module the slicing support of OctoPrint is encapsulated.
 .. autoclass:: SlicingManager
    :members:
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/slicing/exceptions.py
+++ b/src/octoprint/slicing/exceptions.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 Slicing related exceptions.
 
@@ -27,6 +25,7 @@ Slicing related exceptions.
    :show-inheritance:
 
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1,10 +1,10 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module bundles commonly used utility methods or helper classes that are used in multiple places within
 OctoPrint's source code.
 """
+
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"

--- a/src/octoprint/util/platform/__init__.py
+++ b/src/octoprint/util/platform/__init__.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
-from __future__ import absolute_import, division, print_function, unicode_literals
-
 """
 This module bundles platform specific flags and implementations.
 """
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Fix a bunch of documentation issues, reduces the number of warnings shown from 235 to 2.

#### How was it tested? How can it be tested by the reviewer?

Building the docs locally and fixing the raised issues

#### Any background context you want to provide?

None

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

None

#### Further notes

https://github.com/OctoPrint/OctoPrint/commit/cc102f9e81c3116ebbb487ddebecbb339a01db41 - fixes a docstring bug introduced probably when some scripts were adding future imports in the migration to Python 3. Not looked into the origin, but future imports above docstrings break sphinx.

https://github.com/OctoPrint/OctoPrint/commit/70354ec0b30429ee939ded0368a60a6009d97886 - fixes all warnings from sphinx, with the exception of the two pages not in the contents as they were removed.

https://github.com/OctoPrint/OctoPrint/commit/9d8576a2902d52309bc78a620db21a9eae3245ad - fixes the issues introduced by the first commit, where we now have a bunch of duplicate documentations and I ended up with 235 warnings. Now down to just 2. In effect, reverts https://github.com/OctoPrint/OctoPrint/commit/97a82c0cc13bcf936cdd723162ea7cccfb0dccf4, as this didn't actually fix the root issue I don't think.

Note that there is now less on the docs pages for the modules changed here, as not *every* class/function is documented, just those that are mentioned in the module level docstrings