### PR TITLE
Switch bom_aware_open to use utf-8-sig by default

### DIFF
--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -810,7 +810,7 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
         if os.stat(path).st_mtime + ttl < time.time():
             return None
 
-        with bom_aware_open(path, encoding="utf-8", mode="rt") as f:
+        with bom_aware_open(path, mode="rt") as f:
             result = yaml.safe_load(f)
 
         if isinstance(result, list):
@@ -824,7 +824,7 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
 
             if cache is not None:
                 try:
-                    with bom_aware_open(cache, encoding="utf-8", mode="wt") as f:
+                    with bom_aware_open(cache, mode="wt") as f:
                         yaml.safe_dump(result, f)
                 except Exception as e:
                     logger.info(

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1078,27 +1078,11 @@ else:
             self.cleanup()
 
 
-def bom_aware_open(filename, encoding="ascii", mode="r", **kwargs):
-    import codecs
-
+def bom_aware_open(filename, encoding="utf-8", mode="r", **kwargs):
     assert "b" not in mode, "binary mode not support by bom_aware_open"
 
-    codec = codecs.lookup(encoding)
-    encoding = codec.name
-
-    if kwargs is None:
-        kwargs = {}
-
-    potential_bom_attribute = "BOM_" + codec.name.replace("utf-", "utf").upper()
-    if "r" in mode and hasattr(codecs, potential_bom_attribute):
-        # these encodings might have a BOM, so let's see if there is one
-        bom = getattr(codecs, potential_bom_attribute)
-
-        with io.open(filename, mode="rb") as f:
-            header = f.read(4)
-
-        if header.startswith(bom):
-            encoding += "-sig"
+    if encoding in {"utf-8", "utf8"} and "r" in mode:
+        encoding = "utf-8-sig"
 
     return io.open(filename, encoding=encoding, mode=mode, **kwargs)
 

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -5648,9 +5648,7 @@ class PrintingGcodeFileInformation(PrintingFileInformation):
         """
         PrintingFileInformation.start(self)
         with self._handle_mutex:
-            self._handle = bom_aware_open(
-                self._filename, encoding="utf-8", errors="replace", newline=""
-            )
+            self._handle = bom_aware_open(self._filename, errors="replace", newline="")
             self._pos = self._handle.tell()
             if self._handle.encoding.endswith("-sig"):
                 # Apparently we found an utf-8 bom in the file.

--- a/tests/util/test_file_helpers.py
+++ b/tests/util/test_file_helpers.py
@@ -33,9 +33,7 @@ class BomAwareOpenTest(unittest.TestCase):
         """Tests that the contents of a UTF8 file with BOM are loaded correctly (without the BOM)."""
 
         # test
-        with octoprint.util.bom_aware_open(
-            self.filename_utf8_with_bom, encoding="utf-8"
-        ) as f:
+        with octoprint.util.bom_aware_open(self.filename_utf8_with_bom) as f:
             contents = f.readlines()
 
         # assert
@@ -46,9 +44,7 @@ class BomAwareOpenTest(unittest.TestCase):
         """Tests that the contents of a UTF8 file without BOM are loaded correctly."""
 
         # test
-        with octoprint.util.bom_aware_open(
-            self.filename_utf8_without_bom, encoding="utf-8"
-        ) as f:
+        with octoprint.util.bom_aware_open(self.filename_utf8_without_bom) as f:
             contents = f.readlines()
 
         # assert
@@ -60,7 +56,7 @@ class BomAwareOpenTest(unittest.TestCase):
 
         # test
         with octoprint.util.bom_aware_open(
-            self.filename_utf8_with_bom, errors="replace"
+            self.filename_utf8_with_bom, errors="replace", encoding="ascii"
         ) as f:
             contents = f.readlines()
 
@@ -72,7 +68,9 @@ class BomAwareOpenTest(unittest.TestCase):
     def test_bom_aware_open_encoding_error(self):
         """Tests that an encoding error is thrown if not suppressed when opening a UTF8 file as ASCII."""
         try:
-            with octoprint.util.bom_aware_open(self.filename_utf8_without_bom) as f:
+            with octoprint.util.bom_aware_open(
+                self.filename_utf8_without_bom, encoding="ascii"
+            ) as f:
                 f.readlines()
             self.fail("Expected an exception")
         except UnicodeDecodeError:
@@ -85,21 +83,16 @@ class BomAwareOpenTest(unittest.TestCase):
             with octoprint.util.bom_aware_open(
                 self.filename_utf8_without_bom,
                 mode="rt",
-                encoding="utf-8",
                 errors="ignore",
             ) as f:
                 f.readlines()
 
-        calls = [
-            mock.call(self.filename_utf8_without_bom, mode="rb"),
-            mock.call(
-                self.filename_utf8_without_bom,
-                encoding="utf-8",
-                mode="rt",
-                errors="ignore",
-            ),
-        ]
-        mock_open.assert_has_calls(calls)
+        mock_open.assert_called_once_with(
+            self.filename_utf8_without_bom,
+            encoding="utf-8-sig",
+            mode="rt",
+            errors="ignore",
+        )
 
     def test_bom_aware_open_parameters_binary_mode(self):
         """Tests that binary mode raises an AssertionError."""
@@ -108,7 +101,6 @@ class BomAwareOpenTest(unittest.TestCase):
             octoprint.util.bom_aware_open,
             self.filename_utf8_without_bom,
             mode="rb",
-            encoding="utf-8",
             errors="ignore",
         )
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This changes the API of bom_aware_open to match the default python
encoding of utf-8.

It also avoids the double open from before by using the `utf-8-sig`
encoding

Fixes #4228

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
