### PR TITLE
Enable Deflate for web socket connections

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -337,6 +337,7 @@ class Server(object):
         # monkey patch/fix some stuff
         util.tornado.fix_json_encode()
         util.tornado.fix_websocket_check_origin()
+        util.tornado.enable_per_message_deflate_extension()
         util.flask.fix_flask_jsonify()
         util.watchdog.fix_scandir()
 

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -54,6 +54,22 @@ def fix_json_encode():
     tornado.escape.json_encode = fixed_json_encode
 
 
+def enable_per_message_deflate_extension():
+    """
+    This configures tornado.websocket.WebSocketHandler.get_compression_options to support the permessage-deflate extension
+    to the websocket protocol, minimizing data bandwidth if clients support the extension as well
+    """
+
+    def get_compression_options(self):
+        return {"compression_level": 1, "mem_level": 1}
+
+    tornado.websocket.WebSocketHandler.get_compression_options = get_compression_options
+
+
+# enabled 5/5: MEASUREMENT: read=9197 written=424
+# disabled:
+
+
 def fix_websocket_check_origin():
     """
     This fixes tornado.websocket.WebSocketHandler.check_origin to do the same origin check against the Host
@@ -84,6 +100,9 @@ def fix_websocket_check_origin():
 
     tornado.websocket.WebSocketHandler.check_origin = patched_check_origin
 
+
+# 90 kb with compression 5
+# 100 kb without compression
 
 # ~~ More sensible logging
 

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -66,10 +66,6 @@ def enable_per_message_deflate_extension():
     tornado.websocket.WebSocketHandler.get_compression_options = get_compression_options
 
 
-# enabled 5/5: MEASUREMENT: read=9197 written=424
-# disabled:
-
-
 def fix_websocket_check_origin():
     """
     This fixes tornado.websocket.WebSocketHandler.check_origin to do the same origin check against the Host

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -101,9 +101,6 @@ def fix_websocket_check_origin():
     tornado.websocket.WebSocketHandler.check_origin = patched_check_origin
 
 
-# 90 kb with compression 5
-# 100 kb without compression
-
 # ~~ More sensible logging
 
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR drastically reduces the bandwidth used by the web socket by enabling the `permessage-deflate` extension of the websocket protocol. This is supported by Tornado 4.5 and up.

#### How was it tested? How can it be tested by the reviewer?

I created a small benchmark by starting OctoPrint with and without compression, starting OctoApp and counting the bytes received by the web socket within 60s. With the changes, OctoPrint mirrors back the `Sec-WebSocket-Extensions: permessage-deflate` header (see screenshot).

No compression as currently in OctoPrint: 114 / 131 / 138 kb
Minimal compression as in PR: 8 / 8 / 8 kb

The increase in the data volume over time is due to the growing history message (I assume) but is negligible in the compressed tests.

Changes are also tested with Safari and Chrome, both actually already included the `Sec-WebSocket-Extensions: permessage-deflate` header to request compression

I tested the compression on a OctoPi running on a Raspberry Pi 3B (non +) and with 10 open tabs and the Resource Monitor plugin that sends a lot of data via the web socket, the CPU usage of OctoPrint was unchanged in the 18-20% range (0-400) compared to the same OctoPrint version without the compression. 

Tested on platforms:

- [x] macOS
- [x] OctoPi
- [x] Windows

#### Any background context you want to provide?

Reducing the bandwidth is essential for mobile applications and also some tunnels limit the bandwidth (e.g. TSD with 50MB/month)

#### What are the relevant tickets if any?

/

#### Screenshots (if appropriate)

![Screenshot 2021-11-25 at 17 06 21](https://user-images.githubusercontent.com/5859228/143473484-e1228d69-12ee-4561-a070-6f1abb9da956.png)

#### Further notes
