### PR TITLE
Use C++ HierarchicalChainMap

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ INSTALL_REQUIRES_PYTHON3 = [
     "colorlog>=5.0.1,<6",
     # vendor bundled dependencies
     "unidecode",  # dependency of awesome-slugify, leave w/o range to not cause dependency hell w/ Octolapse deps
+    "op_hierarchical_chainmap @ git+https://github.com/flaviut/op-hierarchical-chainmap.git@1e61f5e941552838393525032f59de7085936485#egg=op_hierarchical_chainmap",
 ]
 
 # OSX specific requirements

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -705,7 +705,15 @@ class Settings(object):
 
         assert isinstance(default_settings, dict)
 
-        self._map = HierarchicalChainMap({}, default_settings)
+        try:
+            from op_hierarchical_chainmap import (
+                HierarchicalChainMap as CppHierarchicalChainMap,
+            )
+
+            self._map = CppHierarchicalChainMap({}, default_settings)
+        except ImportError:
+            self._map = HierarchicalChainMap({}, default_settings)
+
         self.load_overlays(overlays)
 
         self._config = None


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This replaces the HierarchicalChainMap with a version written in C++. That means that Octoprint's settings functionality gets faster throughout, without any breaking changes.

On my machine, this improves the response time of /api/settings from 1.6s to .4s.

#### How was it tested? How can it be tested by the reviewer?

- unit tests on the implementation of the ChainMap
- unit tests comparing the python HierarchicalChainMap to the C++
- manual testing by loading into octoprint
- running the above under valgrind to test for memory safety issues (you must use `./configure --with-valgrind ...` when building python)

#### Any background context you want to provide?

https://github.com/OctoPrint/OctoPrint/pull/4236 is a re-write of this functionally in a simpler & more logical way, but isn't compatible with the existing code in certain edge cases.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

![before](https://user-images.githubusercontent.com/5213469/145682394-2a243226-b732-4205-b8da-bdf4c82f3305.png)
![after](https://user-images.githubusercontent.com/5213469/145682395-b2454594-0b0c-425c-bfea-03cba1126e70.png)

#### Further notes
