### PR TITLE
✨ New plugin lifecycle callback `on_plugin_pending_uninstall`

### DIFF
--- a/docs/plugins/concepts.rst
+++ b/docs/plugins/concepts.rst
@@ -35,9 +35,22 @@ any :ref:`settings overlays <sec-plugins-controlproperties-plugin_settings_overl
 
 On disabling a plugin, its hook handlers, helpers, mixin implementations and settings overlays will be de-registered again.
 
+When a plugin gets enabled, OctoPrint will also call the :func:`on_plugin_enabled` callback on its implementation
+(if it exists). Likewise, when a plugin gets disabled OctoPrint will call the :func:`on_plugin_disabled` callback on
+its implementation (again, if it exists).
+
 Some plugin types require a reload of the frontend or a restart of OctoPrint for enabling/disabling them. You
 can recognize such plugins by their implementations implementing :class:`~octoprint.plugin.ReloadNeedingPlugin` or
 :class:`~octoprint.plugin.RestartNeedingPlugin` or providing handlers for one of the hooks marked correspondingly.
+For these plugins, disabling them will *not* trigger the respective callback at runtime as they will not actually
+be disabled right away but only marked as such so that they won't even load during the required restart.
+
+Note that uninstalling a plugin through the bundled Plugin Manager will make a plugin first get disabled and
+then unloaded, but only if it doesn't require a restart. Plugins wishing to react to an uninstall through the
+Plugin Manager may implement :func:`~octoprint.plugin.types.OctoPrintPlugin.on_plugin_pending_uninstall` (added in OctoPrint 1.8.0) which will always be called by the Plugin Manager,
+regardless of whether the plugin requires a restart of OctoPrint to be fully uninstalled or not. Please be aware
+that the Plugin Manager is not the only way to uninstall a plugin from the system, a user may also uninstall it
+manually through the command line, circumventing Plugin Manager completely.
 
 .. image:: ../images/plugins_lifecycle.png
    :align: center

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -2401,9 +2401,15 @@ class Plugin(object):
         pass
 
     def on_plugin_enabled(self):
+        """
+        Called by the plugin core when the plugin was enabled. Override this to react to the event.
+        """
         pass
 
     def on_plugin_disabled(self):
+        """
+        Called by the plugin core when the plugin was disabled. Override this to react to the event.
+        """
         pass
 
 

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -125,6 +125,14 @@ class OctoPrintPlugin(Plugin):
             os.makedirs(self._data_folder)
         return self._data_folder
 
+    def on_plugin_pending_uninstall(self):
+        """
+        Called by the plugin manager when the plugin is pending uninstall. Override this to react to the event.
+
+        NOT called during plugin uninstalls triggered outside of OctoPrint!
+        """
+        pass
+
 
 class ReloadNeedingPlugin(Plugin):
     """

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -1269,6 +1269,14 @@ class PluginManagerPlugin(
             )
             abort(500, description="Could not uninstall plugin, its origin is unknown")
 
+        if plugin.implementation:
+            try:
+                plugin.implementation.on_plugin_pending_uninstall()
+            except Exception:
+                self._logger.exception(
+                    "Error while calling on_plugin_pending_uninstall on the plugin, proceeding regardless"
+                )
+
         if plugin.origin.type == "entry_point":
             # plugin is installed through entry point, need to use pip to uninstall it
             origin = plugin.origin[3]


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This adds a new `on_plugin_pending_uninstall` callback to `octoprint.plugin.types.OctoPrintPlugin` (and therefore all plugin implementations) that will be called when a plugin is uninstalled *through the Plugin Manager*. That way plugins can react to a pending uninstall and perform any necessary cleanup tasks. Note that this method will **not** be called if the plugin is uninstalled externally of OctoPrint, e.g. by deleting it or a `pip uninstall`.

#### How was it tested? How can it be tested by the reviewer?

Uninstalling this:

``` python
import octoprint.plugin

class UninstallTestPlugin(octoprint.plugin.OctoPrintPlugin):
    def on_plugin_pending_uninstall(self):
        self._logger.info("I am about to get uninstalled!")

__plugin_pythoncompat__ = ">3"
__plugin_implementation__ = UninstallTestPlugin()
```

should log a message about pending uninstall.

#### Any background context you want to provide?

[Recent discussion on Discord](https://discord.com/channels/704958479194128507/708230829050036236/895235133009965067).

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
