### PR TITLE
Move away from `ubuntu-16.04` in GH actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
   test-e2e:
     name: 🧪 E2E tests
     needs: build
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-18.04
     steps:
       - name: ⬇ Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Because it's going to be gone on September 20th 2021: https://github.com/actions/virtual-environments/issues/3287

I'm conservatively just bumping to `ubuntu-18.04` since there was probably a reason this was set to `ubuntu-16.04` while all the other actions run on `ubuntu-latest`
