### PR TITLE
Add ipv6 loopback address to example

### DIFF
--- a/docs/features/accesscontrol.rst
+++ b/docs/features/accesscontrol.rst
@@ -184,6 +184,7 @@ further down there's also a dedicated list of steps for OctoPi specifically.
           autologinAs: "<yourUsername>"
           localNetworks:
           - "127.0.0.0/8"
+          - "::1/128"
           - "<yourAddressRange>"
 
 4. Restart OctoPrint, check that everything works.


### PR DESCRIPTION
on my recently installed rpi 4b device with the latest octopi image, `localhost` resolves to `::1`, which I hadn't thought to add to the `localNetworks` list in the config.  With this change people following this guide as I did will end up adding the ipv6 version so that `localhost` will correctly resolve regardless of which network stack is active and primary.

#### What does this PR do and why is it necessary?

Minor documentation fix to correct an issue I encountered trying to get autologinAs to work so that I could replace my printers simple LCD display with a raspberry pi connected touchscreen

#### How was it tested? How can it be tested by the reviewer?

* Image a Raspberry Pi with the Octopi image and ensure it's connected to a display either through the ribbon cable or HDMI
* Connect the rpi to an IPv6 enabled local network and verify that `ping localhost` on the rpi resolves to `::1` (I'm using the Ether net port on my Pi, not sure if this matters)
* Configure autologin as per the guide (but don't include the `::1/128` address that this change introduces)
* Restart the Pi and verify that the login screen appears when you open a browser and connect to `localhost`
* Update the `~/.octoprint/config.yaml` again to include the `::1/128`
* Restart the Pi and retest, verify that the login screen _does not_ appear.

#### Any background context you want to provide?

This may be related to my router being fully IPv6 enabled and my connecting the Pi to it over ethernet rather than Wifi (which goes through a second NAT layer and may or may not have IPv6 enabled.

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

None

#### Further notes

