### PR TITLE
Check if paused for printer.is_ready

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -157,6 +157,7 @@ date of first contribution):
   * [Christian Würthner](https://github.com/crysxd)
   * [Maciej Urbański](https://github.com/rooterkyberian)
   * [Adam Wolf](https://github.com/adamwolf)
+  * [Didi Kohen](https://github.com/kohend)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -921,7 +921,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
     def is_ready(self, *args, **kwargs):
         return (
             self.is_operational()
-            and not self.is_printing()
+            and not self._comm.isBusy()
+            # isBusy is true when paused
             and not self._comm.isStreaming()
         )
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Checks for paused print in the is_ready method.

#### How was it tested? How can it be tested by the reviewer?
With the BetterHeaterTimeout plugin, it can be tested by anything that checks the is_ready API while the printer is ready and when it's paused.

#### Any background context you want to provide?
Found it when using BetterHeaterTimeout plugin

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/309245/145224599-b6c2d584-60f7-47a9-95ef-c767978a9b25.png)

#### Further notes
