### PR TITLE
Fixed bug in the _.map usage in terminal

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/terminal.js
+++ b/src/octoprint/static/js/app/viewmodels/terminal.js
@@ -286,7 +286,7 @@ $(function () {
                 display = "line";
             }
 
-            if (type === undefined) {
+            if (type === undefined || typeof type != "string") {
                 if (line.startsWith("Recv:")) {
                     type = "recv";
                 } else if (line.startsWith("Send:")) {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
It fixes what seems to be an oversight when using the _.map function (https://underscorejs.org/#map) - the third parameter passed to the function (iteratee) is the entire dataset/array - the function being called (https://github.com/OctoPrint/OctoPrint/blob/rc/maintenance/src/octoprint/static/js/app/viewmodels/terminal.js#L284) does not validate if the input is of a valid type and therefore assigns the entire array as "type" for each entry. This causes a massive overloading of data. The history data of 300 lines should be turn into a simple json with 300 entries, with each entry having 3 entries of a string type, but the current bug causes the 300 lines to be returned a 300 entries with 300 entries each in the "type".

#### How was it tested? How can it be tested by the reviewer?
Using console debug

#### Screenshots (if appropriate)
Without typeof test: notice the **type: Array(300)**
![image](https://user-images.githubusercontent.com/69049371/134963163-7881a806-309b-456b-bf88-dc098b99711a.png)

With typeof test:
![image](https://user-images.githubusercontent.com/69049371/134963184-e42f4c9c-32ff-4d67-afe3-f8f79d3bf20d.png)

#### Further notes
I think we/someone should grep the source - there might be other places where the _.map function is causing similar problems. I spent 20 minutes looking and I don't think there is but always good to double check.
