### PR TITLE
✏️ Additional file information properties documented

### DIFF
--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -365,6 +365,14 @@ Files
      - 0..1
      - :ref:`GCODE analysis information <sec-api-datamodel-files-gcodeanalysis>`
      - Information from the analysis of the GCODE file, if available. Left out in abridged version.
+   * - ``prints``
+     - 0..1
+     - :ref:`Print history information <sec-api-datamodel-files-prints>`
+     - Information about previous prints of the file. Left out if the file has never been printed.
+   * - ``statistics``
+     - 0..1
+     - :ref:`Print statistics information <sec-api-datamodel-files-stats>`
+     - Statistics about the file, based on the previous print times. Left out if the file has never been printed.
 
 .. _sec-api-datamodel-files-fileabridged:
 
@@ -505,6 +513,62 @@ References
      - URL
      - The model from which this file was generated (e.g. an STL, currently not used). Never present for
        folders.
+
+.. _sec-api-datamodel-files-prints:
+
+Print History
+-------------
+
+.. list-table::
+   :widths: 15 5 10 30
+   :header-rows: 1
+
+   * - Name
+     - Multiplicity
+     - Type
+     - Description
+   * - ``success``
+     - 1
+     - Number
+     - Number of successful prints
+   * - ``failure``
+     - 1
+     - Number
+     - Number of failed prints
+   * - ``last.date``
+     - 1
+     - Unix Timestamp
+     - Last date this file was printed
+   * - ``last.printTime``
+     - 1
+     - Float
+     - Last print time in seconds
+   * - ``last.success``
+     - 1
+     - Boolean
+     - Whether the last print was a success or not
+
+.. _sec-api-datamodel-files-stats:
+
+Print Statistics
+----------------
+
+.. list-table::
+   :widths: 15 5 10 30
+   :header-rows: 1
+
+   * - Name
+     - Multiplicity
+     - Type
+     - Description
+   * - ``averagePrintTime``
+     - 1
+     - Object
+     - Object that maps printer profile names to the last print time of the file, in seconds
+   * - ``lastPrintTime``
+     - 1
+     - Object
+     - Object that maps printer profile names to the average print time of the file, in seconds
 
 .. _sec-api-datamodel-access:
 


### PR DESCRIPTION
Closes #2682

I couldn't find what the `notes` or `links` properties were referring to - plugins can add additional metadata so this may be where this comes from. It's also an old ticket, maybe things changed...
