### PR TITLE
Revert change to immutabledict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,6 +54,7 @@ INSTALL_REQUIRES = [
     "pkginfo>=1.7.1,<2",
     "requests>=2.26.0,<3",
     "semantic_version>=2.8.5,<3",
+    "frozendict>=2.0,<3",
     "psutil>=5.8,<6",
     "Click>=7.1.2,<8",  # newer versions require Python 3
     "future>=0.18.2,<1",
@@ -76,7 +77,6 @@ INSTALL_REQUIRES_PYTHON2 = [
     "chainmap>=1.0.3,<2",
     "typing>=3.10.0.0,<4",
     "enum34>=1.1.10,<1.2",
-    "frozendict==1.2",  # newer versions from different maintainer require Python 3
     "colorlog<5",  # newer versions require Python 3
     # vendor bundled dependencies
     "unidecode<1.3",  # dependency of awesome-slugify, newer versions require Python 3
@@ -87,7 +87,6 @@ INSTALL_REQUIRES_PYTHON3 = [
     "feedparser>=6.0.8,<7",
     "tornado>=6,<7",  # tornado < 6 is incompatible with Python 3.10
     "zeroconf>=0.33,<0.34",  # breaking changes can happen on minor version increases
-    "immutabledict>=2.1,<3",
     "pathvalidate>=2.4.1,<3",
     "colorlog>=5.0.1,<6",
     # vendor bundled dependencies

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,6 @@ INSTALL_REQUIRES = [
     "pkginfo>=1.7.1,<2",
     "requests>=2.26.0,<3",
     "semantic_version>=2.8.5,<3",
-    "frozendict>=2.0,<3",
     "psutil>=5.8,<6",
     "Click>=7.1.2,<8",  # newer versions require Python 3
     "future>=0.18.2,<1",
@@ -77,6 +76,7 @@ INSTALL_REQUIRES_PYTHON2 = [
     "chainmap>=1.0.3,<2",
     "typing>=3.10.0.0,<4",
     "enum34>=1.1.10,<1.2",
+    "frozendict==1.2",  # newer versions require Python 3
     "colorlog<5",  # newer versions require Python 3
     # vendor bundled dependencies
     "unidecode<1.3",  # dependency of awesome-slugify, newer versions require Python 3
@@ -87,6 +87,7 @@ INSTALL_REQUIRES_PYTHON3 = [
     "feedparser>=6.0.8,<7",
     "tornado>=6,<7",  # tornado < 6 is incompatible with Python 3.10
     "zeroconf>=0.33,<0.34",  # breaking changes can happen on minor version increases
+    "frozendict>=2.0,<3",
     "pathvalidate>=2.4.1,<3",
     "colorlog>=5.0.1,<6",
     # vendor bundled dependencies

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -15,12 +15,7 @@ import os
 import threading
 import time
 
-try:
-    from immutabledict import immutabledict
-except ImportError:
-    # Python 2
-    from frozendict import frozendict as immutabledict
-
+from frozendict import frozendict
 from past.builtins import basestring, long
 
 import octoprint.util.json
@@ -56,7 +51,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         self._logger_job = logging.getLogger("{}.job".format(__name__))
 
         self._dict = (
-            immutabledict
+            frozendict
             if settings().getBoolean(["devel", "useFrozenDictForPrinterState"])
             else dict
         )
@@ -203,7 +198,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
     @property
     def firmware_info(self):
-        return immutabledict(self._firmware_info) if self._firmware_info else None
+        return frozendict(self._firmware_info) if self._firmware_info else None
 
     # ~~ handling of PrinterCallbacks
 
@@ -844,11 +839,11 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             return self._comm.getErrorString()
 
     def get_current_data(self, *args, **kwargs):
-        return util.thaw_immutabledict(self._stateMonitor.get_current_data())
+        return util.thaw_frozendict(self._stateMonitor.get_current_data())
 
     def get_current_job(self, *args, **kwargs):
         currentData = self._stateMonitor.get_current_data()
-        return util.thaw_immutabledict(currentData["job"])
+        return util.thaw_frozendict(currentData["job"])
 
     def get_current_temperatures(self, *args, **kwargs):
         if self._comm is not None:

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -33,13 +33,8 @@ except ImportError:
     # Python 2.7
     from collections import Iterable, MutableMapping, Set
 
-try:
-    from immutabledict import immutabledict
-except ImportError:
-    # Python 2
-    from frozendict import frozendict as immutabledict
-
 import past.builtins
+from frozendict import frozendict
 
 try:
     import queue
@@ -1214,23 +1209,23 @@ except ImportError:
         monotonic_time = time.time
 
 
-def thaw_immutabledict(obj):
-    if not isinstance(obj, (dict, immutabledict)):
-        raise ValueError("obj must be a dict or immutabledict instance")
+def thaw_frozendict(obj):
+    if not isinstance(obj, (dict, frozendict)):
+        raise ValueError("obj must be a dict or frozendict instance")
 
     # only true love can thaw a frozen dict
     letitgo = {}
     for key, value in obj.items():
-        if isinstance(value, (dict, immutabledict)):
-            letitgo[key] = thaw_immutabledict(value)
+        if isinstance(value, (dict, frozendict)):
+            letitgo[key] = thaw_frozendict(value)
         else:
             letitgo[key] = copy.deepcopy(value)
     return letitgo
 
 
-thaw_frozendict = deprecated(
-    "thaw_frozendict has been renamed to thaw_immutabledict", since="1.6.0"
-)(thaw_immutabledict)
+thaw_immutabledict = deprecated(
+    "thaw_immutabledict has been renamed back to thaw_frozendict", since="1.8.0"
+)(thaw_frozendict)
 
 
 def utmify(link, source=None, medium=None, name=None, term=None, content=None):

--- a/src/octoprint/util/json/__init__.py
+++ b/src/octoprint/util/json/__init__.py
@@ -8,11 +8,7 @@ __copyright__ = "Copyright (C) 2018 The OctoPrint Project - Released under terms
 import collections
 import json
 
-try:
-    from immutabledict import immutabledict
-except ImportError:
-    # Python 2
-    from frozendict import frozendict as immutabledict
+from frozendict import frozendict
 
 from octoprint.util import to_unicode
 
@@ -49,5 +45,5 @@ class JsonEncoding(object):
         raise TypeError
 
 
-JsonEncoding.add_encoder(immutabledict, lambda obj: dict(obj))
+JsonEncoding.add_encoder(frozendict, lambda obj: dict(obj))
 JsonEncoding.add_encoder(bytes, lambda obj: to_unicode(obj))

--- a/tests/util/test_misc.py
+++ b/tests/util/test_misc.py
@@ -8,12 +8,7 @@ __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms
 import unittest
 
 import ddt
-
-try:
-    from immutabledict import immutabledict
-except ImportError:
-    # Python 2
-    from frozendict import frozendict as immutabledict
+from frozendict import frozendict
 
 import octoprint.util
 
@@ -71,35 +66,35 @@ class MiscTestCase(unittest.TestCase):
         self.assertEqual(actual, expected)
 
     @ddt.data(
-        (immutabledict(a=1, b=2, c=3), {"a": 1, "b": 2, "c": 3}),
+        (frozendict(a=1, b=2, c=3), {"a": 1, "b": 2, "c": 3}),
         (
-            immutabledict(a=1, b=2, c=immutabledict(c1=1, c2=2)),
+            frozendict(a=1, b=2, c=frozendict(c1=1, c2=2)),
             {"a": 1, "b": 2, "c": {"c1": 1, "c2": 2}},
         ),
         ({"a": 1, "b": 2, "c": 3}, {"a": 1, "b": 2, "c": 3}),
         (
-            {"a": 1, "b": 2, "c": immutabledict(c1=1, c2=2)},
+            {"a": 1, "b": 2, "c": frozendict(c1=1, c2=2)},
             {"a": 1, "b": 2, "c": {"c1": 1, "c2": 2}},
         ),
         (
             {
                 "a": 1,
                 "b": 2,
-                "c": {"c1": 1, "c2": 2, "c3": immutabledict(c11=11, c12=12)},
+                "c": {"c1": 1, "c2": 2, "c3": frozendict(c11=11, c12=12)},
             },
             {"a": 1, "b": 2, "c": {"c1": 1, "c2": 2, "c3": {"c11": 11, "c12": 12}}},
         ),
     )
     @ddt.unpack
-    def test_unfreeze_immutabledict(self, input, expected):
-        result = octoprint.util.thaw_immutabledict(input)
+    def test_unfreeze_frozendict(self, input, expected):
+        result = octoprint.util.thaw_frozendict(input)
         self.assertIsInstance(result, dict)
         self.assertDictEqual(result, expected)
 
     @ddt.data(None, "invalid", 3, [1, 2], (3, 4))
-    def test_unfreeze_immutabledict_invalid(self, input):
+    def test_unfreeze_frozendict_invalid(self, input):
         try:
-            octoprint.util.thaw_immutabledict(input)
+            octoprint.util.thaw_frozendict(input)
             self.fail("expected ValueError")
         except ValueError:
             # expected


### PR DESCRIPTION
The original frozendict module is maintained again and has not removed
setup.py from the repository to make packaging harder. Also the 2.x
releases have added native code to speed it up.

As briefly discussed at https://github.com/OctoPrint/OctoPrint/commit/849cea15c139f072ac3145736cfc002b13d28aa6