### PR TITLE
:pencil2: Add missing tool change scripts documentation

### DIFF
--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -38,6 +38,8 @@ The following GCODE scripts are sent by OctoPrint automatically:
   * ``afterPrintDone``: Sent just after a print job finished. Defaults to an empty script.
   * ``afterPrintPaused``: Sent just after a print job was paused. Defaults to an empty script.
   * ``beforePrintResumed``: Sent just before a print job is resumed. Defaults to an empty script.
+  * ``beforeToolChange``: Sent just before a tool change command (``Tn``) is issued.
+  * ``afterToolChange``: Sent just after a tool change command (``Tn``) is issued
 
 .. note::
 
@@ -107,6 +109,11 @@ There are a few additional template variables available for the following specif
       "Log position on cancel" under Settings > Serial > Advanced options!
     * ``cancel_temperature``: Last known temperature values when the print was cancelled. See ``last_temperature`` above
       for the structure to expect here.
+
+  * ``beforeToolChange`` and ``afterToolChange``
+
+    * ``tool.old``: The number of the previous tool
+    * ``tool.new``: The number of the new tool
 
 
 .. warning::


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Adds missing script/context docs

#### How was it tested? How can it be tested by the reviewer?
Local docs build

#### Any background context you want to provide?
Found after a request on my gcode macro plugin

I worked out what to add based on these lines:
https://github.com/OctoPrint/OctoPrint/blob/19388fc11f6fb62b8840d51ded7498c7b0028e49/src/octoprint/util/comm.py#L4814-L4821
