### PR TITLE
:bug: Remove CSS `width: auto` on announcements dialog, breaks things

### DIFF
--- a/src/octoprint/plugins/announcements/static/js/announcements.js
+++ b/src/octoprint/plugins/announcements/static/js/announcements.js
@@ -209,7 +209,6 @@ $(function () {
                         }
                     })
                     .css({
-                        "width": "auto",
                         "margin-left": function () {
                             return -($(this).width() / 2);
                         }


### PR DESCRIPTION
This makes the width of the modal really narrow when it is first opened & on certain screen sizes, removing this line appears to fix the issues.

Closes #4216


Related to #4103, there's a commit there that removed `width: auto` from most of the core dialogs. Apparently this one was missed and has just been noticed.