### PR TITLE
✨ virtual: Add printer lock feature

### DIFF
--- a/src/octoprint/plugins/virtual_printer/__init__.py
+++ b/src/octoprint/plugins/virtual_printer/__init__.py
@@ -74,6 +74,8 @@ class VirtualPrinterPlugin(
             "enable_eeprom": True,
             "support_M503": True,
             "resend_ratio": 0,
+            "passwordOnStart": False,
+            "password": "1234",
         }
 
     def get_settings_version(self):

--- a/src/octoprint/plugins/virtual_printer/__init__.py
+++ b/src/octoprint/plugins/virtual_printer/__init__.py
@@ -74,8 +74,8 @@ class VirtualPrinterPlugin(
             "enable_eeprom": True,
             "support_M503": True,
             "resend_ratio": 0,
-            "passwordOnStart": False,
-            "password": "1234",
+            "locked": False,
+            "passcode": "1234",
         }
 
     def get_settings_version(self):

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -186,7 +186,7 @@ class VirtualPrinter(object):
 
         self._capabilities = self._settings.get(["capabilities"], merged=True)
 
-        self._locked = self._settings.get_boolean(["passwordOnStart"])
+        self._locked = self._settings.get_boolean(["locked"])
 
         self._temperature_reporter = None
         self._sdstatus_reporter = None
@@ -319,7 +319,7 @@ class VirtualPrinter(object):
                 for item in self._settings.get(["resetLines"]):
                     self._send(item + "\n")
 
-            self._locked = self._settings.get_boolean(["passwordOnStart"])
+            self._locked = self._settings.get_boolean(["locked"])
 
     @property
     def timeout(self):
@@ -910,8 +910,9 @@ class VirtualPrinter(object):
         else:
             time.sleep(timeout)
 
-    # Password Feature - lock with M510, unlock with M511 P<password>.
+    # Passcode Feature - lock with M510, unlock with M511 P<passcode>.
     # https://marlinfw.org/docs/gcode/M510.html / https://marlinfw.org/docs/gcode/M511.html
+
     def _gcode_M510(self, data):
         self._locked = True
 
@@ -919,11 +920,11 @@ class VirtualPrinter(object):
         if self._locked:
             matchP = re.search(r"P([0-9]+)", data)
             if matchP:
-                password = matchP.group(1)
-                if password == self._settings.get(["password"]):
+                passcode = matchP.group(1)
+                if passcode == self._settings.get(["passcode"]):
                     self._locked = False
                 else:
-                    self._send("Incorrect Password")
+                    self._send("Incorrect passcode")
 
     # EEPROM management commands
 


### PR DESCRIPTION
For testing behaviour when the printer is locked. Marlin feature, enabled with `PASSWORD_FEATURE`.

Can be enabled on startup, where no communication is possible until unlock. In Marlin, it accepts a 1-9 digit password.

Also added/fixed OKs not being sent on Klipper MCU errors. Possible resolution to the hanging experienced debugging https://github.com/OctoPrint/OctoPrint/issues/4299#issuecomment-978112886

Tested locally, Windows 10/Python 3.9. 
