### PR TITLE
Use -framerate instead of -r by default

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -158,6 +158,7 @@ date of first contribution):
   * [Maciej Urbański](https://github.com/rooterkyberian)
   * [Adam Wolf](https://github.com/adamwolf)
   * [Didi Kohen](https://github.com/kohend)
+  * [Taylor Talkington](https://github.com/The-EG)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -262,7 +262,7 @@ default_settings = {
         "flipH": False,
         "flipV": False,
         "rotate90": False,
-        "ffmpegCommandline": '{ffmpeg} -r {fps} -i "{input}" -vcodec {videocodec} -threads {threads} -b:v {bitrate} -f {containerformat} -y {filters} "{output}"',
+        "ffmpegCommandline": '{ffmpeg} -framerate {fps} -i "{input}" -vcodec {videocodec} -threads {threads} -b:v {bitrate} -f {containerformat} -y {filters} "{output}"',
         "timelapse": {
             "type": "off",
             "options": {},


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] ~~If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket~~
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] ~~If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)~~
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This changes the default timelapse ffmpeg command to use the `-framerate` option instead of `-r`. This should address #4153 for new installations.

#### How was it tested? How can it be tested by the reviewer?

- Ran pytest and pre-commit per CONTRIBUTING. 
- Verified `-framerate` is used by default on new configuration.

#### Any background context you want to provide?
The ffmpeg documents state (emphasis mine):
> r[:stream_specifier] fps (input/output,per-stream)
> 
> Set frame rate (Hz value, fraction or abbreviation).
> 
> As an input option, ignore any timestamps stored in the file and instead generate timestamps assuming constant frame rate fps. **This is not the same as the -framerate option used for some input formats like image2 or v4l2 (it used to be the same in older versions of FFmpeg). If in doubt use -framerate instead of the input option -r.**



#### What are the relevant tickets if any?
#4153 

#### Screenshots (if appropriate)

#### Further notes
