### PR TITLE
🐛 Gcode Viewer: Preventing middle mouse wheel from scrolling the entire page and panning the canvas.

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -476,16 +476,16 @@ $(function () {
                 .on("slide", self.changeCommandRange);
         };
 
-        self._configureContainerElement = function(containerElement) {
+        self._configureContainerElement = function (containerElement) {
             // Prevent the default browser action for the mouse wheel down event. The desired behavor is to have the
             // gocde canvas pan on mouse down + drag, which happens. But if we don't prevent the default action, the browser
             // will also scroll the entire page.
-            containerElement.mousedown(function(event){
+            containerElement.mousedown(function (event) {
                 // Middle mouse button
                 if (event.which === 2) {
                     event.preventDefault();
                 }
-            })
+            });
         };
 
         self.loadFile = function (path, date) {


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

This fixes a bug reported by @MarcelloTheArcane, where in the gcode viewer, the middle mouse wheel pans the gcode canvas and the entire webpage. The desired behavior is to have the middle mouse wheel + drag to only pan the gcode canvas.

#### How was it tested? How can it be tested by the reviewer?

I tested the fix by running a local copy of my change on my Pi and ensuring the fix worked correctly.

#### Any background context you want to provide?

Nope

#### What are the relevant tickets if any?

Reported Bug:
https://github.com/OctoPrint/OctoPrint/issues/4218

#### Screenshots (if appropriate)

#### Further notes
