### PR TITLE
Add support for changing hook order

### DIFF
--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -561,6 +561,14 @@ plugins are tracked:
      _forcedCompatible:
      - ...
 
+     # Custom sorting of hooks and implementations provided by plugins. Two-tiered dictionary
+     # structure, plugin identifier mapping to a dictionary of order overrides mapped by
+     # sorting context/hook name
+     _sortingOrder:
+       some_plugin:
+         some_hook: 1
+         some_other_hook: 200
+
      # The rest are individual plugin settings, each tracked by their identifier, e.g.:
      some_plugin:
        some_setting: true

--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -601,6 +601,7 @@ def init_pluginsystem(
     ]
     plugin_entry_points = ["octoprint.plugin"]
     plugin_disabled_list = settings.get(["plugins", "_disabled"])
+    plugin_sorting_order = settings.get(["plugins", "_sortingOrder"], merged=True)
 
     plugin_blacklist = []
     if not ignore_blacklist and settings.getBoolean(
@@ -632,6 +633,7 @@ def init_pluginsystem(
         plugin_folders=plugin_folders,
         plugin_entry_points=plugin_entry_points,
         plugin_disabled_list=plugin_disabled_list,
+        plugin_sorting_order=plugin_sorting_order,
         plugin_blacklist=plugin_blacklist,
         plugin_validators=plugin_validators,
         compatibility_ignored_list=compatibility_ignored_list,

--- a/src/octoprint/plugin/__init__.py
+++ b/src/octoprint/plugin/__init__.py
@@ -39,6 +39,7 @@ def plugin_manager(
     plugin_bases=None,
     plugin_entry_points=None,
     plugin_disabled_list=None,
+    plugin_sorting_order=None,
     plugin_blacklist=None,
     plugin_restart_needing_hooks=None,
     plugin_obsolete_hooks=None,
@@ -64,6 +65,8 @@ def plugin_manager(
             this defaults to the entry point ``octoprint.plugin``.
         plugin_disabled_list (list): A list of plugin identifiers that are currently disabled. If not provided this
             defaults to all plugins for which ``enabled`` is set to ``False`` in the settings.
+        plugin_sorting_order (dict): A dict containing a custom sorting orders for plugins. The keys are plugin identifiers,
+            mapped to dictionaries containing the sorting contexts as key and the custom sorting value as value.
         plugin_blacklist (list): A list of plugin identifiers/identifier-requirement tuples
             that are currently blacklisted.
         plugin_restart_needing_hooks (list): A list of hook namespaces which cause a plugin to need a restart in order
@@ -121,6 +124,7 @@ def plugin_manager(
                 plugin_entry_points,
                 logging_prefix="octoprint.plugins.",
                 plugin_disabled_list=plugin_disabled_list,
+                plugin_sorting_order=plugin_sorting_order,
                 plugin_blacklist=plugin_blacklist,
                 plugin_restart_needing_hooks=plugin_restart_needing_hooks,
                 plugin_obsolete_hooks=plugin_obsolete_hooks,

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -2144,6 +2144,12 @@ class PluginManager:
                 else:
                     sorting_value = self.default_order
 
+                override = self.plugin_sorting_order.get(impl[0], {}).get(
+                    sorting_context, None
+                )
+                if override:
+                    sorting_value = override
+
             plugin_info = self.get_plugin_info(impl[0], require_enabled=False)
             return (
                 sv(sorting_value),

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -438,7 +438,7 @@ default_settings = {
             "regex": r"Recv: (echo:\s*)?busy:\s*processing",
         },
     ],
-    "plugins": {"_disabled": [], "_forcedCompatible": []},
+    "plugins": {"_disabled": [], "_forcedCompatible": [], "_sortingOrder": {}},
     "scripts": {
         "gcode": {
             "afterPrintCancelled": "; disable motors\nM84\n\n;disable all heaters\n{% snippet 'disable_hotends' %}\n{% snippet 'disable_bed' %}\n;disable fan\nM106 S0",


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Allows the user to override the hook order value for plugins. Useful in cases where one plugin hook might need to be executed before another but they have conflicting order values.

#### How was it tested? How can it be tested by the reviewer?
Config:
Each plugin can have an additional key called '_hook_order_overrides' which contains a subkey for each hook ID.

Example:
```
  softwareupdate:
    _hook_order_overrides:
      octoprint.access.permissions: 11
      octoprint.events.register_custom_events: 99
```

UI:
Settings -> Plugin Manager -> Hook Order (See screenshot)

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots
![image](https://user-images.githubusercontent.com/1585573/125954158-b129ab87-2bba-4b2f-9251-69b720a656c3.png)

#### Further notes
I'm sure the JS side of things can be optimized better. Pointers appreciated.

I wasn't sure the best way to display what the computed default was in the UI. I just labeled it as "Definition". Originally I called it "Original" and displayed the order number instead of the value or "Default". Thoughts?

I used ` _hook_order_overrides` as the config key name but if there is something better/shorter you'd prefer let me know. Same goes for the blueprint path or anything else for the matter.

There are two(2) TODO lines which maybe you can answer:
1. https://github.com/kantlivelong/OctoPrint/blob/08a26d76bcd4f5a957658211e5cdb6cbb34e8079/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js#L584
2. https://github.com/kantlivelong/OctoPrint/blob/08a26d76bcd4f5a957658211e5cdb6cbb34e8079/src/octoprint/plugins/pluginmanager/__init__.py#L717
