### PR TITLE
:pencil: use slash in git bash

### DIFF
--- a/docs/development/environment.rst
+++ b/docs/development/environment.rst
@@ -180,7 +180,7 @@ Open the Git Bash you just installed and in that:
    cd /c/Devel
    git clone https://github.com/OctoPrint/OctoPrint.git
    cd OctoPrint
-   virtualenv --python=C:\Python3\python.exe venv3
+   virtualenv --python=C:/Python3/python.exe venv3
    source ./venv3/Scripts/activate
    pip install --upgrade pip
    python -m pip install -e '.[develop,plugins,docs]'
@@ -207,7 +207,7 @@ Then:
 .. code-block:: none
 
    cd /c/Devel/OctoPrint
-   virtualenv --python=C:\Python27\python.exe venv2
+   virtualenv --python=C:/Python27/python.exe venv2
    source ./venv2/Scripts/activate
    python -m pip install --upgrade pip
    pip install -e '.[develop,plugins]'


### PR DESCRIPTION
- changed backslashes to normal slashes for the creation of the venv.

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
This PR changes the documentation for the venv command under windows.
It is not working with backslashes because the command is running in the git bash
#### How was it tested? How can it be tested by the reviewer?
as per the instructions in the documentation
