### PR TITLE
Add filament change events

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -146,6 +146,7 @@ date of first contribution):
   * ["sparxooo"](https://github.com/sparxooo)
   * ["Stevil Knevil"](https://github.com/StevilKnevil)
   * [ldursw](https://github.com/ldursw)
+  * [Ian Wilt](https://github.com/ianwiltdotcom)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -608,7 +608,7 @@ EStop
    An ``M112`` was sent to the printer through OctoPrint (not triggered when printing from SD!)
 
 FilamentChange
-  An ''M600'', ''M701'' or ''M702'' was sent to the printer through OctoPrint (not triggered when printing from SD!)
+  An ``M600``, ``M701`` or ``M702`` was sent to the printer through OctoPrint (not triggered when printing from SD!)
 
 
 PositionUpdate

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -607,6 +607,10 @@ Eject
 EStop
    An ``M112`` was sent to the printer through OctoPrint (not triggered when printing from SD!)
 
+FilamentChange
+  An ''M600'', ''M701'' or ''M702'' was sent to the printer through OctoPrint (not triggered when printing from SD!)
+
+
 PositionUpdate
    The response to an ``M114`` was received by OctoPrint. The payload contains the current position information
    parsed from the response and (in the case of the selected tool ``t`` and the current feedrate ``f``) tracked

--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -106,6 +106,7 @@ class Events(object):
     REGISTERED_MESSAGE_RECEIVED = "RegisteredMessageReceived"
     COMMAND_SUPPRESSED = "CommandSuppressed"
     INVALID_TOOL_REPORTED = "InvalidToolReported"
+    FILAMENT_CHANGE = "FilamentChange"
 
     # Timelapse
     CAPTURE_START = "CaptureStart"

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -301,6 +301,10 @@ gcodeToEvent = {
     # motors on/off
     "M80": Events.POWER_ON,
     "M81": Events.POWER_OFF,
+    # filament change
+    "M600": Events.FILAMENT_CHANGE,
+    "M701": Events.FILAMENT_CHANGE,
+    "M702": Events.FILAMENT_CHANGE,
 }
 
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Adds Gcode processing events for M600, M701, M702 (Filament Change, Load filament, Unload filament) as a new event FilamentChange. Also added a description to the relevant documentation page.

#### How was it tested? How can it be tested by the reviewer?

Built everything into a virtual environment and nothing broke. Set up OctoPrint server. Connected to a virtual printer with the Virtual Printer plugin, turned on debug logs for octoprint.events.fire, and entered M600, M701 and M702 to the terminal. Each Gcode fired the event.

#### Any background context you want to provide?

I forked OctoText because I wanted to get notifications for when I needed to change the filament while printing, and realized that it listens to Gcode events. However, I realized I couldn't possibly make changes to that plugin as needed because there's no event that's fired for filament change related Gcode.

#### What are the relevant tickets if any?

https://github.com/OctoPrint/OctoPrint/issues/2888

#### Further notes

This is my first pull request ever so please let me know if I made any mistakes or anything. I tried my best :)
