### PR TITLE
WebRTC webcam support

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -148,6 +148,7 @@ date of first contribution):
   * [ldursw](https://github.com/ldursw)
   * [Ian Wilt](https://github.com/ianwiltdotcom)
   * [Ben Sycha](https://github.com/Sycha)
+  * [John Boiles](https://github.com/johnboiles)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -129,6 +129,7 @@ def getSettings():
             "streamUrl": s.get(["webcam", "stream"]),
             "streamRatio": s.get(["webcam", "streamRatio"]),
             "streamTimeout": s.getInt(["webcam", "streamTimeout"]),
+            "streamWebrtcIce": s.get(["webcam", "streamWebrtcIce"]),
             "snapshotUrl": s.get(["webcam", "snapshot"]),
             "snapshotTimeout": s.getInt(["webcam", "snapshotTimeout"]),
             "snapshotSslValidation": s.getBoolean(["webcam", "snapshotSslValidation"]),
@@ -549,6 +550,8 @@ def _saveSettings(data):
             s.set(["webcam", "streamRatio"], data["webcam"]["streamRatio"])
         if "streamTimeout" in data["webcam"]:
             s.setInt(["webcam", "streamTimeout"], data["webcam"]["streamTimeout"])
+        if "streamWebrtcIce" in data["webcam"]:
+            s.set(["webcam", "streamWebrtcIce"], data["webcam"]["streamWebrtcIce"])
         if "snapshotUrl" in data["webcam"]:
             s.set(["webcam", "snapshot"], data["webcam"]["snapshotUrl"])
         if "snapshotTimeout" in data["webcam"]:

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -129,7 +129,7 @@ def getSettings():
             "streamUrl": s.get(["webcam", "stream"]),
             "streamRatio": s.get(["webcam", "streamRatio"]),
             "streamTimeout": s.getInt(["webcam", "streamTimeout"]),
-            "streamWebrtcIce": s.get(["webcam", "streamWebrtcIce"]),
+            "streamWebrtcIceServers": s.get(["webcam", "streamWebrtcIceServers"]),
             "snapshotUrl": s.get(["webcam", "snapshot"]),
             "snapshotTimeout": s.getInt(["webcam", "snapshotTimeout"]),
             "snapshotSslValidation": s.getBoolean(["webcam", "snapshotSslValidation"]),
@@ -550,8 +550,13 @@ def _saveSettings(data):
             s.set(["webcam", "streamRatio"], data["webcam"]["streamRatio"])
         if "streamTimeout" in data["webcam"]:
             s.setInt(["webcam", "streamTimeout"], data["webcam"]["streamTimeout"])
-        if "streamWebrtcIce" in data["webcam"]:
-            s.set(["webcam", "streamWebrtcIce"], data["webcam"]["streamWebrtcIce"])
+        if "streamWebrtcIceServers" in data["webcam"] and isinstance(
+            data["webcam"]["streamWebrtcIceServers"], (list, tuple)
+        ):
+            s.set(
+                ["webcam", "streamWebrtcIceServers"],
+                data["webcam"]["streamWebrtcIceServers"],
+            )
         if "snapshotUrl" in data["webcam"]:
             s.set(["webcam", "snapshot"], data["webcam"]["snapshotUrl"])
         if "snapshotTimeout" in data["webcam"]:

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -249,7 +249,7 @@ default_settings = {
         "stream": None,
         "streamRatio": "16:9",
         "streamTimeout": 5,
-        "streamWebrtcIce": "stun:stun.l.google.com:19302",
+        "streamWebrtcIceServers": ["stun:stun.l.google.com:19302"],
         "snapshot": None,
         "snapshotTimeout": 5,
         "snapshotSslValidation": True,

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -249,6 +249,7 @@ default_settings = {
         "stream": None,
         "streamRatio": "16:9",
         "streamTimeout": 5,
+        "streamWebrtcIce": "stun:stun.l.google.com:19302",
         "snapshot": None,
         "snapshotTimeout": 5,
         "snapshotSslValidation": True,

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1685,10 +1685,11 @@ var negotiateWebRTC = function (streamUrl) {
         });
 };
 
-var startWebRTC = function (videoElement, streamUrl) {
+var startWebRTC = function (videoElement, streamUrl, iceServers) {
+    iceServers = iceServers || ["stun:stun.l.google.com:19302"];
     var config = {
         sdpSemantics: "unified-plan",
-        iceServers: [{urls: ["stun:stun.l.google.com:19302"]}]
+        iceServers: [{urls: iceServers}]
     };
     pc = new RTCPeerConnection(config);
     pc.addEventListener("track", function (evt) {

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1686,4 +1686,5 @@ var startWebRTC = function (videoElement, streamUrl) {
     });
 
     negotiateWebRTC(streamUrl);
+    return pc;
 };

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1543,7 +1543,7 @@ var copyToClipboard = function (text) {
 
 var determineWebcamStreamType = function (streamUrl) {
     if (streamUrl) {
-        if (streamUrl.startsWith("webrtc://")) {
+        if (streamUrl.startsWith("webrtc")) {
             return "webrtc";
         }
 
@@ -1663,9 +1663,11 @@ var negotiateWebRTC = function (streamUrl) {
         })
         .then(function () {
             var offer = pc.localDescription;
-            streamUrl = streamUrl.slice("webrtc://".length);
+            // webrtc://host.com becomes http://host.com
+            // webrtcs://host.com becomes https://host.com
+            streamUrl = "http" + streamUrl.slice("webrtc".length);
             return $.ajax({
-                url: "http://" + streamUrl,
+                url: streamUrl,
                 type: "POST",
                 dataType: "json",
                 data: JSON.stringify({

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1651,22 +1651,19 @@ var negotiateWebRTC = function (streamUrl) {
         .then(function () {
             var offer = pc.localDescription;
             streamUrl = streamUrl.slice("webrtc://".length);
-            return fetch("http://" + streamUrl, {
-                body: JSON.stringify({
+            return $.ajax({
+                url: "http://" + streamUrl,
+                type: "POST",
+                dataType: "json",
+                data: JSON.stringify({
                     sdp: offer.sdp,
                     type: offer.type
                 }),
-                headers: {
-                    "Content-Type": "application/json"
-                },
-                method: "POST"
+                contentType: "application/json; charset=UTF-8"
             });
         })
         .then(function (response) {
-            return response.json();
-        })
-        .then(function (answer) {
-            return pc.setRemoteDescription(answer);
+            return pc.setRemoteDescription(response);
         })
         .catch(function (e) {
             console.error(e);

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1625,7 +1625,16 @@ var deepMerge = function (target, source) {
 };
 
 var isWebRTCAvailable = function () {
-    return typeof RTCPeerConnection == "function";
+    return (
+        typeof RTCPeerConnection == "function" &&
+        typeof RTCPeerConnection.prototype.addEventListener == "function" &&
+        typeof RTCPeerConnection.prototype.addTransceiver == "function" &&
+        typeof RTCPeerConnection.prototype.createOffer == "function" &&
+        typeof RTCPeerConnection.prototype.setLocalDescription == "function" &&
+        typeof RTCPeerConnection.prototype.removeEventListener == "function" &&
+        typeof RTCPeerConnection.prototype.addEventListener == "function" &&
+        typeof RTCPeerConnection.prototype.setRemoteDescription == "function"
+    );
 };
 
 var negotiateWebRTC = function (streamUrl) {

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1624,6 +1624,10 @@ var deepMerge = function (target, source) {
     return target;
 };
 
+var isWebRTCAvailable = function () {
+    return typeof RTCPeerConnection == "function";
+};
+
 var negotiateWebRTC = function (streamUrl) {
     pc.addTransceiver("video", {direction: "recvonly"});
     pc.addTransceiver("audio", {direction: "recvonly"});

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1686,11 +1686,12 @@ var negotiateWebRTC = function (streamUrl) {
 };
 
 var startWebRTC = function (videoElement, streamUrl, iceServers) {
-    iceServers = iceServers || ["stun:stun.l.google.com:19302"];
     var config = {
-        sdpSemantics: "unified-plan",
-        iceServers: [{urls: iceServers}]
+        sdpSemantics: "unified-plan"
     };
+    if (iceServers) {
+        config.iceServers = [{urls: iceServers}];
+    }
     pc = new RTCPeerConnection(config);
     pc.addEventListener("track", function (evt) {
         if (evt.track.kind == "video") {

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -43,6 +43,7 @@ $(function () {
         self.webcamHlsEnabled = ko.observable(false);
         self.webcamWebRTCEnabled = ko.observable(false);
         self.webcamError = ko.observable(false);
+        self.webRTCPeerConnection = null;
 
         self.keycontrolActive = ko.observable(false);
         self.keycontrolHelpActive = ko.observable(false);
@@ -739,7 +740,22 @@ $(function () {
         self._switchToWebRTCWebcam = function () {
             var video = document.getElementById("webcam_webrtc");
 
-            startWebRTC(video, self.settings.webcam_streamUrl());
+            // Close any existing, disconnected connection
+            if (
+                self.webRTCPeerConnection != null &&
+                self.webRTCPeerConnection.connectionState != "connected"
+            ) {
+                self.webRTCPeerConnection.close();
+                self.webRTCPeerConnection = null;
+            }
+
+            // Open a new connection if necessary
+            if (self.webRTCPeerConnection == null) {
+                self.webRTCPeerConnection = startWebRTC(
+                    video,
+                    self.settings.webcam_streamUrl()
+                );
+            }
 
             self.webcamMjpgEnabled(false);
             self.webcamHlsEnabled(false);

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -756,7 +756,8 @@ $(function () {
             if (self.webRTCPeerConnection == null) {
                 self.webRTCPeerConnection = startWebRTC(
                     video,
-                    self.settings.webcam_streamUrl()
+                    self.settings.webcam_streamUrl(),
+                    [self.settings.webcam_streamWebrtcIce()]
                 );
             }
 

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -41,6 +41,7 @@ $(function () {
         self.webcamLoaded = ko.observable(false);
         self.webcamMjpgEnabled = ko.observable(false);
         self.webcamHlsEnabled = ko.observable(false);
+        self.webcamWebRTCEnabled = ko.observable(false);
         self.webcamError = ko.observable(false);
 
         self.keycontrolActive = ko.observable(false);
@@ -524,6 +525,8 @@ $(function () {
                 self._switchToMjpgWebcam();
             } else if (streamType == "hls") {
                 self._switchToHlsWebcam();
+            } else if (streamType == "webrtc") {
+                self._switchToWebRTCWebcam();
             } else {
                 throw "Unknown stream type " + streamType;
             }
@@ -708,6 +711,7 @@ $(function () {
 
                 self.webcamHlsEnabled(false);
                 self.webcamMjpgEnabled(true);
+                self.webcamWebRTCEnabled(false);
             }
         };
 
@@ -729,6 +733,17 @@ $(function () {
 
             self.webcamMjpgEnabled(false);
             self.webcamHlsEnabled(true);
+            self.webcamWebRTCEnabled(false);
+        };
+
+        self._switchToWebRTCWebcam = function () {
+            var video = document.getElementById("webcam_webrtc");
+
+            startWebRTC(video, self.settings.webcam_streamUrl());
+
+            self.webcamMjpgEnabled(false);
+            self.webcamHlsEnabled(false);
+            self.webcamWebRTCEnabled(true);
         };
     }
 

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -526,7 +526,7 @@ $(function () {
                 self._switchToMjpgWebcam();
             } else if (streamType == "hls") {
                 self._switchToHlsWebcam();
-            } else if (streamType == "webrtc") {
+            } else if (isWebRTCAvailable() && streamType == "webrtc") {
                 self._switchToWebRTCWebcam();
             } else {
                 throw "Unknown stream type " + streamType;
@@ -738,6 +738,9 @@ $(function () {
         };
 
         self._switchToWebRTCWebcam = function () {
+            if (!isWebRTCAvailable()) {
+                return;
+            }
             var video = document.getElementById("webcam_webrtc");
 
             // Close any existing, disconnected connection

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -757,7 +757,7 @@ $(function () {
                 self.webRTCPeerConnection = startWebRTC(
                     video,
                     self.settings.webcam_streamUrl(),
-                    [self.settings.webcam_streamWebrtcIce()]
+                    self.settings.webcam_streamWebrtcIceServers()
                 );
             }
 

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -1333,6 +1333,11 @@ $(function () {
                     profiles: function (value) {
                         self.temperature_profiles($.extend(true, [], value));
                     }
+                },
+                webcam: {
+                    streamWebrtcIceServers: function (value) {
+                        self.webcam_streamWebrtcIceServers(value.join(", "));
+                    }
                 }
             };
 

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -454,7 +454,7 @@ $(function () {
                     hls.loadSource(self.webcam_streamUrl());
                     hls.attachMedia(video_element);
                 }
-            } else if (streamType == "webrtc") {
+            } else if (isWebRTCAvailable() && streamType == "webrtc") {
                 webcam_element = $(
                     '<video id="webcam_webrtc" muted autoplay playsinline style="width: 100%"/>'
                 );

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -439,6 +439,7 @@ $(function () {
             );
             var streamType = determineWebcamStreamType(self.webcam_streamUrl());
             var webcam_element;
+            var webrtc_peer_connection;
             if (streamType == "mjpg") {
                 webcam_element = $('<img src="' + self.webcam_streamUrl() + '">');
             } else if (streamType == "hls") {
@@ -459,7 +460,10 @@ $(function () {
                 );
                 video_element = webcam_element[0];
 
-                startWebRTC(video_element, self.webcam_streamUrl());
+                webrtc_peer_connection = startWebRTC(
+                    video_element,
+                    self.webcam_streamUrl()
+                );
             } else {
                 throw "Unknown stream type " + streamType;
             }
@@ -475,6 +479,10 @@ $(function () {
                 message: message,
                 onclose: function () {
                     self.testWebcamStreamUrlBusy(false);
+                    if (webrtc_peer_connection != null) {
+                        webrtc_peer_connection.close();
+                        webrtc_peer_connection = null;
+                    }
                 }
             });
         };

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -456,7 +456,7 @@ $(function () {
                 }
             } else if (isWebRTCAvailable() && streamType == "webrtc") {
                 webcam_element = $(
-                    '<video id="webcam_webrtc" muted autoplay playsinline style="width: 100%"/>'
+                    '<video id="webcam_webrtc" muted autoplay playsinline controls style="width: 100%"/>'
                 );
                 video_element = webcam_element[0];
 

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -456,7 +456,7 @@ $(function () {
                 }
             } else if (streamType == "webrtc") {
                 webcam_element = $(
-                    '<video id="webcam_webrtc" muted autoplay style="width: 100%"/>'
+                    '<video id="webcam_webrtc" muted autoplay playsinline style="width: 100%"/>'
                 );
                 video_element = webcam_element[0];
 

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -453,6 +453,13 @@ $(function () {
                     hls.loadSource(self.webcam_streamUrl());
                     hls.attachMedia(video_element);
                 }
+            } else if (streamType == "webrtc") {
+                webcam_element = $(
+                    '<video id="webcam_webrtc" muted autoplay style="width: 100%"/>'
+                );
+                video_element = webcam_element[0];
+
+                startWebRTC(video_element, self.webcam_streamUrl());
             } else {
                 throw "Unknown stream type " + streamType;
             }

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -153,7 +153,7 @@ $(function () {
         self.webcam_streamUrl = ko.observable(undefined);
         self.webcam_streamRatio = ko.observable(undefined);
         self.webcam_streamTimeout = ko.observable(undefined);
-        self.webcam_streamWebrtcIce = ko.observable(undefined);
+        self.webcam_streamWebrtcIceServers = ko.observable(undefined);
         self.webcam_snapshotUrl = ko.observable(undefined);
         self.webcam_snapshotTimeout = ko.observable(undefined);
         self.webcam_snapshotSslValidation = ko.observable(undefined);
@@ -464,7 +464,7 @@ $(function () {
                 webrtc_peer_connection = startWebRTC(
                     video_element,
                     self.webcam_streamUrl(),
-                    [self.webcam_streamWebrtcIce()]
+                    self.webcam_streamWebrtcIceServers()
                 );
             } else {
                 throw "Unknown stream type " + streamType;
@@ -1163,6 +1163,15 @@ $(function () {
                             }
                         });
                         return result;
+                    }
+                },
+                webcam: {
+                    streamWebrtcIceServers: function () {
+                        return splitTextToArray(
+                            self.webcam_streamWebrtcIceServers(),
+                            ",",
+                            true
+                        );
                     }
                 }
             };

--- a/src/octoprint/static/js/app/viewmodels/settings.js
+++ b/src/octoprint/static/js/app/viewmodels/settings.js
@@ -153,6 +153,7 @@ $(function () {
         self.webcam_streamUrl = ko.observable(undefined);
         self.webcam_streamRatio = ko.observable(undefined);
         self.webcam_streamTimeout = ko.observable(undefined);
+        self.webcam_streamWebrtcIce = ko.observable(undefined);
         self.webcam_snapshotUrl = ko.observable(undefined);
         self.webcam_snapshotTimeout = ko.observable(undefined);
         self.webcam_snapshotSslValidation = ko.observable(undefined);
@@ -462,7 +463,8 @@ $(function () {
 
                 webrtc_peer_connection = startWebRTC(
                     video_element,
-                    self.webcam_streamUrl()
+                    self.webcam_streamUrl(),
+                    [self.webcam_streamWebrtcIce()]
                 );
             } else {
                 throw "Unknown stream type " + streamType;

--- a/src/octoprint/templates/dialogs/settings/webcam.jinja2
+++ b/src/octoprint/templates/dialogs/settings/webcam.jinja2
@@ -15,6 +15,7 @@
         <div class="hide">
             {% include "snippets/settings/webcam/webcamStreamTimeout.jinja2" %}
             {% include "snippets/settings/webcam/webcamCacheBuster.jinja2" %}
+            {% include "snippets/settings/webcam/webcamStreamWebrtcIce.jinja2" %}
         </div>
     </div>
 </form>

--- a/src/octoprint/templates/dialogs/settings/webcam.jinja2
+++ b/src/octoprint/templates/dialogs/settings/webcam.jinja2
@@ -15,7 +15,7 @@
         <div class="hide">
             {% include "snippets/settings/webcam/webcamStreamTimeout.jinja2" %}
             {% include "snippets/settings/webcam/webcamCacheBuster.jinja2" %}
-            {% include "snippets/settings/webcam/webcamStreamWebrtcIce.jinja2" %}
+            {% include "snippets/settings/webcam/webcamStreamWebrtcIceServers.jinja2" %}
         </div>
     </div>
 </form>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
@@ -1,7 +1,7 @@
-<div class="control-group" title="{{ _('Endpoint to use for WebRTC ICE')|edq }}">
+<div class="control-group" title="{{ _('ICE server (STUN and/or TURN) to use for WebRTC')|edq }}">
     <label class="control-label" for="settings-webcamStreamWebrtcIce">{{ _('WebRTC ICE endpoint') }}</label>
     <div class="controls">
         <input type="text" class="input-block-level" data-bind="value: webcam_streamWebrtcIce, valueUpdate: 'afterkeydown'" id="settings-webcamStreamWebrtcIce">
-        <span class="help-block"><span class="label">{{ _('WebRTC') }}</span> {% trans %}Only used for WebRTC streams. Provide the endpoint to use for WebRTC's Interactive Connectivity Establishment (ICE). Usually a STUN server. If unsure, leave at the default of <code>stun:stun.l.google.com:19302</code>.{% endtrans %}</span>
+        <span class="help-block"><span class="label">{{ _('WebRTC') }}</span> {% trans %}Only used for WebRTC streams. Optionally specify the ICE server (STUN and/or TURN) to use for WebRTC. If unsure, leave at the default of <code>stun:stun.l.google.com:19302</code>.{% endtrans %}</span>
     </div>
 </div>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
@@ -1,7 +1,0 @@
-<div class="control-group" title="{{ _('ICE server (STUN and/or TURN) to use for WebRTC')|edq }}">
-    <label class="control-label" for="settings-webcamStreamWebrtcIce">{{ _('WebRTC ICE endpoint') }}</label>
-    <div class="controls">
-        <input type="text" class="input-block-level" data-bind="value: webcam_streamWebrtcIce, valueUpdate: 'afterkeydown'" id="settings-webcamStreamWebrtcIce">
-        <span class="help-block"><span class="label">{{ _('WebRTC') }}</span> {% trans %}Only used for WebRTC streams. Optionally specify the ICE server (STUN and/or TURN) to use for WebRTC. If unsure, leave at the default of <code>stun:stun.l.google.com:19302</code>.{% endtrans %}</span>
-    </div>
-</div>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIce.jinja2
@@ -1,0 +1,7 @@
+<div class="control-group" title="{{ _('Endpoint to use for WebRTC ICE')|edq }}">
+    <label class="control-label" for="settings-webcamStreamWebrtcIce">{{ _('WebRTC ICE endpoint') }}</label>
+    <div class="controls">
+        <input type="text" class="input-block-level" data-bind="value: webcam_streamWebrtcIce, valueUpdate: 'afterkeydown'" id="settings-webcamStreamWebrtcIce">
+        <span class="help-block"><span class="label">{{ _('WebRTC') }}</span> {% trans %}Only used for WebRTC streams. Provide the endpoint to use for WebRTC's Interactive Connectivity Establishment (ICE). Usually a STUN server. If unsure, leave at the default of <code>stun:stun.l.google.com:19302</code>.{% endtrans %}</span>
+    </div>
+</div>

--- a/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIceServers.jinja2
+++ b/src/octoprint/templates/snippets/settings/webcam/webcamStreamWebrtcIceServers.jinja2
@@ -1,0 +1,7 @@
+<div class="control-group" title="{{ _('ICE server (STUN and/or TURN) to use for WebRTC')|edq }}">
+    <label class="control-label" for="settings-webcamStreamWebrtcIceServers">{{ _('WebRTC ICE endpoint') }}</label>
+    <div class="controls">
+        <input type="text" class="input-block-level" data-bind="value: webcam_streamWebrtcIceServers, valueUpdate: 'afterkeydown'" id="settings-webcamStreamWebrtcIceServers">
+        <span class="help-block"><span class="label">{{ _('WebRTC') }}</span> {% trans %}Only used for WebRTC streams. Optionally specify the ICE server(s) (STUN and/or TURN) to use for WebRTC. Multiple servers should be separated by a comma. If unsure, leave at the default of <code>stun:stun.l.google.com:19302</code>.{% endtrans %}</span>
+    </div>
+</div>

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -1,7 +1,7 @@
 {% if enableWebcam %}
     <!-- ko if: loginState.hasPermissionKo(access.permissions.WEBCAM) -->
     <div id="webcam_webrtc_container" tabindex="0" data-bind="visible: webcamWebRTCEnabled()">
-        <video id="webcam_webrtc" muted autoplay style="width: 100%"></video>
+        <video id="webcam_webrtc" muted autoplay playsinline style="width: 100%"></video>
     </div>
     <div id="webcam_hls_container" tabindex="0" data-bind="visible: webcamHlsEnabled()">
         <video id="webcam_hls" muted autoplay style="width: 100%"></video>

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -1,7 +1,7 @@
 {% if enableWebcam %}
     <!-- ko if: loginState.hasPermissionKo(access.permissions.WEBCAM) -->
     <div id="webcam_webrtc_container" tabindex="0" data-bind="visible: webcamWebRTCEnabled()">
-        <video id="webcam_webrtc" muted autoplay playsinline style="width: 100%"></video>
+        <video id="webcam_webrtc" muted autoplay playsinline controls style="width: 100%"></video>
     </div>
     <div id="webcam_hls_container" tabindex="0" data-bind="visible: webcamHlsEnabled()">
         <video id="webcam_hls" muted autoplay style="width: 100%"></video>

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -1,5 +1,8 @@
 {% if enableWebcam %}
     <!-- ko if: loginState.hasPermissionKo(access.permissions.WEBCAM) -->
+    <div id="webcam_webrtc_container" tabindex="0" data-bind="visible: webcamWebRTCEnabled()">
+        <video id="webcam_webrtc" muted autoplay style="width: 100%"></video>
+    </div>
     <div id="webcam_hls_container" tabindex="0" data-bind="visible: webcamHlsEnabled()">
         <video id="webcam_hls" muted autoplay style="width: 100%"></video>
     </div>


### PR DESCRIPTION
 #### What does this PR do and why is it necessary?

This PR adds support for WebRTC webcams when a Stream URL beginning with `webrtc://` is specified in Webcam settings. This allows for HD (1080p) streaming from Raspberry Pis with < 1s of latency (I'm getting ~700ms with my Logitech c920 on a Pi 3B 1.2). This improves upon the MJPEG and HLS webcams by providing high resolution, low bandwidth, and low latency. There are other better-latency-than-HLS protocols out there but they don't have built-in browser support and since they're optimized for CDN distribution, they tend to have >1s latency.

|                     | MJPEG | HLS | WebRTC | [LL-DASH](https://www.theoplayer.com/blog/low-latency-dash) | [Apple LLHLS](https://developer.apple.com/documentation/http_live_streaming/enabling_low-latency_hls) | [Twitter/Community LHLS](https://medium.com/@periscopecode/introducing-lhls-media-streaming-eb6212948bef) |
|---------------------|-------|-----|--------|---------|-------------|--------------|
| High Resolution     | ❌     | ✅   | ✅      | ✅       | ✅           | ✅            |
| Low Bandwidth       | ❌     | ✅   | ✅      | ✅       | ✅           | ✅            |
| Low Latency         | ✅     | ❌   | ✅      | ⚠️       | ⚠️           | ⚠️            |
| Browser Support | ✅     | ✅   | ✅      | ❌       | ❌           | ❌            |

If accepted, the next step on this project will be to provide a WebRTC server as a part of OctoPi (similar to `ffmpeg_hls.service` for HLS support). I've started on those changes [here](https://github.com/guysoft/OctoPi/compare/devel...johnboiles:webrtc-support?expand=1).

#### How was it tested? How can it be tested by the reviewer?

I tested this on a Pi3 B 1.2 with a Logitech c920 camera. I tested in Safari, Chrome, and Firefox.

To run a WebRTC server you'll need to download my fork of `aiortc` and run it. I'm running it on the same Pi that has my OctoPrint instance. This is what will need to be bundled into OctoPi. 

```bash
# Checkout my branch of aiortc
git clone https://github.com/johnboiles/aiortc.git
cd aiortc
git checkout octoprint-webrtc-support

# Get some apt dependencies
sudo apt install python3-venv libavdevice-dev libavfilter-dev libopus-dev libvpx-dev pkg-config libsrtp2-dev

# Create a python virtual environment
python3 -m venv venv
source venv/bin/activate

# Upgrade pip because why not
pip install --upgrade pip

# Get dependencies specific to webcam.py
pip install aiohttp crc32c

# Install aiortc from the local source
pip install .

# [Optional] If you want to modify the python code, point to the source files for python and copy in a few compiled files
export  PYTHONPATH=$PWD/src
cp venv/lib/python3.7/site-packages/aiortc-1.2.1-py3.7-linux-armv7l.egg/aiortc/codecs/* src/aiortc/codecs/

# Stop anything using the webcam right now
sudo systemctl stop ffmpeg_hls
sudo systemctl stop webcamd

# Run the example
cd examples/webcam
python webcam.py --preferred-codec=video/H264

# Or if you're adventurous and want to try passing forward raw h264 data (works on old Logitcech c920s and maybe others)
python webcam.py --no-transcode --preferred-codec=video/H264 --video-options='{"video_size": "1920x1080", "framerate": "30", "input_format": "h264"}'

# If you're very adventurous and have a Pi camera, this might work for you:
v4l2-ctl -d /dev/video0 -v pixelformat=H264,width=1920,height=1080
v4l2-ctl -d /dev/video0 -c video_bitrate_mode=1,video_bitrate=4000000,h264_profile=4,h264_i_frame_period=60,h264_level=11,repeat_sequence_header=1
v4l2-ctl -d /dev/video0 -p 30
python webcam.py --no-transcode --preferred-codec=video/H264 --video-options='{"video_size": "1920x1080", "framerate": "30", "input_format": "h264", "pixelformat": "H264"}'

# Set your Webcam Stream URL in settings to point to your WebRTC server
# e.g. webrtc://octopi.local:8080/offer
```

#### Any background context you want to provide?

See thread [here](https://community.octoprint.org/t/low-latency-h264-streaming-support-prob-w-webrtc/36996/8) for a bit more context.

#### What are the relevant tickets if any?

None in the OctoPrint Repo. However, see also these relevant `aiortc` PRs that are needed to passthrough native h264 to WebRTC (required for 1080p on the Pi3):

* https://github.com/aiortc/aiortc/pull/559
* https://github.com/aiortc/aiortc/pull/564

#### Screenshots (if appropriate)

Look at that 🔥 1080p 30fps video inside OctoPrint -- I had to zoom in so you can see it in its 1080p glory.

<img width="1115" alt="image" src="https://user-images.githubusercontent.com/218876/132767654-ed196c5f-9b02-47b8-bad8-5489e4a4a7d9.png">

#### Further notes

The most uncertain part of this PR is how to define the Stream URL for WebRTC streams. The WebRTC entrypoint is just an HTTP url (e.g. `http://octopi.local:8080/offer`). I used `webrtc://octopi.local:8080/offer` since it was simple and straightforward in my opinion. The one problem with it though is that the current setup wouldn't allow you to use https for webrtc. This would be best to decide now since it'd be potentially a breaking change for any WebRTC users in the future. Some alternatives:
* `webrtc://http://octopi.local:8080/offer`
* `webrtc://octopi.local:8080/offer` (for http) AND `webrtcs://octopi.local:8080/offer` (for https)
* `webrtc:http://octopi.local:8080/offer`

Long-term (after a lot of testing) I think WebRTC could potentially be a better default than MJPEG. For low resolutions like 640x480, the Pi can handle transcoding to h264 just fine (`aiortc` supports using the `h264_omx` hardware encoder) so it should be able to support a wide variety of camera hardware at similar video quality to mjpegstreamer (and use less bandwidth).