### PR TITLE
fix for timelapse percent sign issue

### DIFF
--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -202,7 +202,7 @@ def get_unrendered_timelapses():
 def delete_unrendered_timelapse(name):
     global _cleanup_lock
 
-    pattern = "%s{}*.jpg".format(util.glob_escape(name)) % ""
+    pattern = "{}*.jpg".format(util.glob_escape(name))
 
     basedir = settings().getBaseFolder("timelapse_tmp")
     with _cleanup_lock:

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -202,7 +202,7 @@ def get_unrendered_timelapses():
 def delete_unrendered_timelapse(name):
     global _cleanup_lock
 
-    pattern = "{}*.jpg".format(util.glob_escape(name))
+    pattern = "%s{}*.jpg".format(util.glob_escape(name)) % ""
 
     basedir = settings().getBaseFolder("timelapse_tmp")
     with _cleanup_lock:
@@ -593,7 +593,8 @@ class Timelapse(object):
         self._in_timelapse = True
         self._gcode_file = os.path.basename(gcode_file)
         self._file_prefix = "{}_{}".format(
-            os.path.splitext(self._gcode_file)[0], time.strftime("%Y%m%d%H%M%S")
+            os.path.splitext(self._gcode_file)[0].replace("%", "%%"),
+            time.strftime("%Y%m%d%H%M%S"),
         )
 
     def stop_timelapse(self, do_create_movie=True, success=True):


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
When filenames have the `%` sign in them capturing of images breaks the "old style" string format replacement. This resolves that with a simple replacement of `%` with `%%` for the file_prefix pattern. 

#### How was it tested? How can it be tested by the reviewer?
Tested locally with virtual printer and rendered timelapses. 

#### Any background context you want to provide?
Assume this is related to the ability of uploading files with special characters in their filenames with recent update to OctoPrint. 

#### What are the relevant tickets if any?
#4365 

#### Screenshots (if appropriate)

#### Further notes
