### PR TITLE
Fixing A Bug In A Past PR - Trying To Change The Default Plugin Sort

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -149,6 +149,7 @@ date of first contribution):
   * [Ian Wilt](https://github.com/ianwiltdotcom)
   * [Ben Sycha](https://github.com/Sycha)
   * [Bryan Kenote](https://github.com/bryankenote)
+  * [Quinn Damerell](https://github.com/QuinnDamerell)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -50,7 +50,7 @@ $(function () {
                     return !item.enabled;
                 }
             },
-            "popularity",
+            "name",
             [],
             [
                 ["bundled", "3rdparty"],
@@ -138,7 +138,7 @@ $(function () {
                     return !plugin.abandoned;
                 }
             },
-            "title",
+            "popularity",
             ["filter_installed", "filter_incompatible"],
             [],
             0


### PR DESCRIPTION
  * [✅] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [✅] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [✅] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [✅] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [✅] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [✅] Your changes follow the existing coding style
  * [✅] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [✅] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [✅] You have run the existing unit tests against your changes and
    nothing broke
  * [✅] You have added yourself to the AUTHORS.md file :)

This PR fixes a small issue in a past PR, when Joe tried to change the default plugin sort from name to 'popular'.

Here's the PR for reference:
https://github.com/OctoPrint/OctoPrint/pull/4031

I saw this change in the release notes a few months back and it has baffled me why I never saw the change reflected on new installs. I dug into it and I found that the wrong list object was updated with the sort type, so I reverted the incorrect list back and fixed it.