### PR TITLE
Send Server-Timing header

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -1392,6 +1392,10 @@ class Server(object):
         @app.before_request
         def before_request():
             g.locale = self._get_locale()
+
+            # used for performance measurement
+            g.start_time = octoprint.util.monotonic_time()
+
             if self._debug and "perfprofile" in request.args:
                 try:
                     from pyinstrument import Profiler
@@ -1414,6 +1418,11 @@ class Server(object):
                 g.perfprofiler.stop()
                 output_html = g.perfprofiler.output_html()
                 return make_response(output_html)
+
+            if hasattr(g, "start_time"):
+                end_time = octoprint.util.monotonic_time()
+                duration_ms = int((end_time - g.start_time) * 1000)
+                response.headers.add("Server-Timing", "app;dur={}".format(duration_ms))
 
             return response
 


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Sends the Server-Timing header with each api request.

This is useful to be able to tell when a performance issue is due to the
network or due to the actual execution time

There's hardly any overhead, so send it with every request.

![screenshot of app timing](https://user-images.githubusercontent.com/5213469/133334933-415832fa-b233-4ef1-9d84-3e875145ac2e.png)


#### How was it tested? How can it be tested by the reviewer?

I had octoprint make some requests with the network debugger pane open.

#### Any background context you want to provide?

This is helpful in understanding long load times. Turns out that that in my situation, many of the requests being sent take a long time to return not because they're slow, they're < 10ms, but because the system I'm running them on has very poor WiFi latency.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
