### PR TITLE
Add static files to .ignore

### DIFF
--- a/.ignore
+++ b/.ignore
@@ -1,0 +1,4 @@
+# ripgrep ignore file
+
+src/octoprint/static/vendor/
+src/octoprint/vendor/


### PR DESCRIPTION
This file is used by at least ripgrep and fd to know which files they should not look into when searching.

This change is very simple and only developer-facing, so I have not filled out the checklist.