### PR TITLE
Provide a content-length for streaming zip downloads

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -154,6 +154,7 @@ date of first contribution):
   * [Bryan Kenote](https://github.com/bryankenote)
   * [Quinn Damerell](https://github.com/QuinnDamerell)
   * [Sven Samoray](https://github.com/thelastWallE)
+  * [Carey Metcalfe](https://github.com/pR0Ps)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/THIRDPARTYLICENSES.md
+++ b/THIRDPARTYLICENSES.md
@@ -74,6 +74,7 @@
   * [watchdog](http://github.com/gorakhargosh/watchdog): Apache License 2.0
   * [websocket-client](https://github.com/liris/websocket-client): LGPLv3
   * [wrapt](http://wrapt.readthedocs.org/): BSD
+  * [zipstream-ng](https://github.com/pR0Ps/zipstream-ng): LGPLv3
 
 ## Development (testing, documentation generation, etc)
 

--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ INSTALL_REQUIRES = [
     "sentry-sdk>=0.15.1,<1",
     "filetype>=1.0.7,<2",
     "zeroconf>=0.33,<0.34",
-    "zipstream-new>=1.1.8,<1.2",
+    "zipstream-ng>=1.3.1,<2.0.0",
     "pathvalidate>=2.4.1,<3",
     "colorlog>=5.0.1,<6",
     # vendor bundled dependencies

--- a/src/octoprint/cli/systeminfo.py
+++ b/src/octoprint/cli/systeminfo.py
@@ -6,7 +6,7 @@ import logging
 import os
 
 import click
-import zipstream
+from zipstream.ng import ZIP_DEFLATED, ZipStream
 
 from octoprint.cli import init_platform_for_cli, standard_options
 
@@ -42,39 +42,28 @@ def get_systeminfo(environment_detector, connectivity_checker, additional_fields
 def get_systeminfo_bundle(systeminfo, logbase, printer=None, plugin_manager=None):
     from octoprint.util import to_bytes
 
+    try:
+        z = ZipStream(compress_type=ZIP_DEFLATED)
+    except RuntimeError:
+        # no zlib support
+        z = ZipStream(sized=True)
+
+    if printer and printer.is_operational():
+        firmware_info = printer.firmware_info
+        if firmware_info:
+            # add firmware to systeminfo so it's included in systeminfo.txt
+            systeminfo["printer.firmware"] = firmware_info["name"]
+
+        # Add printer log, if available
+        if hasattr(printer, "_log"):
+            z.add(to_bytes("\n".join(printer._log)), "terminal.txt")
+
+    # add systeminfo
     systeminfotxt = []
     for k in sorted(systeminfo.keys()):
         systeminfotxt.append("{}: {}".format(k, systeminfo[k]))
 
-    terminaltxt = None
-    if printer and printer.is_operational():
-        firmware_info = printer.firmware_info
-        if firmware_info:
-            systeminfo["printer.firmware"] = firmware_info["name"]
-
-        if hasattr(printer, "_log"):
-            terminaltxt = list(printer._log)
-
-    try:
-        import zlib  # noqa: F401
-
-        compress_type = zipstream.ZIP_DEFLATED
-    except ImportError:
-        # no zlib, no compression
-        compress_type = zipstream.ZIP_STORED
-
-    z = zipstream.ZipFile()
-
-    # add systeminfo
-    z.writestr(
-        "systeminfo.txt", to_bytes("\n".join(systeminfotxt)), compress_type=compress_type
-    )
-
-    # add terminal.txt, if available
-    if terminaltxt:
-        z.writestr(
-            "terminal.txt", to_bytes("\n".join(terminaltxt)), compress_type=compress_type
-        )
+    z.add(to_bytes("\n".join(systeminfotxt)), arcname="systeminfo.txt")
 
     # add logs
     for log in (
@@ -83,7 +72,7 @@ def get_systeminfo_bundle(systeminfo, logbase, printer=None, plugin_manager=None
     ):
         logpath = os.path.join(logbase, log)
         if os.path.exists(logpath):
-            z.write(logpath, arcname=log, compress_type=compress_type)
+            z.add_path(logpath, arcname=log)
 
     # add additional bundle contents from bundled plugins
     if plugin_manager:
@@ -103,10 +92,10 @@ def get_systeminfo_bundle(systeminfo, logbase, printer=None, plugin_manager=None
                     if isinstance(content, str):
                         # log path
                         if os.path.exists(content) and os.access(content, os.R_OK):
-                            z.write(content, arcname=log, compress_type=compress_type)
+                            z.add_path(content, arcname=log)
                     elif callable(content):
                         # content generating callable
-                        z.writestr(log, to_bytes(content()), compress_type=compress_type)
+                        z.add(to_bytes(content()), arcname=log)
             except Exception:
                 logging.getLogger(__name__).exception(
                     "Error while retrieving additional bundle contents for plugin {}".format(
@@ -170,8 +159,7 @@ def systeminfo_command(ctx, path, **kwargs):
             )
             try:
                 with open(zipfilename, "wb") as f:
-                    for data in z:
-                        f.write(data)
+                    f.writelines(z)
             except Exception as e:
                 click.echo(str(e), err=True)
                 click.echo(f"There was an error writing to {zipfilename}.", err=True)

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -20,6 +20,7 @@ import tornado.iostream
 import tornado.tcpserver
 import tornado.util
 import tornado.web
+from zipstream.ng import ZIP_DEFLATED, ZipStream
 
 import octoprint.util
 
@@ -1434,32 +1435,28 @@ class StaticZipBundleHandler(CorsSupportMixin, tornado.web.RequestHandler):
                 f'attachment; filename="{self.get_attachment_name()}"',
             )
 
-        import zipstream
-
-        compress_type = zipstream.ZIP_STORED
+        z = ZipStream(sized=True)
         if self._compress:
             try:
-                import zlib  # noqa: F401
-
-                compress_type = zipstream.ZIP_DEFLATED
-            except ImportError:
-                # no zlib, no compression
+                z = ZipStream(compress_type=ZIP_DEFLATED)
+            except RuntimeError:
+                # no zlib support
                 pass
 
-        z = zipstream.ZipFile()
         for f in self.normalize_files(files):
             # noinspection PyCompatibility
             name = f.get("name")
             path = f.get("path")
-            iter = f.get("iter")
-            content = f.get("content")
+            data = f.get("iter") or f.get("content")
 
             if path:
-                z.write(path, arcname=name, compress_type=compress_type)
-            elif iter and name:
-                z.write_iter(name, iter, compress_type=compress_type)
-            elif content and name:
-                z.writestr(name, content, compress_type=compress_type)
+                z.add_path(path, arcname=name)
+            elif data and name:
+                z.add(data, arcname=name)
+
+        if z.sized:
+            self.set_header("Content-Length", len(z))
+        self.set_header("Last-Modified", z.last_modified)
 
         for chunk in z:
             try:
@@ -1582,6 +1579,9 @@ class SystemInfoBundleHandler(CorsSupportMixin, tornado.web.RequestHandler):
             "Content-Disposition",
             f'attachment; filename="{get_systeminfo_bundle_name()}"',
         )
+        if z.sized:
+            self.set_header("Content-Length", len(z))
+        self.set_header("Last-Modified", z.last_modified)
 
         for chunk in z:
             try:


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have made sure your changes don't interfere with current development by talking it through with the maintainers, e.g. through a Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely new feature, or maintenance if it's a bug fix or improvement of existing functionality for the current stable version (no PRs against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master, maintenance or devel please), e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase and squash your PR if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the .less source files, not the .css files (those are generated with lessc)
  * [x] You have tested your changes (please state how!) - ideally you have added unit tests
  * [x] You have run the existing unit tests against your changes and nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
This PR improves the existing zip streaming functionality by setting the size of the generated zip as the `Content-Length` header in the response (where possible). This allows browsers and other clients to check for free space, calculate download progress, and detect if the download fails (they get less data than expected). This is most useful when downloading multiple timelapses due to their potential size.

This is enabled by using [`zipstream-ng`](https://github.com/pR0Ps/zipstream-ng) (a library I maintain) to generate the zip streams since it provides the ability to calculate the final size of a zip file before actually creating and streaming it.

Also, a small oversight where the printer's firmware wasn't being added to `systeminfo.txt` when downloading system info was fixed.

#### How was it tested? How can it be tested by the reviewer?
Timelapse downloads were tested by adding setting up timelapse recording, adding a virtual printer, and "printing" a sample file multiple times. This generated multiple timelapses. All the timelapses were then selected and downloaded. The download prompt showed the total size of the zip file (see attached screenshot). After downloading the zipfile was extracted and the contents were verified to be the same as when downloading the files individually.

A similar process (but with less setup) was used to verify log and system information zip downloads. Generating a zip file on the local filesystem was tested using `octoprint systeminfo .`

#### Any background context you want to provide?
The reason this PR is based against the `devel` branch is that the added library does not support Python 2.7 which is currently still supported in the `maintenance` branch.

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
![timelapse-download](https://user-images.githubusercontent.com/466941/140864348-7cbe9145-c05b-4845-87b1-4f9cb788592c.png)