### PR TITLE
Update service script README to include daemon-reload for systemd users.

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,7 +28,12 @@ Download the systemd files to the locations shown:
 octoprint.service   => /etc/systemd/system/octoprint.service
 ```
 
-Next, enable and start the `octoprint` service:
+Next, make necessary modifications (if any) then notify systemd:
+```sh
+sudo systemctl daemon-reload
+```
+
+Finally, enable and start the `octoprint` service:
 
 ```sh
 # Enable octoprint service


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Just a minor doc update. systemd won't pick up on the service addition/change until `daemon-reload` is called(or the system is rebooted).

#### How was it tested? How can it be tested by the reviewer?
In the same doc :)

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
