### PR TITLE
Timelapse thumbnails

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -754,9 +754,10 @@ class Server(object):
             )
         }
 
-        valid_timelapse = lambda path: not octoprint.util.is_hidden_path(
-            path
-        ) and octoprint.timelapse.valid_timelapse(path)
+        valid_timelapse = lambda path: not octoprint.util.is_hidden_path(path) and (
+            octoprint.timelapse.valid_timelapse(path)
+            or octoprint.timelapse.valid_timelapse_thumbnail(path)
+        )
         timelapse_path_validator = {
             "path_validation": util.tornado.path_validation_factory(
                 valid_timelapse,

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -182,6 +182,7 @@ def downloadTimelapse(filename):
 def deleteTimelapse(filename):
     timelapse_folder = settings().getBaseFolder("timelapse")
     full_path = os.path.realpath(os.path.join(timelapse_folder, filename))
+    thumb_path = octoprint.timelapse.create_thumbnail_path(full_path)
     if (
         octoprint.timelapse.valid_timelapse(full_path)
         and full_path.startswith(timelapse_folder)
@@ -195,6 +196,20 @@ def deleteTimelapse(filename):
                 "Error deleting timelapse file {}".format(full_path)
             )
             abort(500, description="Unexpected error: {}".format(ex))
+
+    if (
+        octoprint.timelapse.valid_timelapse_thumbnail(thumb_path)
+        and thumb_path.startswith(timelapse_folder)
+        and os.path.exists(thumb_path)
+        and not util.is_hidden_path(thumb_path)
+    ):
+        try:
+            os.remove(thumb_path)
+        except Exception as ex:
+            # Do not treat this as an error, log and ignore
+            logging.getLogger(__file__).warning(
+                "Unable to delete thumbnail {} ({})".format(thumb_path, ex)
+            )
 
     return getTimelapseData()
 

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -146,6 +146,13 @@ def getTimelapseData():
     for f in files:
         output = dict(f)
         output["url"] = url_for("index") + "downloads/timelapse/" + urlquote(f["name"])
+        if output["thumbnail"] is not None:
+            output["thumbnail"] = (
+                url_for("index") + "downloads/timelapse/" + urlquote(f["thumbnail"])
+            )
+        else:
+            output.pop("thumbnail", None)
+
         finished_list.append(output)
 
     result = {

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -263,6 +263,7 @@ default_settings = {
         "flipV": False,
         "rotate90": False,
         "ffmpegCommandline": '{ffmpeg} -r {fps} -i "{input}" -vcodec {videocodec} -threads {threads} -b:v {bitrate} -f {containerformat} -y {filters} "{output}"',
+        "ffmpegThumbnailCommandline": '{ffmpeg} -sseof -1 -i "{input}" -update 1 -q:v 0.7 "{output}"',
         "timelapse": {
             "type": "off",
             "options": {},

--- a/src/octoprint/static/css/octoprint.css
+++ b/src/octoprint/static/css/octoprint.css
@@ -1,1 +1,2921 @@
-.btn{display:inline-block;*display:inline;*zoom:1;padding:4px 12px;margin-bottom:0;font-size:14px;line-height:20px;text-align:center;vertical-align:middle;cursor:pointer;color:#333;text-shadow:0 1px 1px rgba(255,255,255,.75);background-color:#f5f5f5;background-image:-moz-linear-gradient(top,#fff,#e6e6e6);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#e6e6e6));background-image:-webkit-linear-gradient(top,#fff,#e6e6e6);background-image:-o-linear-gradient(top,#fff,#e6e6e6);background-image:linear-gradient(to bottom,#fff,#e6e6e6);background-repeat:repeat-x;*background-color:#e6e6e6;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false);border:1px solid #ccc;*border:0;border-bottom-color:#b3b3b3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;*margin-left:.3em;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05);box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05)}.btn.active,.btn.disabled,.btn:active,.btn:focus,.btn:hover,.btn[disabled]{color:#333;background-color:#e6e6e6;*background-color:#d9d9d9}.btn.active,.btn:active{background-color:#ccc \9}.btn:first-child{*margin-left:0}.btn:focus,.btn:hover{color:#333;text-decoration:none;background-position:0 -15px;-webkit-transition:background-position .1s linear;-moz-transition:background-position .1s linear;-o-transition:background-position .1s linear;transition:background-position .1s linear}.btn:focus{outline:#333 dotted thin;outline:-webkit-focus-ring-color auto 5px;outline-offset:-2px}.btn.active,.btn:active{background-image:none;outline:0;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05);box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05)}.btn.disabled,.btn[disabled]{cursor:default;background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.btn-large{padding:11px 19px;font-size:17.5px;-webkit-border-radius:6px;-moz-border-radius:6px;border-radius:6px}.btn-large [class*=" icon-"],.btn-large [class^=icon-]{margin-top:4px}.btn-small{padding:2px 10px;font-size:11.9px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.btn-small [class*=" icon-"],.btn-small [class^=icon-]{margin-top:0}.btn-mini [class*=" icon-"],.btn-mini [class^=icon-]{margin-top:-1px}.btn-mini{padding:0 6px;font-size:10.5px;-webkit-border-radius:3px;-moz-border-radius:3px;border-radius:3px}.btn-block{display:block;width:100%;padding-left:0;padding-right:0;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.btn-block+.btn-block{margin-top:5px}input[type=submit].btn-block,input[type=reset].btn-block,input[type=button].btn-block{width:100%}.btn-primary{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#006dcc;background-image:-moz-linear-gradient(top,#08c,#04c);background-image:-webkit-gradient(linear,0 0,0 100%,from(#08c),to(#04c));background-image:-webkit-linear-gradient(top,#08c,#04c);background-image:-o-linear-gradient(top,#08c,#04c);background-image:linear-gradient(to bottom,#08c,#04c);background-repeat:repeat-x;border-color:#04c #04c #002a80;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#04c;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-primary.active,.btn-primary.disabled,.btn-primary:active,.btn-primary:focus,.btn-primary:hover,.btn-primary[disabled]{color:#fff;background-color:#04c;*background-color:#003bb3}.btn-primary.active,.btn-primary:active{background-color:#039 \9}.btn-warning{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#faa732;background-image:-moz-linear-gradient(top,#fbb450,#f89406);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fbb450),to(#f89406));background-image:-webkit-linear-gradient(top,#fbb450,#f89406);background-image:-o-linear-gradient(top,#fbb450,#f89406);background-image:linear-gradient(to bottom,#fbb450,#f89406);background-repeat:repeat-x;border-color:#f89406 #f89406 #ad6704;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#f89406;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-warning.active,.btn-warning.disabled,.btn-warning:active,.btn-warning:focus,.btn-warning:hover,.btn-warning[disabled]{color:#fff;background-color:#f89406;*background-color:#df8505}.btn-warning.active,.btn-warning:active{background-color:#c67605 \9}.btn-danger{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#da4f49;background-image:-moz-linear-gradient(top,#ee5f5b,#bd362f);background-image:-webkit-gradient(linear,0 0,0 100%,from(#ee5f5b),to(#bd362f));background-image:-webkit-linear-gradient(top,#ee5f5b,#bd362f);background-image:-o-linear-gradient(top,#ee5f5b,#bd362f);background-image:linear-gradient(to bottom,#ee5f5b,#bd362f);background-repeat:repeat-x;border-color:#bd362f #bd362f #802420;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#bd362f;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-danger.active,.btn-danger.disabled,.btn-danger:active,.btn-danger:focus,.btn-danger:hover,.btn-danger[disabled]{color:#fff;background-color:#bd362f;*background-color:#a9302a}.btn-danger.active,.btn-danger:active{background-color:#942a25 \9}.btn-success{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#5bb75b;background-image:-moz-linear-gradient(top,#62c462,#51a351);background-image:-webkit-gradient(linear,0 0,0 100%,from(#62c462),to(#51a351));background-image:-webkit-linear-gradient(top,#62c462,#51a351);background-image:-o-linear-gradient(top,#62c462,#51a351);background-image:linear-gradient(to bottom,#62c462,#51a351);background-repeat:repeat-x;border-color:#51a351 #51a351 #387038;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#51a351;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-success.active,.btn-success.disabled,.btn-success:active,.btn-success:focus,.btn-success:hover,.btn-success[disabled]{color:#fff;background-color:#51a351;*background-color:#499249}.btn-success.active,.btn-success:active{background-color:#408140 \9}.btn-info{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#49afcd;background-image:-moz-linear-gradient(top,#5bc0de,#2f96b4);background-image:-webkit-gradient(linear,0 0,0 100%,from(#5bc0de),to(#2f96b4));background-image:-webkit-linear-gradient(top,#5bc0de,#2f96b4);background-image:-o-linear-gradient(top,#5bc0de,#2f96b4);background-image:linear-gradient(to bottom,#5bc0de,#2f96b4);background-repeat:repeat-x;border-color:#2f96b4 #2f96b4 #1f6377;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#2f96b4;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-info.active,.btn-info.disabled,.btn-info:active,.btn-info:focus,.btn-info:hover,.btn-info[disabled]{color:#fff;background-color:#2f96b4;*background-color:#2a85a0}.btn-info.active,.btn-info:active{background-color:#24748c \9}.btn-inverse{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#363636;background-image:-moz-linear-gradient(top,#444,#222);background-image:-webkit-gradient(linear,0 0,0 100%,from(#444),to(#222));background-image:-webkit-linear-gradient(top,#444,#222);background-image:-o-linear-gradient(top,#444,#222);background-image:linear-gradient(to bottom,#444,#222);background-repeat:repeat-x;border-color:#222 #222 #000;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#222;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.btn-inverse.active,.btn-inverse.disabled,.btn-inverse:active,.btn-inverse:focus,.btn-inverse:hover,.btn-inverse[disabled]{color:#fff;background-color:#222;*background-color:#151515}.btn-inverse.active,.btn-inverse:active{background-color:#080808 \9}button.btn,input[type=submit].btn{*padding-top:3px;*padding-bottom:3px}button.btn::-moz-focus-inner,input[type=submit].btn::-moz-focus-inner{padding:0;border:0}button.btn.btn-large,input[type=submit].btn.btn-large{*padding-top:7px;*padding-bottom:7px}button.btn.btn-small,input[type=submit].btn.btn-small{*padding-top:3px;*padding-bottom:3px}button.btn.btn-mini,input[type=submit].btn.btn-mini{*padding-top:1px;*padding-bottom:1px}.btn-link,.btn-link:active,.btn-link[disabled]{background-color:transparent;background-image:none;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.btn-link{border-color:transparent;cursor:pointer;color:#08c;-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.btn-link:focus,.btn-link:hover{color:#005580;text-decoration:underline;background-color:transparent}.btn-link[disabled]:focus,.btn-link[disabled]:hover{color:#333;text-decoration:none}.clearfix{*zoom:1}.clearfix:after,.clearfix:before{display:table;content:"";line-height:0}.clearfix:after{clear:both}.hide-text{font:0/0 a;color:transparent;text-shadow:none;background-color:transparent;border:0}.input-block-level{display:block;width:100%;min-height:30px;-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.nowrap{white-space:nowrap}.actioncol{text-align:center;white-space:nowrap}.actioncol a{text-decoration:none;color:#000}.actioncol a.disabled{color:#ccc;cursor:default}#navbar .navbar-inner{background-color:#ebebeb;background-image:-moz-linear-gradient(top,#fff,#ccc);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#ccc));background-image:-webkit-linear-gradient(top,#fff,#ccc);background-image:-o-linear-gradient(top,#fff,#ccc);background-image:linear-gradient(to bottom,#fff,#ccc);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffcccccc', GradientType=0)}#navbar .navbar-inner .brand,#navbar .navbar-inner .nav>li>a{text-shadow:0 1px 0 #ccc;color:#333}#navbar .navbar-inner .brand .caret,#navbar .navbar-inner .nav>li>a .caret{border-bottom-color:#939393;border-top-color:#939393}#navbar .navbar-inner .brand:focus .caret,#navbar .navbar-inner .brand:hover .caret,#navbar .navbar-inner .nav>li>a:focus .caret,#navbar .navbar-inner .nav>li>a:hover .caret{border-bottom-color:#636363;border-top-color:#636363}#navbar .navbar-inner .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner .nav>li.dropdown.open>.dropdown-toggle{background-color:#e0e0e0;background-image:-moz-linear-gradient(top,#ccc,#fff);background-image:-webkit-gradient(linear,0 0,0 100%,from(#ccc),to(#fff));background-image:-webkit-linear-gradient(top,#ccc,#fff);background-image:-o-linear-gradient(top,#ccc,#fff);background-image:linear-gradient(to bottom,#ccc,#fff);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffcccccc', endColorstr='#ffffffff', GradientType=0)}#navbar .navbar-inner .nav>li>a:hover{background-color:#dedede;background-image:-moz-linear-gradient(top,#f2f2f2,#bfbfbf);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f2f2f2),to(#bfbfbf));background-image:-webkit-linear-gradient(top,#f2f2f2,#bfbfbf);background-image:-o-linear-gradient(top,#f2f2f2,#bfbfbf);background-image:linear-gradient(to bottom,#f2f2f2,#bfbfbf);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2', endColorstr='#ffbfbfbf', GradientType=0)}#navbar .navbar-inner.transparent{background-color:rgba(235,235,235,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(255,255,255,.6),rgba(204,204,204,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(255,255,255,.6)),to(rgba(204,204,204,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(255,255,255,.6),rgba(204,204,204,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(255,255,255,.6),rgba(204,204,204,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(255,255,255,.6),rgba(204,204,204,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99ffffff', endColorstr='#99cccccc', GradientType=0)}#navbar .navbar-inner.transparent .brand,#navbar .navbar-inner.transparent .nav>li>a{text-shadow:0 1px 0 #ccc;color:#333}#navbar .navbar-inner.transparent .brand .caret,#navbar .navbar-inner.transparent .nav>li>a .caret{border-bottom-color:#939393;border-top-color:#939393}#navbar .navbar-inner.transparent .brand:focus .caret,#navbar .navbar-inner.transparent .brand:hover .caret,#navbar .navbar-inner.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.transparent .nav>li>a:hover .caret{border-bottom-color:#636363;border-top-color:#636363}#navbar .navbar-inner.transparent .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.transparent .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(224,224,224,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(204,204,204,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(204,204,204,.6)),to(rgba(255,255,255,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(204,204,204,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(204,204,204,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(204,204,204,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99cccccc', endColorstr='#99ffffff', GradientType=0)}#navbar .navbar-inner.transparent .nav>li>a:hover{background-color:rgba(222,222,222,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(242,242,242,.6),rgba(191,191,191,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(242,242,242,.6)),to(rgba(191,191,191,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(242,242,242,.6),rgba(191,191,191,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(242,242,242,.6),rgba(191,191,191,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(242,242,242,.6),rgba(191,191,191,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f2f2f2', endColorstr='#99bfbfbf', GradientType=0)}#navbar .navbar-inner.red{background-color:#bb645f;background-image:-moz-linear-gradient(top,#e28e8a,#802420);background-image:-webkit-gradient(linear,0 0,0 100%,from(#e28e8a),to(#802420));background-image:-webkit-linear-gradient(top,#e28e8a,#802420);background-image:-o-linear-gradient(top,#e28e8a,#802420);background-image:linear-gradient(to bottom,#e28e8a,#802420);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe28e8a', endColorstr='#ff802420', GradientType=0)}#navbar .navbar-inner.red .brand,#navbar .navbar-inner.red .nav>li>a{text-shadow:0 1px 0 #d86761;color:#f2f2f2}#navbar .navbar-inner.red .brand .caret,#navbar .navbar-inner.red .nav>li>a .caret{border-bottom-color:#d89491;border-top-color:#d89491}#navbar .navbar-inner.red .brand:focus .caret,#navbar .navbar-inner.red .brand:hover .caret,#navbar .navbar-inner.red .nav>li>a:focus .caret,#navbar .navbar-inner.red .nav>li>a:hover .caret{border-bottom-color:#e5c3c1;border-top-color:#e5c3c1}#navbar .navbar-inner.red .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.red .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.red .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.red .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.red .nav>li.dropdown.open>.dropdown-toggle{background-color:#a74f4a;background-image:-moz-linear-gradient(top,#802420,#e28e8a);background-image:-webkit-gradient(linear,0 0,0 100%,from(#802420),to(#e28e8a));background-image:-webkit-linear-gradient(top,#802420,#e28e8a);background-image:-o-linear-gradient(top,#802420,#e28e8a);background-image:linear-gradient(to bottom,#802420,#e28e8a);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff802420', endColorstr='#ffe28e8a', GradientType=0)}#navbar .navbar-inner.red .nav>li>a:hover{background-color:#af5651;background-image:-moz-linear-gradient(top,#dd7a75,#6b1f1b);background-image:-webkit-gradient(linear,0 0,0 100%,from(#dd7a75),to(#6b1f1b));background-image:-webkit-linear-gradient(top,#dd7a75,#6b1f1b);background-image:-o-linear-gradient(top,#dd7a75,#6b1f1b);background-image:linear-gradient(to bottom,#dd7a75,#6b1f1b);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdd7a75', endColorstr='#ff6b1f1b', GradientType=0)}#navbar .navbar-inner.red.transparent{background-color:rgba(187,100,95,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(226,142,138,.6),rgba(128,36,32,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(226,142,138,.6)),to(rgba(128,36,32,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(226,142,138,.6),rgba(128,36,32,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(226,142,138,.6),rgba(128,36,32,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(226,142,138,.6),rgba(128,36,32,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99e28e8a', endColorstr='#99802420', GradientType=0)}#navbar .navbar-inner.red.transparent .brand,#navbar .navbar-inner.red.transparent .nav>li>a{text-shadow:0 1px 0 #d86761;color:#f2f2f2}#navbar .navbar-inner.red.transparent .brand .caret,#navbar .navbar-inner.red.transparent .nav>li>a .caret{border-bottom-color:#d89491;border-top-color:#d89491}#navbar .navbar-inner.red.transparent .brand:focus .caret,#navbar .navbar-inner.red.transparent .brand:hover .caret,#navbar .navbar-inner.red.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.red.transparent .nav>li>a:hover .caret{border-bottom-color:#e5c3c1;border-top-color:#e5c3c1}#navbar .navbar-inner.red.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.red.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.red.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.red.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.red.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(167,79,74,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(128,36,32,.6),rgba(226,142,138,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(128,36,32,.6)),to(rgba(226,142,138,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(128,36,32,.6),rgba(226,142,138,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(128,36,32,.6),rgba(226,142,138,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(128,36,32,.6),rgba(226,142,138,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99802420', endColorstr='#99e28e8a', GradientType=0)}#navbar .navbar-inner.red.transparent .nav>li>a:hover{background-color:rgba(175,86,81,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(221,122,117,.6),rgba(107,31,27,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(221,122,117,.6)),to(rgba(107,31,27,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(221,122,117,.6),rgba(107,31,27,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(221,122,117,.6),rgba(107,31,27,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(221,122,117,.6),rgba(107,31,27,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99dd7a75', endColorstr='#996b1f1b', GradientType=0)}#navbar .navbar-inner.orange{background-color:#e39665;background-image:-moz-linear-gradient(top,#f9c3a0,#c2530c);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f9c3a0),to(#c2530c));background-image:-webkit-linear-gradient(top,#f9c3a0,#c2530c);background-image:-o-linear-gradient(top,#f9c3a0,#c2530c);background-image:linear-gradient(to bottom,#f9c3a0,#c2530c);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9c3a0', endColorstr='#ffc2530c', GradientType=0)}#navbar .navbar-inner.orange .brand,#navbar .navbar-inner.orange .nav>li>a{text-shadow:0 1px 0 #f6a570;color:#f2f2f2}#navbar .navbar-inner.orange .brand .caret,#navbar .navbar-inner.orange .nav>li>a .caret{border-bottom-color:#f2b58d;border-top-color:#f2b58d}#navbar .navbar-inner.orange .brand:focus .caret,#navbar .navbar-inner.orange .brand:hover .caret,#navbar .navbar-inner.orange .nav>li>a:focus .caret,#navbar .navbar-inner.orange .nav>li>a:hover .caret{border-bottom-color:#f2d3bf;border-top-color:#f2d3bf}#navbar .navbar-inner.orange .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.orange .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.orange .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.orange .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.orange .nav>li.dropdown.open>.dropdown-toggle{background-color:#d88047;background-image:-moz-linear-gradient(top,#c2530c,#f9c3a0);background-image:-webkit-gradient(linear,0 0,0 100%,from(#c2530c),to(#f9c3a0));background-image:-webkit-linear-gradient(top,#c2530c,#f9c3a0);background-image:-o-linear-gradient(top,#c2530c,#f9c3a0);background-image:linear-gradient(to bottom,#c2530c,#f9c3a0);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc2530c', endColorstr='#fff9c3a0', GradientType=0)}#navbar .navbar-inner.orange .nav>li>a:hover{background-color:#d98956;background-image:-moz-linear-gradient(top,#f8b488,#aa490a);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f8b488),to(#aa490a));background-image:-webkit-linear-gradient(top,#f8b488,#aa490a);background-image:-o-linear-gradient(top,#f8b488,#aa490a);background-image:linear-gradient(to bottom,#f8b488,#aa490a);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff8b488', endColorstr='#ffaa490a', GradientType=0)}#navbar .navbar-inner.orange.transparent{background-color:rgba(227,150,101,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(249,195,160,.6),rgba(194,83,12,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(249,195,160,.6)),to(rgba(194,83,12,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(249,195,160,.6),rgba(194,83,12,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(249,195,160,.6),rgba(194,83,12,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(249,195,160,.6),rgba(194,83,12,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f9c3a0', endColorstr='#99c2530c', GradientType=0)}#navbar .navbar-inner.orange.transparent .brand,#navbar .navbar-inner.orange.transparent .nav>li>a{text-shadow:0 1px 0 #f6a570;color:#f2f2f2}#navbar .navbar-inner.orange.transparent .brand .caret,#navbar .navbar-inner.orange.transparent .nav>li>a .caret{border-bottom-color:#f2b58d;border-top-color:#f2b58d}#navbar .navbar-inner.orange.transparent .brand:focus .caret,#navbar .navbar-inner.orange.transparent .brand:hover .caret,#navbar .navbar-inner.orange.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.orange.transparent .nav>li>a:hover .caret{border-bottom-color:#f2d3bf;border-top-color:#f2d3bf}#navbar .navbar-inner.orange.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.orange.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.orange.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.orange.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.orange.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(216,128,71,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(194,83,12,.6),rgba(249,195,160,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(194,83,12,.6)),to(rgba(249,195,160,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(194,83,12,.6),rgba(249,195,160,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(194,83,12,.6),rgba(249,195,160,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(194,83,12,.6),rgba(249,195,160,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c2530c', endColorstr='#99f9c3a0', GradientType=0)}#navbar .navbar-inner.orange.transparent .nav>li>a:hover{background-color:rgba(217,137,86,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(248,180,136,.6),rgba(170,73,10,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(248,180,136,.6)),to(rgba(170,73,10,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(248,180,136,.6),rgba(170,73,10,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(248,180,136,.6),rgba(170,73,10,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(248,180,136,.6),rgba(170,73,10,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f8b488', endColorstr='#99aa490a', GradientType=0)}#navbar .navbar-inner.yellow{background-color:#e3d765;background-image:-moz-linear-gradient(top,#f9f0a0,#c2b00c);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f9f0a0),to(#c2b00c));background-image:-webkit-linear-gradient(top,#f9f0a0,#c2b00c);background-image:-o-linear-gradient(top,#f9f0a0,#c2b00c);background-image:linear-gradient(to bottom,#f9f0a0,#c2b00c);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9f0a0', endColorstr='#ffc2b00c', GradientType=0)}#navbar .navbar-inner.yellow .brand,#navbar .navbar-inner.yellow .nav>li>a{text-shadow:0 1px 0 #c2b00c;color:#f2f2f2}#navbar .navbar-inner.yellow .brand .caret,#navbar .navbar-inner.yellow .nav>li>a .caret{border-bottom-color:#f2e88d;border-top-color:#f2e88d}#navbar .navbar-inner.yellow .brand:focus .caret,#navbar .navbar-inner.yellow .brand:hover .caret,#navbar .navbar-inner.yellow .nav>li>a:focus .caret,#navbar .navbar-inner.yellow .nav>li>a:hover .caret{border-bottom-color:#f2edbf;border-top-color:#f2edbf}#navbar .navbar-inner.yellow .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.yellow .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.yellow .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.yellow .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.yellow .nav>li.dropdown.open>.dropdown-toggle{background-color:#d8ca47;background-image:-moz-linear-gradient(top,#c2b00c,#f9f0a0);background-image:-webkit-gradient(linear,0 0,0 100%,from(#c2b00c),to(#f9f0a0));background-image:-webkit-linear-gradient(top,#c2b00c,#f9f0a0);background-image:-o-linear-gradient(top,#c2b00c,#f9f0a0);background-image:linear-gradient(to bottom,#c2b00c,#f9f0a0);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc2b00c', endColorstr='#fff9f0a0', GradientType=0)}#navbar .navbar-inner.yellow .nav>li>a:hover{background-color:#d9cc56;background-image:-moz-linear-gradient(top,#f8ed88,#aa9a0a);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f8ed88),to(#aa9a0a));background-image:-webkit-linear-gradient(top,#f8ed88,#aa9a0a);background-image:-o-linear-gradient(top,#f8ed88,#aa9a0a);background-image:linear-gradient(to bottom,#f8ed88,#aa9a0a);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff8ed88', endColorstr='#ffaa9a0a', GradientType=0)}#navbar .navbar-inner.yellow.transparent{background-color:rgba(227,215,101,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(249,240,160,.6),rgba(194,176,12,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(249,240,160,.6)),to(rgba(194,176,12,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(249,240,160,.6),rgba(194,176,12,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(249,240,160,.6),rgba(194,176,12,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(249,240,160,.6),rgba(194,176,12,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f9f0a0', endColorstr='#99c2b00c', GradientType=0)}#navbar .navbar-inner.yellow.transparent .brand,#navbar .navbar-inner.yellow.transparent .nav>li>a{text-shadow:0 1px 0 #c2b00c;color:#f2f2f2}#navbar .navbar-inner.yellow.transparent .brand .caret,#navbar .navbar-inner.yellow.transparent .nav>li>a .caret{border-bottom-color:#f2e88d;border-top-color:#f2e88d}#navbar .navbar-inner.yellow.transparent .brand:focus .caret,#navbar .navbar-inner.yellow.transparent .brand:hover .caret,#navbar .navbar-inner.yellow.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.yellow.transparent .nav>li>a:hover .caret{border-bottom-color:#f2edbf;border-top-color:#f2edbf}#navbar .navbar-inner.yellow.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.yellow.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.yellow.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.yellow.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.yellow.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(216,202,71,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(194,176,12,.6),rgba(249,240,160,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(194,176,12,.6)),to(rgba(249,240,160,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(194,176,12,.6),rgba(249,240,160,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(194,176,12,.6),rgba(249,240,160,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(194,176,12,.6),rgba(249,240,160,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c2b00c', endColorstr='#99f9f0a0', GradientType=0)}#navbar .navbar-inner.yellow.transparent .nav>li>a:hover{background-color:rgba(217,204,86,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(248,237,136,.6),rgba(170,154,10,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(248,237,136,.6)),to(rgba(170,154,10,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(248,237,136,.6),rgba(170,154,10,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(248,237,136,.6),rgba(170,154,10,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(248,237,136,.6),rgba(170,154,10,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f8ed88', endColorstr='#99aa9a0a', GradientType=0)}#navbar .navbar-inner.green{background-color:#98f064;background-image:-moz-linear-gradient(top,#c8ffa7,#50da00);background-image:-webkit-gradient(linear,0 0,0 100%,from(#c8ffa7),to(#50da00));background-image:-webkit-linear-gradient(top,#c8ffa7,#50da00);background-image:-o-linear-gradient(top,#c8ffa7,#50da00);background-image:linear-gradient(to bottom,#c8ffa7,#50da00);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8ffa7', endColorstr='#ff50da00', GradientType=0)}#navbar .navbar-inner.green .brand,#navbar .navbar-inner.green .nav>li>a{text-shadow:0 1px 0 #50da00;color:#333}#navbar .navbar-inner.green .brand .caret,#navbar .navbar-inner.green .nav>li>a .caret{border-bottom-color:#55992e;border-top-color:#55992e}#navbar .navbar-inner.green .brand:focus .caret,#navbar .navbar-inner.green .brand:hover .caret,#navbar .navbar-inner.green .nav>li>a:focus .caret,#navbar .navbar-inner.green .nav>li>a:hover .caret{border-bottom-color:#446630;border-top-color:#446630}#navbar .navbar-inner.green .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.green .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner.green .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.green .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.green .nav>li.dropdown.open>.dropdown-toggle{background-color:#80e943;background-image:-moz-linear-gradient(top,#50da00,#c8ffa7);background-image:-webkit-gradient(linear,0 0,0 100%,from(#50da00),to(#c8ffa7));background-image:-webkit-linear-gradient(top,#50da00,#c8ffa7);background-image:-o-linear-gradient(top,#50da00,#c8ffa7);background-image:linear-gradient(to bottom,#50da00,#c8ffa7);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff50da00', endColorstr='#ffc8ffa7', GradientType=0)}#navbar .navbar-inner.green .nav>li>a:hover{background-color:#8ae655;background-image:-moz-linear-gradient(top,#b8ff8e,#47c100);background-image:-webkit-gradient(linear,0 0,0 100%,from(#b8ff8e),to(#47c100));background-image:-webkit-linear-gradient(top,#b8ff8e,#47c100);background-image:-o-linear-gradient(top,#b8ff8e,#47c100);background-image:linear-gradient(to bottom,#b8ff8e,#47c100);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffb8ff8e', endColorstr='#ff47c100', GradientType=0)}#navbar .navbar-inner.green.transparent{background-color:rgba(152,240,100,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(200,255,167,.6),rgba(80,218,0,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(200,255,167,.6)),to(rgba(80,218,0,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(200,255,167,.6),rgba(80,218,0,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(200,255,167,.6),rgba(80,218,0,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(200,255,167,.6),rgba(80,218,0,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8ffa7', endColorstr='#9950da00', GradientType=0)}#navbar .navbar-inner.green.transparent .brand,#navbar .navbar-inner.green.transparent .nav>li>a{text-shadow:0 1px 0 #50da00;color:#333}#navbar .navbar-inner.green.transparent .brand .caret,#navbar .navbar-inner.green.transparent .nav>li>a .caret{border-bottom-color:#55992e;border-top-color:#55992e}#navbar .navbar-inner.green.transparent .brand:focus .caret,#navbar .navbar-inner.green.transparent .brand:hover .caret,#navbar .navbar-inner.green.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.green.transparent .nav>li>a:hover .caret{border-bottom-color:#446630;border-top-color:#446630}#navbar .navbar-inner.green.transparent .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.green.transparent .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner.green.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.green.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.green.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(128,233,67,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(80,218,0,.6),rgba(200,255,167,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(80,218,0,.6)),to(rgba(200,255,167,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(80,218,0,.6),rgba(200,255,167,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(80,218,0,.6),rgba(200,255,167,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(80,218,0,.6),rgba(200,255,167,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#9950da00', endColorstr='#99c8ffa7', GradientType=0)}#navbar .navbar-inner.green.transparent .nav>li>a:hover{background-color:rgba(138,230,85,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(184,255,142,.6),rgba(71,193,0,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(184,255,142,.6)),to(rgba(71,193,0,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(184,255,142,.6),rgba(71,193,0,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(184,255,142,.6),rgba(71,193,0,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(184,255,142,.6),rgba(71,193,0,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99b8ff8e', endColorstr='#9947c100', GradientType=0)}#navbar .navbar-inner.blue{background-color:#2e63cc;background-image:-moz-linear-gradient(top,#4d88ff,#002b80);background-image:-webkit-gradient(linear,0 0,0 100%,from(#4d88ff),to(#002b80));background-image:-webkit-linear-gradient(top,#4d88ff,#002b80);background-image:-o-linear-gradient(top,#4d88ff,#002b80);background-image:linear-gradient(to bottom,#4d88ff,#002b80);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff4d88ff', endColorstr='#ff002b80', GradientType=0)}#navbar .navbar-inner.blue .brand,#navbar .navbar-inner.blue .nav>li>a{text-shadow:0 1px 0 #1a66ff;color:#f2f2f2}#navbar .navbar-inner.blue .brand .caret,#navbar .navbar-inner.blue .nav>li>a .caret{border-bottom-color:#799bdf;border-top-color:#799bdf}#navbar .navbar-inner.blue .brand:focus .caret,#navbar .navbar-inner.blue .brand:hover .caret,#navbar .navbar-inner.blue .nav>li>a:focus .caret,#navbar .navbar-inner.blue .nav>li>a:hover .caret{border-bottom-color:#b6c7e9;border-top-color:#b6c7e9}#navbar .navbar-inner.blue .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.blue .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.blue .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.blue .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.blue .nav>li.dropdown.open>.dropdown-toggle{background-color:#1f50b3;background-image:-moz-linear-gradient(top,#002b80,#4d88ff);background-image:-webkit-gradient(linear,0 0,0 100%,from(#002b80),to(#4d88ff));background-image:-webkit-linear-gradient(top,#002b80,#4d88ff);background-image:-o-linear-gradient(top,#002b80,#4d88ff);background-image:linear-gradient(to bottom,#002b80,#4d88ff);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff002b80', endColorstr='#ff4d88ff', GradientType=0)}#navbar .navbar-inner.blue .nav>li>a:hover{background-color:#1f55c2;background-image:-moz-linear-gradient(top,#37f,#026);background-image:-webkit-gradient(linear,0 0,0 100%,from(#37f),to(#026));background-image:-webkit-linear-gradient(top,#37f,#026);background-image:-o-linear-gradient(top,#37f,#026);background-image:linear-gradient(to bottom,#37f,#026);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff3377ff', endColorstr='#ff002266', GradientType=0)}#navbar .navbar-inner.blue.transparent{background-color:rgba(46,99,204,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(77,136,255,.6),rgba(0,43,128,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(77,136,255,.6)),to(rgba(0,43,128,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(77,136,255,.6),rgba(0,43,128,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(77,136,255,.6),rgba(0,43,128,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(77,136,255,.6),rgba(0,43,128,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#994d88ff', endColorstr='#99002b80', GradientType=0)}#navbar .navbar-inner.blue.transparent .brand,#navbar .navbar-inner.blue.transparent .nav>li>a{text-shadow:0 1px 0 #1a66ff;color:#f2f2f2}#navbar .navbar-inner.blue.transparent .brand .caret,#navbar .navbar-inner.blue.transparent .nav>li>a .caret{border-bottom-color:#799bdf;border-top-color:#799bdf}#navbar .navbar-inner.blue.transparent .brand:focus .caret,#navbar .navbar-inner.blue.transparent .brand:hover .caret,#navbar .navbar-inner.blue.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.blue.transparent .nav>li>a:hover .caret{border-bottom-color:#b6c7e9;border-top-color:#b6c7e9}#navbar .navbar-inner.blue.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.blue.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.blue.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.blue.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.blue.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(31,80,179,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(0,43,128,.6),rgba(77,136,255,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(0,43,128,.6)),to(rgba(77,136,255,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(0,43,128,.6),rgba(77,136,255,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(0,43,128,.6),rgba(77,136,255,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(0,43,128,.6),rgba(77,136,255,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99002b80', endColorstr='#994d88ff', GradientType=0)}#navbar .navbar-inner.blue.transparent .nav>li>a:hover{background-color:rgba(31,85,194,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(51,119,255,.6),rgba(0,34,102,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(51,119,255,.6)),to(rgba(0,34,102,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(51,119,255,.6),rgba(0,34,102,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(51,119,255,.6),rgba(0,34,102,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(51,119,255,.6),rgba(0,34,102,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#993377ff', endColorstr='#99002266', GradientType=0)}#navbar .navbar-inner.violet{background-color:#9864f0;background-image:-moz-linear-gradient(top,#c8a7ff,#5000da);background-image:-webkit-gradient(linear,0 0,0 100%,from(#c8a7ff),to(#5000da));background-image:-webkit-linear-gradient(top,#c8a7ff,#5000da);background-image:-o-linear-gradient(top,#c8a7ff,#5000da);background-image:linear-gradient(to bottom,#c8a7ff,#5000da);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8a7ff', endColorstr='#ff5000da', GradientType=0)}#navbar .navbar-inner.violet .brand,#navbar .navbar-inner.violet .nav>li>a{text-shadow:0 1px 0 #a774ff;color:#f2f2f2}#navbar .navbar-inner.violet .brand .caret,#navbar .navbar-inner.violet .nav>li>a .caret{border-bottom-color:#b58df9;border-top-color:#b58df9}#navbar .navbar-inner.violet .brand:focus .caret,#navbar .navbar-inner.violet .brand:hover .caret,#navbar .navbar-inner.violet .nav>li>a:focus .caret,#navbar .navbar-inner.violet .nav>li>a:hover .caret{border-bottom-color:#d3bff5;border-top-color:#d3bff5}#navbar .navbar-inner.violet .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.violet .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.violet .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.violet .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.violet .nav>li.dropdown.open>.dropdown-toggle{background-color:#8043e9;background-image:-moz-linear-gradient(top,#5000da,#c8a7ff);background-image:-webkit-gradient(linear,0 0,0 100%,from(#5000da),to(#c8a7ff));background-image:-webkit-linear-gradient(top,#5000da,#c8a7ff);background-image:-o-linear-gradient(top,#5000da,#c8a7ff);background-image:linear-gradient(to bottom,#5000da,#c8a7ff);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5000da', endColorstr='#ffc8a7ff', GradientType=0)}#navbar .navbar-inner.violet .nav>li>a:hover{background-color:#8a55e6;background-image:-moz-linear-gradient(top,#b88eff,#4700c1);background-image:-webkit-gradient(linear,0 0,0 100%,from(#b88eff),to(#4700c1));background-image:-webkit-linear-gradient(top,#b88eff,#4700c1);background-image:-o-linear-gradient(top,#b88eff,#4700c1);background-image:linear-gradient(to bottom,#b88eff,#4700c1);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffb88eff', endColorstr='#ff4700c1', GradientType=0)}#navbar .navbar-inner.violet.transparent{background-color:rgba(152,100,240,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(200,167,255,.6),rgba(80,0,218,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(200,167,255,.6)),to(rgba(80,0,218,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(200,167,255,.6),rgba(80,0,218,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(200,167,255,.6),rgba(80,0,218,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(200,167,255,.6),rgba(80,0,218,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8a7ff', endColorstr='#995000da', GradientType=0)}#navbar .navbar-inner.violet.transparent .brand,#navbar .navbar-inner.violet.transparent .nav>li>a{text-shadow:0 1px 0 #a774ff;color:#f2f2f2}#navbar .navbar-inner.violet.transparent .brand .caret,#navbar .navbar-inner.violet.transparent .nav>li>a .caret{border-bottom-color:#b58df9;border-top-color:#b58df9}#navbar .navbar-inner.violet.transparent .brand:focus .caret,#navbar .navbar-inner.violet.transparent .brand:hover .caret,#navbar .navbar-inner.violet.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.violet.transparent .nav>li>a:hover .caret{border-bottom-color:#d3bff5;border-top-color:#d3bff5}#navbar .navbar-inner.violet.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.violet.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.violet.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.violet.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.violet.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(128,67,233,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(80,0,218,.6),rgba(200,167,255,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(80,0,218,.6)),to(rgba(200,167,255,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(80,0,218,.6),rgba(200,167,255,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(80,0,218,.6),rgba(200,167,255,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(80,0,218,.6),rgba(200,167,255,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#995000da', endColorstr='#99c8a7ff', GradientType=0)}#navbar .navbar-inner.violet.transparent .nav>li>a:hover{background-color:rgba(138,85,230,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(184,142,255,.6),rgba(71,0,193,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(184,142,255,.6)),to(rgba(71,0,193,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(184,142,255,.6),rgba(71,0,193,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(184,142,255,.6),rgba(71,0,193,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(184,142,255,.6),rgba(71,0,193,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99b88eff', endColorstr='#994700c1', GradientType=0)}#navbar .navbar-inner.black{background-color:#4f4f4f;background-image:-moz-linear-gradient(top,#787878,#121212);background-image:-webkit-gradient(linear,0 0,0 100%,from(#787878),to(#121212));background-image:-webkit-linear-gradient(top,#787878,#121212);background-image:-o-linear-gradient(top,#787878,#121212);background-image:linear-gradient(to bottom,#787878,#121212);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff787878', endColorstr='#ff121212', GradientType=0)}#navbar .navbar-inner.black .brand,#navbar .navbar-inner.black .nav>li>a{text-shadow:0 1px 0 #5e5e5e;color:#f2f2f2}#navbar .navbar-inner.black .brand .caret,#navbar .navbar-inner.black .nav>li>a .caret{border-bottom-color:#959595;border-top-color:#959595}#navbar .navbar-inner.black .brand:focus .caret,#navbar .navbar-inner.black .brand:hover .caret,#navbar .navbar-inner.black .nav>li>a:focus .caret,#navbar .navbar-inner.black .nav>li>a:hover .caret{border-bottom-color:#c4c4c4;border-top-color:#c4c4c4}#navbar .navbar-inner.black .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.black .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.black .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.black .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.black .nav>li.dropdown.open>.dropdown-toggle{background-color:#3b3b3b;background-image:-moz-linear-gradient(top,#121212,#787878);background-image:-webkit-gradient(linear,0 0,0 100%,from(#121212),to(#787878));background-image:-webkit-linear-gradient(top,#121212,#787878);background-image:-o-linear-gradient(top,#121212,#787878);background-image:linear-gradient(to bottom,#121212,#787878);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff121212', endColorstr='#ff787878', GradientType=0)}#navbar .navbar-inner.black .nav>li>a:hover{background-color:#424242;background-image:-moz-linear-gradient(top,#6b6b6b,#050505);background-image:-webkit-gradient(linear,0 0,0 100%,from(#6b6b6b),to(#050505));background-image:-webkit-linear-gradient(top,#6b6b6b,#050505);background-image:-o-linear-gradient(top,#6b6b6b,#050505);background-image:linear-gradient(to bottom,#6b6b6b,#050505);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff6b6b6b', endColorstr='#ff050505', GradientType=0)}#navbar .navbar-inner.black.transparent{background-color:rgba(79,79,79,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(120,120,120,.6),rgba(18,18,18,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(120,120,120,.6)),to(rgba(18,18,18,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(120,120,120,.6),rgba(18,18,18,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(120,120,120,.6),rgba(18,18,18,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(120,120,120,.6),rgba(18,18,18,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99787878', endColorstr='#99121212', GradientType=0)}#navbar .navbar-inner.black.transparent .brand,#navbar .navbar-inner.black.transparent .nav>li>a{text-shadow:0 1px 0 #5e5e5e;color:#f2f2f2}#navbar .navbar-inner.black.transparent .brand .caret,#navbar .navbar-inner.black.transparent .nav>li>a .caret{border-bottom-color:#959595;border-top-color:#959595}#navbar .navbar-inner.black.transparent .brand:focus .caret,#navbar .navbar-inner.black.transparent .brand:hover .caret,#navbar .navbar-inner.black.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.black.transparent .nav>li>a:hover .caret{border-bottom-color:#c4c4c4;border-top-color:#c4c4c4}#navbar .navbar-inner.black.transparent .brand span{background-image:url(../img/tentacle-20x20-light.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.black.transparent .brand span{background-image:url(../img/tentacle-20x20-light@2x.png)}}#navbar .navbar-inner.black.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.black.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.black.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(59,59,59,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(18,18,18,.6),rgba(120,120,120,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(18,18,18,.6)),to(rgba(120,120,120,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(18,18,18,.6),rgba(120,120,120,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(18,18,18,.6),rgba(120,120,120,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(18,18,18,.6),rgba(120,120,120,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99121212', endColorstr='#99787878', GradientType=0)}#navbar .navbar-inner.black.transparent .nav>li>a:hover{background-color:rgba(66,66,66,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(107,107,107,.6),rgba(5,5,5,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(107,107,107,.6)),to(rgba(5,5,5,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(107,107,107,.6),rgba(5,5,5,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(107,107,107,.6),rgba(5,5,5,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(107,107,107,.6),rgba(5,5,5,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#996b6b6b', endColorstr='#99050505', GradientType=0)}#navbar .navbar-inner.white{background-color:#e9e9e9;background-image:-moz-linear-gradient(top,#fff,#c8c8c8);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#c8c8c8));background-image:-webkit-linear-gradient(top,#fff,#c8c8c8);background-image:-o-linear-gradient(top,#fff,#c8c8c8);background-image:linear-gradient(to bottom,#fff,#c8c8c8);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffc8c8c8', GradientType=0)}#navbar .navbar-inner.white .brand,#navbar .navbar-inner.white .nav>li>a{text-shadow:0 1px 0 #c8c8c8;color:#333}#navbar .navbar-inner.white .brand .caret,#navbar .navbar-inner.white .nav>li>a .caret{border-bottom-color:#919191;border-top-color:#919191}#navbar .navbar-inner.white .brand:focus .caret,#navbar .navbar-inner.white .brand:hover .caret,#navbar .navbar-inner.white .nav>li>a:focus .caret,#navbar .navbar-inner.white .nav>li>a:hover .caret{border-bottom-color:#626262;border-top-color:#626262}#navbar .navbar-inner.white .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.white .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner.white .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.white .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.white .nav>li.dropdown.open>.dropdown-toggle{background-color:#dedede;background-image:-moz-linear-gradient(top,#c8c8c8,#fff);background-image:-webkit-gradient(linear,0 0,0 100%,from(#c8c8c8),to(#fff));background-image:-webkit-linear-gradient(top,#c8c8c8,#fff);background-image:-o-linear-gradient(top,#c8c8c8,#fff);background-image:linear-gradient(to bottom,#c8c8c8,#fff);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8c8c8', endColorstr='#ffffffff', GradientType=0)}#navbar .navbar-inner.white .nav>li>a:hover{background-color:#dcdcdc;background-image:-moz-linear-gradient(top,#f2f2f2,#bbb);background-image:-webkit-gradient(linear,0 0,0 100%,from(#f2f2f2),to(#bbb));background-image:-webkit-linear-gradient(top,#f2f2f2,#bbb);background-image:-o-linear-gradient(top,#f2f2f2,#bbb);background-image:linear-gradient(to bottom,#f2f2f2,#bbb);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2', endColorstr='#ffbbbbbb', GradientType=0)}#navbar .navbar-inner.white.transparent{background-color:rgba(233,233,233,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(255,255,255,.6),rgba(200,200,200,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(255,255,255,.6)),to(rgba(200,200,200,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(255,255,255,.6),rgba(200,200,200,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(255,255,255,.6),rgba(200,200,200,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(255,255,255,.6),rgba(200,200,200,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99ffffff', endColorstr='#99c8c8c8', GradientType=0)}#navbar .navbar-inner.white.transparent .brand,#navbar .navbar-inner.white.transparent .nav>li>a{text-shadow:0 1px 0 #c8c8c8;color:#333}#navbar .navbar-inner.white.transparent .brand .caret,#navbar .navbar-inner.white.transparent .nav>li>a .caret{border-bottom-color:#919191;border-top-color:#919191}#navbar .navbar-inner.white.transparent .brand:focus .caret,#navbar .navbar-inner.white.transparent .brand:hover .caret,#navbar .navbar-inner.white.transparent .nav>li>a:focus .caret,#navbar .navbar-inner.white.transparent .nav>li>a:hover .caret{border-bottom-color:#626262;border-top-color:#626262}#navbar .navbar-inner.white.transparent .brand span{background-image:url(../img/tentacle-20x20.png)}@media (-webkit-min-device-pixel-ratio:2),(min-resolution:192dpi){#navbar .navbar-inner.white.transparent .brand span{background-image:url(../img/tentacle-20x20@2x.png)}}#navbar .navbar-inner.white.transparent .nav>li.dropdown.active>.dropdown-toggle,#navbar .navbar-inner.white.transparent .nav>li.dropdown.open.active>.dropdown-toggle,#navbar .navbar-inner.white.transparent .nav>li.dropdown.open>.dropdown-toggle{background-color:rgba(222,222,222,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(200,200,200,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(200,200,200,.6)),to(rgba(255,255,255,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(200,200,200,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(200,200,200,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(200,200,200,.6),rgba(255,255,255,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8c8c8', endColorstr='#99ffffff', GradientType=0)}#navbar .navbar-inner.white.transparent .nav>li>a:hover{background-color:rgba(220,220,220,.6);background-image:"../img/trans-background.png";background-image:-moz-linear-gradient(top,rgba(242,242,242,.6),rgba(187,187,187,.6)),url(../img/trans-background.png);background-image:-webkit-gradient(linear,0 0,0 100%,from(rgba(242,242,242,.6)),to(rgba(187,187,187,.6))),url(../img/trans-background.png);background-image:-webkit-linear-gradient(top,rgba(242,242,242,.6),rgba(187,187,187,.6)),url(../img/trans-background.png);background-image:-o-linear-gradient(top,rgba(242,242,242,.6),rgba(187,187,187,.6)),url(../img/trans-background.png);background-image:linear-gradient(to bottom,rgba(242,242,242,.6),rgba(187,187,187,.6)),url(../img/trans-background.png);background-repeat:repeat-x;filter:progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f2f2f2', endColorstr='#99bbbbbb', GradientType=0)}#navbar .navbar-inner .brand{padding:10px 20px 6px}#navbar .navbar-inner .brand span{padding-left:26px;background-size:20px 20px;background-repeat:no-repeat;display:inline-block;max-width:250px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;vertical-align:top;line-height:20px;height:24px}#navbar_login a.dropdown-toggle span{display:inline-block;max-width:100px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;vertical-align:top}.octoprint-container{margin-top:20px}.octoprint-container .tab-content{padding:9px 15px;border-left:1px solid #ddd;border-right:1px solid #ddd;border-bottom:1px solid #ddd;-webkit-border-bottom-right-radius:4px;-moz-border-radius-bottomright:4px;border-bottom-right-radius:4px;-webkit-border-bottom-left-radius:4px;-moz-border-radius-bottomleft:4px;border-bottom-left-radius:4px}.octoprint-container .nav{margin-bottom:0}.octoprint-container .tab-content h1{display:block;width:100%;padding:0;margin-bottom:20px;font-size:21px;line-height:40px;color:#333;border:0;border-bottom:1px solid #e5e5e5;font-weight:400}.octoprint-container .accordion-heading .accordion-heading-button{float:right}.octoprint-container .accordion-heading .accordion-heading-button>a{display:inline-block;padding:8px 15px;font-size:14px;line-height:20px;color:#000;text-decoration:none;background:0 0;-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.octoprint-container .accordion-heading a.accordion-toggle{display:inline-block}.octoprint-container .accordion-heading [class*=" icon-"],.octoprint-container .accordion-heading [class^=icon-]{color:#000}.print-control .btn{padding-left:4px;padding-right:4px}.upload-buttons .btn{margin-right:0}table{table-layout:fixed}table .popover-title{text-overflow:ellipsis;word-break:break-all}table td,table th{overflow:hidden}table td.gcode_files_name,table th.gcode_files_name{text-overflow:ellipsis;text-align:left;white-space:nowrap}table td.gcode_files_action,table th.gcode_files_action{width:90px;text-align:center;white-space:nowrap}table td.gcode_files_action a,table th.gcode_files_action a{text-decoration:none;color:#000}table td.gcode_files_action a.disabled,table th.gcode_files_action a.disabled{color:#ccc;cursor:default}table td.timelapse_files_checkbox,table td.timelapse_unrendered_checkbox,table th.timelapse_files_checkbox,table th.timelapse_unrendered_checkbox{text-align:center;width:10px}table td.timelapse_files_checkbox input[type=checkbox],table td.timelapse_unrendered_checkbox input[type=checkbox],table th.timelapse_files_checkbox input[type=checkbox],table th.timelapse_unrendered_checkbox input[type=checkbox]{margin-top:0}table td.timelapse_files_name,table td.timelapse_unrendered_name,table th.timelapse_files_name,table th.timelapse_unrendered_name{text-overflow:ellipsis;text-align:left}table td.timelapse_files_size,table td.timelapse_unrendered_size,table th.timelapse_files_size,table th.timelapse_unrendered_size{text-align:right;width:55px}table td.timelapse_unrendered_count,table th.timelapse_unrendered_count{text-align:right;width:45px}table td.timelapse_files_action,table td.timelapse_unrendered_action,table th.timelapse_files_action,table th.timelapse_unrendered_action{width:60px;text-align:center;white-space:nowrap}table td.timelapse_files_action a,table td.timelapse_unrendered_action a,table th.timelapse_files_action a,table th.timelapse_unrendered_action a{text-decoration:none;color:#000}table td.timelapse_files_action a.disabled,table td.timelapse_unrendered_action a.disabled,table th.timelapse_files_action a.disabled,table th.timelapse_unrendered_action a.disabled{color:#ccc;cursor:default}table td.settings_users_name,table th.settings_users_name{text-overflow:ellipsis;text-align:left;width:100px}table td.settings_users_active,table th.settings_users_active{text-align:center;width:55px}table td table.settings_users_details_table,table th table.settings_users_details_table{font-size:.8em;margin-bottom:0}table td table.settings_users_details_table .settings_users_details_key,table th table.settings_users_details_table .settings_users_details_key{width:100px}table td table.settings_users_details_table td,table td table.settings_users_details_table th,table th table.settings_users_details_table td,table th table.settings_users_details_table th{border:0;padding:0}table td.settings_groups_default,table th.settings_groups_default{text-align:center;width:20px}table td.settings_groups_name,table th.settings_groups_name{width:180px}table td table.settings_groups_details_table,table th table.settings_groups_details_table{font-size:.8em;margin-bottom:0}table td table.settings_groups_details_table .settings_groups_details_key,table th table.settings_groups_details_table .settings_groups_details_key{width:100px}table td table.settings_groups_details_table td,table td table.settings_groups_details_table th,table th table.settings_groups_details_table td,table th table.settings_groups_details_table th{border:0;padding:0}table td.settings_groups_actions,table td.settings_users_actions,table th.settings_groups_actions,table th.settings_users_actions{width:60px;text-align:center;white-space:nowrap}table td.settings_groups_actions a,table td.settings_users_actions a,table th.settings_groups_actions a,table th.settings_users_actions a{text-decoration:none;color:#000}table td.settings_groups_actions a.disabled,table td.settings_users_actions a.disabled,table th.settings_groups_actions a.disabled,table th.settings_users_actions a.disabled{color:#ccc;cursor:default}table td.settings_accesscontrol_groups_list_checkbox,table td.settings_accesscontrol_permissions_list_checkbox,table td.settings_accesscontrol_subgroups_list_checkbox,table th.settings_accesscontrol_groups_list_checkbox,table th.settings_accesscontrol_permissions_list_checkbox,table th.settings_accesscontrol_subgroups_list_checkbox{width:20px}table td #settings-usersDialogAddUser,table td #settings-usersDialogEditUser,table th #settings-usersDialogAddUser,table th #settings-usersDialogEditUser{position:relative;top:50%;transform:translateY(-50%);margin-top:0!important}table td.settings_printerProfiles_profiles_name,table th.settings_printerProfiles_profiles_name{text-overflow:ellipsis;text-align:left}table td.settings_printerProfiles_profiles_model,table th.settings_printerProfiles_profiles_model{text-align:left;width:250px}table td.settings_printerProfiles_profiles_action,table th.settings_printerProfiles_profiles_action{width:80px;text-align:center;white-space:nowrap}table td.settings_printerProfiles_profiles_action a,table th.settings_printerProfiles_profiles_action a{text-decoration:none;color:#000}table td.settings_printerProfiles_profiles_action a.disabled,table th.settings_printerProfiles_profiles_action a.disabled{color:#ccc;cursor:default}#temperature-graph{height:350px;width:100%;background:url(../img/graph-background.png) center no-repeat}#temperature-table{table-layout:fixed;width:100%;margin-top:20px}#temperature-table td,#temperature-table th{line-height:25px}#temperature-table td.temperature_actual,#temperature-table td.temperature_offset,#temperature-table td.temperature_target,#temperature-table td.temperature_tool,#temperature-table th.temperature_actual,#temperature-table th.temperature_offset,#temperature-table th.temperature_target,#temperature-table th.temperature_tool{vertical-align:middle;text-align:center}#temperature-table td.temperature_actual form,#temperature-table td.temperature_offset form,#temperature-table td.temperature_target form,#temperature-table td.temperature_tool form,#temperature-table th.temperature_actual form,#temperature-table th.temperature_offset form,#temperature-table th.temperature_target form,#temperature-table th.temperature_tool form{margin:0}#temperature-table td.temperature_actual .dropdown-menu,#temperature-table td.temperature_offset .dropdown-menu,#temperature-table td.temperature_target .dropdown-menu,#temperature-table td.temperature_tool .dropdown-menu,#temperature-table th.temperature_actual .dropdown-menu,#temperature-table th.temperature_offset .dropdown-menu,#temperature-table th.temperature_target .dropdown-menu,#temperature-table th.temperature_tool .dropdown-menu{text-align:left}#temperature-table td.temperature_tool,#temperature-table th.temperature_tool{width:16%;text-align:left;overflow:hidden;white-space:nowrap;text-overflow:ellipsis}#temperature-table td.temperature_actual,#temperature-table th.temperature_actual{width:12%}#temperature-table td.temperature_target,#temperature-table th.temperature_target{width:42%;overflow:visible}#temperature-table td.temperature_offset,#temperature-table th.temperature_offset{width:30%}.tab-content,.tab-pane{overflow:visible}#speed_fill,#speed_innerWall,#speed_outerWall,#speed_support,#temp_newBedTemp,#temp_newTemp,#webcam_timelapse_fps,#webcam_timelapse_interval,#webcam_timelapse_postRoll,#webcam_timelapse_retractionZHop{text-align:right}ul.dropdown-menu li a{cursor:pointer}#connection_baudrates,#connection_ports,#connection_printers{width:100%}#offline_overlay,#reloadui_overlay{position:fixed;top:0;left:0;width:100%;height:100%;display:none}#offline_overlay{z-index:10002}#reloadui_overlay{z-index:10001}#offline_overlay_background,#reloadui_overlay_background{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#000;filter:alpha(opacity=50);-moz-opacity:.5;-khtml-opacity:.5;opacity:.5}#offline_overlay_wrapper,#reloadui_overlay_wrapper{position:absolute;top:0;bottom:0;left:0;right:0;padding-top:60px}#offline_overlay_wrapper .container,#reloadui_overlay_wrapper .container{margin:auto}#webcam_container{width:100%;position:relative;outline:0;background-color:#000}#webcam_container .keycontrol_overlay{position:absolute;left:10px;right:10px;bottom:10px;background:rgba(0,0,0,.5);font-size:85%;color:#fff;padding:0}#webcam_container .keycontrol_overlay kbd{border:1px solid #eee;border-radius:3px;margin-left:2px;margin-right:2px;font-size:90%;padding:2px;min-width:1em}#webcam_container .keycontrol_overlay .keycontrol_overlay_heading{position:relative;padding:10px;font-weight:700}#webcam_container .keycontrol_overlay .keycontrol_overlay_column{position:relative;width:45%;padding:10px;float:left}#webcam_container .nowebcam{position:absolute;top:0;left:0;right:0;bottom:0}#webcam_container .nowebcam .text{color:#fff;text-align:center;position:relative;margin:auto;width:80%;top:50%;transform:translateY(-50%);display:block}#webcam_container .nowebcam .text.webcam_loading{animation:pulsate 3s ease-out;animation-iteration-count:infinite}#webcam_container .webcam_rotated{position:relative;width:100%;padding-bottom:100%;pointer-events:none}#webcam_container .webcam_rotated .webcam_fixed_ratio{position:absolute;transform:rotate(-90deg);top:0;bottom:0;pointer-events:none}#webcam_container .webcam_rotated .webcam_fixed_ratio .webcam_fixed_ratio_inner{width:100%;height:100%;pointer-events:none}#webcam_container .webcam_unrotated .webcam_fixed_ratio{width:100%;pointer-events:none;padding-bottom:100%;position:relative}#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio43{padding-bottom:75%}#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio169{padding-bottom:56.25%}#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio1610{padding-bottom:62.5%}#webcam_container .webcam_unrotated .webcam_fixed_ratio .webcam_fixed_ratio_inner{position:absolute;top:0;bottom:0;left:0;right:0;pointer-events:none}#webcam_container img{width:100%;height:100%;object-fit:contain}#webcamTestContainer{min-height:384px}#state_wrapper hr{margin:5px 0}#files .gcode_files .scroll-wrapper{overflow-x:hidden;overflow-y:scroll;height:306px;padding-right:2px}#files .gcode_files .entry{padding:5px;line-height:20px;border-bottom:1px solid #ddd;position:relative}#files .gcode_files .entry:hover{background-color:#f5f5f5}#files .gcode_files .entry .title{text-overflow:ellipsis;word-break:break-all;margin-right:30px}#files .gcode_files .entry .additionalInfo,#files .gcode_files .entry .internal,#files .gcode_files .entry .size,#files .gcode_files .entry .uploaded{font-size:85%;color:#999}#files .gcode_files .entry .uploaded [title]{cursor:help}#files .gcode_files .entry .internal{word-break:break-all}#files .gcode_files .entry .action-buttons{position:absolute;bottom:5px;right:5px}#files .gcode_files .entry .additionalInfo{padding-bottom:22px}@keyframes highlightframes{0%{background:#ff0}100%{background:0 0}}#files .gcode_files .entry.highlight{animation:highlightframes 2s}#files .gcode_files .back .back-path{white-space:nowrap}#files .gcode_files .back .back-path span{word-wrap:break-word;white-space:pre-line}#files .upload-buttons{margin-top:10px}#files .form-search{text-align:center;margin-bottom:5px!important}#control .jog-panel{float:left;margin-right:19px}#control h1{text-align:left}#control .jog-panel>div{text-align:center}#control .jog-panel>div.distance{text-align:left}#control .jog-panel .slider{margin-bottom:10px}#control .box{width:30px;height:30px;margin-right:10px;margin-bottom:10px;padding:0}#control .control-box{display:block;height:30px;margin-bottom:10px}#control .btn-group{margin-bottom:10px}#control .btn-group.distance>.btn{width:43px;padding:3px 0;height:30px}#control .slider-handle{width:14px;height:14px;margin-left:-7px;margin-top:-3px}#control .custom_section h1{cursor:pointer}#control .custom_section_horizontal>.custom_control{display:inline-block}#control .custom_section_vertical>.custom_control{display:block}#control .custom_control .slider{margin-left:10px;margin-right:10px;margin-bottom:2px}#control .pulsate_text_opacity{animation:pulsate_input 1s ease-out;animation-iteration-count:infinite}@keyframes pulsate_input{0%{color:#555}50%{color:rgba(85,85,85,.2)}100%{color:#555}}#term .terminal{margin-bottom:30px}#term .terminal #terminal-output,#term .terminal #terminal-output-lowfi{min-height:340px;margin-bottom:5px}#settings_dialog .aboutlink,#settings_dialog .systeminfolink{float:left}#settings_dialog_menu,#wizard_dialog_menu{margin-left:0}#wizard_firstrun_acl .acl_decision{margin-top:1em}#wizard_firstrun_end p,#wizard_firstrun_start p{margin-bottom:1.5em;line-height:1.5}#settings_appearance_managelanguagesdialog_list{width:auto;height:300px;overflow-x:hidden;overflow-y:scroll;padding-right:2px}#settings_appearance_managelanguagesdialog_emptylist{overflow:hidden;width:100%;height:300px;text-align:center;display:table}#settings_appearance_managelanguagesdialog_emptylist div{display:table-cell;vertical-align:middle}#about_authors ul,#about_sponsors ul{columns:3;-webkit-columns:3;-moz-columns:3}.footer ul{margin:0}.footer ul li{display:inline;margin-left:1em;font-size:85%}.footer ul li:first-child{margin-left:0}.footer ul li a{color:#555}.footer #footer_links,.footer #footer_version{max-width:50%}.ui-pnotify{position:fixed}.ui-pnotify .alert a{color:#c09853}.ui-pnotify .alert-danger a,.ui-pnotify .alert-error a{color:#b94a48}.ui-pnotify .alert-success a{color:#468847}.ui-pnotify .alert-info a{color:#3a87ad}.pnotify_additional_info .pnotify_more{font-size:85%}.text-right{text-align:right}.text-center{text-align:center}.text-block{display:block}.overflow_visible{overflow:visible!important}.clickable{cursor:pointer}.border_box{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box}.hidden{display:none}textarea.block{-webkit-box-sizing:border-box;-moz-box-sizing:border-box;box-sizing:border-box;width:100%}@keyframes pulsate{0%{opacity:.5}50%{opacity:1}100%{opacity:.5}}#drop_overlay{position:fixed;top:0;left:0;width:100%;height:100%;z-index:10000;display:none}#drop_overlay.in{display:block}#drop_overlay #drop_overlay_background{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#000;filter:alpha(opacity=50);-moz-opacity:.5;-khtml-opacity:.5;opacity:.5}#drop_overlay #drop_overlay_wrapper{position:absolute;top:0;bottom:0;left:0;right:0;padding-top:60px}#drop_overlay #drop_overlay_wrapper #drop,#drop_overlay #drop_overlay_wrapper #drop_background{position:absolute;top:0;left:0;margin-left:0;width:100%}#drop_overlay #drop_overlay_wrapper #drop_locally,#drop_overlay #drop_overlay_wrapper #drop_locally_background{position:absolute;top:0;left:50%;margin-left:-50%;width:50%;border-right:2px dashed #ccc}#drop_overlay #drop_overlay_wrapper #drop_sd,#drop_overlay #drop_overlay_wrapper #drop_sd_background{position:absolute;top:0;left:50%;margin-left:0;width:50%;border-left:2px dashed #ccc}#drop_overlay #drop_overlay_wrapper .dropzone{height:100%;z-index:10001;color:#fff;font-size:30px}#drop_overlay #drop_overlay_wrapper .dropzone i{font-size:50px}#drop_overlay #drop_overlay_wrapper .dropzone .text{display:block;text-align:center;line-height:40px;position:absolute;width:100%;bottom:5%;filter:alpha(opacity=100);-moz-opacity:1;-khtml-opacity:1;opacity:1}#drop_overlay #drop_overlay_wrapper .dropzone_background{width:50%;height:100%;background-color:#000;filter:alpha(opacity=25);-moz-opacity:.25;-khtml-opacity:.25;opacity:.25}#drop_overlay #drop_overlay_wrapper .dropzone_background.hover{background-color:#000;filter:alpha(opacity=50);-moz-opacity:.5;-khtml-opacity:.5;opacity:.5}#drop_overlay #drop_overlay_wrapper .dropzone_background.fade{-webkit-transition:all .3s ease-out;-moz-transition:all .3s ease-out;-ms-transition:all .3s ease-out;-o-transition:all .3s ease-out;transition:all .3s ease-out;opacity:1}.center{float:none;margin-left:auto;margin-right:auto}.flipH{-webkit-transform:scaleX(-1);-moz-transform:scaleX(-1);-ms-transform:scaleX(-1);transform:scaleX(-1)}.flipV{-webkit-transform:scaleY(-1);-moz-transform:scaleY(-1);-ms-transform:scaleY(-1);transform:scaleY(-1)}.flipH.flipV{-webkit-transform:scaleX(-1) scaleY(-1);-moz-transform:scaleX(-1) scaleY(-1);-ms-transform:scaleX(-1) scaleY(-1);transform:scaleX(-1) scaleY(-1)}.rotate90{-webkit-transform:rotate(-90deg);transform:rotate(-90deg)}.ui-pnotify a{text-decoration:underline}.btn-mini .caret,.btn-small .caret{margin-top:8px}.dropdown-menu-right{right:0;left:auto}.slider .slider-selection{color:#fff;text-shadow:0 -1px 0 rgba(0,0,0,.25);background-color:#006dcc;background-image:-moz-linear-gradient(top,#08c,#04c);background-image:-webkit-gradient(linear,0 0,0 100%,from(#08c),to(#04c));background-image:-webkit-linear-gradient(top,#08c,#04c);background-image:-o-linear-gradient(top,#08c,#04c);background-image:linear-gradient(to bottom,#08c,#04c);background-repeat:repeat-x;border-color:#04c #04c #002a80;border-color:rgba(0,0,0,.1) rgba(0,0,0,.1) rgba(0,0,0,.25);*background-color:#04c;filter:progid:DXImageTransform.Microsoft.gradient(enabled=false)}.slider .slider-selection.active,.slider .slider-selection.disabled,.slider .slider-selection:active,.slider .slider-selection:focus,.slider .slider-selection:hover,.slider .slider-selection[disabled]{color:#fff;background-color:#04c;*background-color:#003bb3}.slider .slider-selection.active,.slider .slider-selection:active{background-color:#039 \9}.slider.slider-disabled .slider-selection{background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.slider .slider-track{background-color:#f5f5f5;border:1px solid #e3e3e3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;-webkit-box-shadow:inset 0 1px 1px rgba(0,0,0,.05);-moz-box-shadow:inset 0 1px 1px rgba(0,0,0,.05);box-shadow:inset 0 1px 1px rgba(0,0,0,.05)}.slider.slider-disabled .slider-track{background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.slider .slider-handle{display:inline-block;*display:inline;*zoom:1;font-size:14px;line-height:20px;text-align:center;vertical-align:middle;cursor:pointer;color:#333;text-shadow:0 1px 1px rgba(255,255,255,.75);background-color:#f5f5f5;background-image:-moz-linear-gradient(top,#fff,#e6e6e6);background-image:-webkit-gradient(linear,0 0,0 100%,from(#fff),to(#e6e6e6));background-image:-webkit-linear-gradient(top,#fff,#e6e6e6);background-image:-o-linear-gradient(top,#fff,#e6e6e6);background-image:linear-gradient(to bottom,#fff,#e6e6e6);background-repeat:repeat-x;*background-color:#e6e6e6;border:1px solid #ccc;*border:0;border-bottom-color:#b3b3b3;-webkit-border-radius:4px;-moz-border-radius:4px;border-radius:4px;*margin-left:.3em;-webkit-box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05);-moz-box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05);box-shadow:inset 0 1px 0 rgba(255,255,255,.2),0 1px 2px rgba(0,0,0,.05);padding:0;margin-bottom:0;opacity:1;filter:alpha(opacity=100)}.slider .slider-handle.active,.slider .slider-handle.disabled,.slider .slider-handle:active,.slider .slider-handle:focus,.slider .slider-handle:hover,.slider .slider-handle[disabled]{color:#333;background-color:#e6e6e6;*background-color:#d9d9d9}.slider .slider-handle.active,.slider .slider-handle:active{background-color:#ccc \9}.slider .slider-handle:first-child{*margin-left:0}.slider .slider-handle:focus,.slider .slider-handle:hover{color:#333;text-decoration:none;background-position:0 -15px;-webkit-transition:background-position .1s linear;-moz-transition:background-position .1s linear;-o-transition:background-position .1s linear;transition:background-position .1s linear}.slider .slider-handle:focus{outline:#333 dotted thin;outline:-webkit-focus-ring-color auto 5px;outline-offset:-2px}.slider .slider-handle.active,.slider .slider-handle:active{background-image:none;outline:0;-webkit-box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05);-moz-box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05);box-shadow:inset 0 2px 4px rgba(0,0,0,.15),0 1px 2px rgba(0,0,0,.05)}.slider .slider-handle.disabled,.slider .slider-handle[disabled]{cursor:default;background-image:none;opacity:.65;filter:alpha(opacity=65);-webkit-box-shadow:none;-moz-box-shadow:none;box-shadow:none}.slider .slider-handle.hide{display:none}.slider .slider-handle.round{-webkit-border-radius:50%;-moz-border-radius:50%;border-radius:50%}.modal.large{width:975px;margin-left:-487px}.full-sized-box{position:absolute;bottom:0;left:0;right:0;top:0;padding:15px}.full-sized-box .row-fluid{height:100%}@media (max-width:979px){.full-sized-box{position:static}}:root .full-sized-box,_::-webkit-full-page-media,_:future{position:static}.safari ::-webkit-scrollbar{width:10px;height:10px}.safari ::-webkit-scrollbar-track{border-radius:10px;-webkit-border-radius:10px}.safari ::-webkit-scrollbar-thumb{-webkit-border-radius:10px;border-radius:10px;background:rgba(100,100,100,.8)}.scrollable{height:100%;overflow:auto;-webkit-overflow-scrolling:touch}.pre-output span{display:block}.input-append .add-on.add-on-limited,.input-prepend .add-on.add-on-limited{overflow-x:hidden;text-overflow:ellipsis;width:inherit}.input-append .btn-group:first-child .btn:first-child,.input-prepend .btn-group:first-child .btn:first-child{-webkit-border-radius:4px 0 0 4px;-moz-border-radius:4px 0 0 4px;border-radius:4px 0 0 4px}.input-append .btn-group .btn:first-child,.input-prepend .btn-group .btn:first-child{-webkit-border-radius:0;-moz-border-radius:0;border-radius:0}.input-append.input-block-level,.input-prepend.input-block-level{display:table}.input-append.input-block-level .add-on,.input-prepend.input-block-level .add-on{display:table-cell;width:1%}.input-append.input-block-level>input,.input-prepend.input-block-level>input{box-sizing:border-box;display:table;min-height:inherit;width:100%}.input-append.input-block-level :not(:last-child),.input-prepend.input-block-level :not(:last-child){border-right:0}.control-group.error .input-append .fileinput-button,.control-group.error .input-prepend .fileinput-button{border-color:#b94a48}.control-text{padding-top:5px;cursor:default}input[type=number]{text-align:right}input[type=number].input-nospin::-webkit-inner-spin-button,input[type=number].input-nospin::-webkit-outer-spin-button{-webkit-appearance:none;margin:0}input[type=number].input-nospin{-moz-appearance:textfield}.dropdown-menu li a.disabled,.dropdown-menu li a.disabled:active,.dropdown-menu li a.disabled:hover,.dropdown-menu li a.disabled:visited{background-color:transparent;background-image:none;color:#aaa;cursor:default}textarea.monospace{font-family:monospace}.progress-text-centered{position:relative}.progress-text-centered .bar{z-index:1;position:absolute;overflow:hidden}.progress-text-centered .progress-text-back,.progress-text-centered .progress-text-front{position:absolute;top:0;z-index:2;text-align:center;width:100%;box-sizing:border-box;padding:0 10px;font-size:12px;line-height:20px}.progress-text-centered .progress-text-front{color:#fff}.search-query-with-clear{position:relative}.search-query-with-clear .search-clear{display:inline-block;color:#ccc;position:absolute;right:28px;height:20px;padding:4px 0;cursor:pointer;visibility:hidden}.search-query-with-clear.active-clear .search-query{padding-right:28px;width:192px}.search-query-with-clear.active-clear .search-clear{visibility:visible}.search-query-with-clear input::-ms-clear{display:none}.search-query-with-clear input[type=search]::-webkit-search-cancel-button,.search-query-with-clear input[type=search]::-webkit-search-decoration,.search-query-with-clear input[type=search]::-webkit-search-results-button,.search-query-with-clear input[type=search]::-webkit-search-results-decoration{-webkit-appearance:none}#navbar_login:not(.open) #login_dropdown_loggedout{display:block;z-index:-1;height:0;width:0;padding:0!important;overflow:hidden;border:0;box-shadow:none;left:-9999px}#navbar_login:not(.open) #login_dropdown_loggedout.hide{display:none}#loginForm{margin:0}#loginForm button{margin-top:20px}#page-container-loading{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#fff;z-index:12301}#page-container-loading .wrapper{position:absolute;top:0;bottom:0;left:0;right:0}#page-container-loading .wrapper .outer{display:table;width:100%;height:100%}#page-container-loading .wrapper .outer .inner{display:table-cell;vertical-align:middle}#page-container-loading .wrapper .outer .inner .content{text-align:center}#page-container-noscript{position:fixed;top:0;left:0;width:100%;height:100%;background-color:#fff;z-index:12310}#page-container-noscript .wrapper{position:absolute;top:0;bottom:0;left:0;right:0}#page-container-noscript .wrapper .outer{display:table;width:100%;height:100%}#page-container-noscript .wrapper .outer .inner{display:table-cell;vertical-align:middle}#page-container-noscript .wrapper .outer .inner .content{text-align:center}@keyframes fadeIn{from{opacity:0}to{opacity:1}}@keyframes backgroundFadeIn{from{opacity:0}to{opacity:.7}}.fade-in{animation-name:fadeIn;animation-duration:.3s}.modal-backdrop:not(.fade){animation-name:backgroundFadeIn;animation-duration:.3s}
+.btn {
+  display: inline-block;
+  *display: inline;
+  /* IE7 inline-block hack */
+  *zoom: 1;
+  padding: 4px 12px;
+  margin-bottom: 0;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  color: #333;
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+  background-color: #f5f5f5;
+  background-image: -moz-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#e6e6e6));
+  background-image: -webkit-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -o-linear-gradient(top, #fff, #e6e6e6);
+  background-image: linear-gradient(to bottom, #fff, #e6e6e6);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
+  border-color: #e6e6e6 #e6e6e6 #bfbfbf;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #e6e6e6;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  border: 1px solid #ccc;
+  *border: 0;
+  border-bottom-color: #b3b3b3;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  *margin-left: 0.3em;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+  -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+}
+.btn:hover,
+.btn:focus,
+.btn:active,
+.btn.active,
+.btn.disabled,
+.btn[disabled] {
+  color: #333;
+  background-color: #e6e6e6;
+  *background-color: #d9d9d9;
+}
+.btn:active,
+.btn.active {
+  background-color: #cccccc \9;
+}
+.btn:first-child {
+  *margin-left: 0;
+}
+.btn:hover,
+.btn:focus {
+  color: #333;
+  text-decoration: none;
+  background-position: 0 -15px;
+  -webkit-transition: background-position 0.1s linear;
+  -moz-transition: background-position 0.1s linear;
+  -o-transition: background-position 0.1s linear;
+  transition: background-position 0.1s linear;
+}
+.btn:focus {
+  outline: thin dotted #333;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.btn.active,
+.btn:active {
+  background-image: none;
+  outline: 0;
+  -webkit-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+  -moz-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+}
+.btn.disabled,
+.btn[disabled] {
+  cursor: default;
+  background-image: none;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.btn-large {
+  padding: 11px 19px;
+  font-size: 17.5px;
+  -webkit-border-radius: 6px;
+  -moz-border-radius: 6px;
+  border-radius: 6px;
+}
+.btn-large [class^="icon-"],
+.btn-large [class*=" icon-"] {
+  margin-top: 4px;
+}
+.btn-small {
+  padding: 2px 10px;
+  font-size: 11.9px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+.btn-small [class^="icon-"],
+.btn-small [class*=" icon-"] {
+  margin-top: 0;
+}
+.btn-mini [class^="icon-"],
+.btn-mini [class*=" icon-"] {
+  margin-top: -1px;
+}
+.btn-mini {
+  padding: 0 6px;
+  font-size: 10.5px;
+  -webkit-border-radius: 3px;
+  -moz-border-radius: 3px;
+  border-radius: 3px;
+}
+.btn-block {
+  display: block;
+  width: 100%;
+  padding-left: 0;
+  padding-right: 0;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.btn-block + .btn-block {
+  margin-top: 5px;
+}
+input[type="submit"].btn-block,
+input[type="reset"].btn-block,
+input[type="button"].btn-block {
+  width: 100%;
+}
+.btn-primary.active,
+.btn-warning.active,
+.btn-danger.active,
+.btn-success.active,
+.btn-info.active,
+.btn-inverse.active {
+  color: rgba(255, 255, 255, 0.75);
+}
+.btn-primary {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #006dcc;
+  background-image: -moz-linear-gradient(top, #08c, #0044cc);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#08c), to(#0044cc));
+  background-image: -webkit-linear-gradient(top, #08c, #0044cc);
+  background-image: -o-linear-gradient(top, #08c, #0044cc);
+  background-image: linear-gradient(to bottom, #08c, #0044cc);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
+  border-color: #0044cc #0044cc #002a80;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #0044cc;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary:active,
+.btn-primary.active,
+.btn-primary.disabled,
+.btn-primary[disabled] {
+  color: #fff;
+  background-color: #0044cc;
+  *background-color: #003bb3;
+}
+.btn-primary:active,
+.btn-primary.active {
+  background-color: #003399 \9;
+}
+.btn-warning {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #faa732;
+  background-image: -moz-linear-gradient(top, #fbb450, #f89406);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fbb450), to(#f89406));
+  background-image: -webkit-linear-gradient(top, #fbb450, #f89406);
+  background-image: -o-linear-gradient(top, #fbb450, #f89406);
+  background-image: linear-gradient(to bottom, #fbb450, #f89406);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fffbb450', endColorstr='#fff89406', GradientType=0);
+  border-color: #f89406 #f89406 #ad6704;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #f89406;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-warning:hover,
+.btn-warning:focus,
+.btn-warning:active,
+.btn-warning.active,
+.btn-warning.disabled,
+.btn-warning[disabled] {
+  color: #fff;
+  background-color: #f89406;
+  *background-color: #df8505;
+}
+.btn-warning:active,
+.btn-warning.active {
+  background-color: #c67605 \9;
+}
+.btn-danger {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #da4f49;
+  background-image: -moz-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ee5f5b), to(#bd362f));
+  background-image: -webkit-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: -o-linear-gradient(top, #ee5f5b, #bd362f);
+  background-image: linear-gradient(to bottom, #ee5f5b, #bd362f);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffee5f5b', endColorstr='#ffbd362f', GradientType=0);
+  border-color: #bd362f #bd362f #802420;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #bd362f;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-danger:hover,
+.btn-danger:focus,
+.btn-danger:active,
+.btn-danger.active,
+.btn-danger.disabled,
+.btn-danger[disabled] {
+  color: #fff;
+  background-color: #bd362f;
+  *background-color: #a9302a;
+}
+.btn-danger:active,
+.btn-danger.active {
+  background-color: #942a25 \9;
+}
+.btn-success {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #5bb75b;
+  background-image: -moz-linear-gradient(top, #62c462, #51a351);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#62c462), to(#51a351));
+  background-image: -webkit-linear-gradient(top, #62c462, #51a351);
+  background-image: -o-linear-gradient(top, #62c462, #51a351);
+  background-image: linear-gradient(to bottom, #62c462, #51a351);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff62c462', endColorstr='#ff51a351', GradientType=0);
+  border-color: #51a351 #51a351 #387038;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #51a351;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-success:hover,
+.btn-success:focus,
+.btn-success:active,
+.btn-success.active,
+.btn-success.disabled,
+.btn-success[disabled] {
+  color: #fff;
+  background-color: #51a351;
+  *background-color: #499249;
+}
+.btn-success:active,
+.btn-success.active {
+  background-color: #408140 \9;
+}
+.btn-info {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #49afcd;
+  background-image: -moz-linear-gradient(top, #5bc0de, #2f96b4);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5bc0de), to(#2f96b4));
+  background-image: -webkit-linear-gradient(top, #5bc0de, #2f96b4);
+  background-image: -o-linear-gradient(top, #5bc0de, #2f96b4);
+  background-image: linear-gradient(to bottom, #5bc0de, #2f96b4);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5bc0de', endColorstr='#ff2f96b4', GradientType=0);
+  border-color: #2f96b4 #2f96b4 #1f6377;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #2f96b4;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-info:hover,
+.btn-info:focus,
+.btn-info:active,
+.btn-info.active,
+.btn-info.disabled,
+.btn-info[disabled] {
+  color: #fff;
+  background-color: #2f96b4;
+  *background-color: #2a85a0;
+}
+.btn-info:active,
+.btn-info.active {
+  background-color: #24748c \9;
+}
+.btn-inverse {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #363636;
+  background-image: -moz-linear-gradient(top, #444, #222);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#444), to(#222));
+  background-image: -webkit-linear-gradient(top, #444, #222);
+  background-image: -o-linear-gradient(top, #444, #222);
+  background-image: linear-gradient(to bottom, #444, #222);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff444444', endColorstr='#ff222222', GradientType=0);
+  border-color: #222 #222 #000000;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #222;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.btn-inverse:hover,
+.btn-inverse:focus,
+.btn-inverse:active,
+.btn-inverse.active,
+.btn-inverse.disabled,
+.btn-inverse[disabled] {
+  color: #fff;
+  background-color: #222;
+  *background-color: #151515;
+}
+.btn-inverse:active,
+.btn-inverse.active {
+  background-color: #080808 \9;
+}
+button.btn,
+input[type="submit"].btn {
+  *padding-top: 3px;
+  *padding-bottom: 3px;
+}
+button.btn::-moz-focus-inner,
+input[type="submit"].btn::-moz-focus-inner {
+  padding: 0;
+  border: 0;
+}
+button.btn.btn-large,
+input[type="submit"].btn.btn-large {
+  *padding-top: 7px;
+  *padding-bottom: 7px;
+}
+button.btn.btn-small,
+input[type="submit"].btn.btn-small {
+  *padding-top: 3px;
+  *padding-bottom: 3px;
+}
+button.btn.btn-mini,
+input[type="submit"].btn.btn-mini {
+  *padding-top: 1px;
+  *padding-bottom: 1px;
+}
+.btn-link,
+.btn-link:active,
+.btn-link[disabled] {
+  background-color: transparent;
+  background-image: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.btn-link {
+  border-color: transparent;
+  cursor: pointer;
+  color: #08c;
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+}
+.btn-link:hover,
+.btn-link:focus {
+  color: #005580;
+  text-decoration: underline;
+  background-color: transparent;
+}
+.btn-link[disabled]:hover,
+.btn-link[disabled]:focus {
+  color: #333;
+  text-decoration: none;
+}
+.clearfix {
+  *zoom: 1;
+}
+.clearfix:before,
+.clearfix:after {
+  display: table;
+  content: "";
+  line-height: 0;
+}
+.clearfix:after {
+  clear: both;
+}
+.hide-text {
+  font: 0/0 a;
+  color: transparent;
+  text-shadow: none;
+  background-color: transparent;
+  border: 0;
+}
+.input-block-level {
+  display: block;
+  width: 100%;
+  min-height: 30px;
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.nowrap {
+  white-space: nowrap;
+}
+.actioncol {
+  text-align: center;
+  white-space: nowrap;
+}
+.actioncol a {
+  text-decoration: none;
+  color: #000;
+}
+.actioncol a.disabled {
+  color: #ccc;
+  cursor: default;
+}
+#navbar .navbar-inner {
+  background-color: #ebebeb;
+  background-image: -moz-linear-gradient(top, #ffffff, #cccccc);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#cccccc));
+  background-image: -webkit-linear-gradient(top, #ffffff, #cccccc);
+  background-image: -o-linear-gradient(top, #ffffff, #cccccc);
+  background-image: linear-gradient(to bottom, #ffffff, #cccccc);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffcccccc', GradientType=0);
+}
+#navbar .navbar-inner .brand,
+#navbar .navbar-inner .nav > li > a {
+  text-shadow: 0 1px 0 #cccccc;
+  color: #333333;
+}
+#navbar .navbar-inner .brand .caret,
+#navbar .navbar-inner .nav > li > a .caret {
+  border-bottom-color: #939393;
+  border-top-color: #939393;
+}
+#navbar .navbar-inner .brand:hover .caret,
+#navbar .navbar-inner .nav > li > a:hover .caret,
+#navbar .navbar-inner .brand:focus .caret,
+#navbar .navbar-inner .nav > li > a:focus .caret {
+  border-bottom-color: #636363;
+  border-top-color: #636363;
+}
+#navbar .navbar-inner .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #e0e0e0;
+  background-image: -moz-linear-gradient(top, #cccccc, #ffffff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#cccccc), to(#ffffff));
+  background-image: -webkit-linear-gradient(top, #cccccc, #ffffff);
+  background-image: -o-linear-gradient(top, #cccccc, #ffffff);
+  background-image: linear-gradient(to bottom, #cccccc, #ffffff);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffcccccc', endColorstr='#ffffffff', GradientType=0);
+}
+#navbar .navbar-inner .nav > li > a:hover {
+  background-color: #dedede;
+  background-image: -moz-linear-gradient(top, #f2f2f2, #bfbfbf);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f2f2f2), to(#bfbfbf));
+  background-image: -webkit-linear-gradient(top, #f2f2f2, #bfbfbf);
+  background-image: -o-linear-gradient(top, #f2f2f2, #bfbfbf);
+  background-image: linear-gradient(to bottom, #f2f2f2, #bfbfbf);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2', endColorstr='#ffbfbfbf', GradientType=0);
+}
+#navbar .navbar-inner.transparent {
+  background-color: rgba(235, 235, 235, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(204, 204, 204, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(255, 255, 255, 0.6)), to(rgba(204, 204, 204, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(204, 204, 204, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(204, 204, 204, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(204, 204, 204, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99ffffff', endColorstr='#99cccccc', GradientType=0);
+}
+#navbar .navbar-inner.transparent .brand,
+#navbar .navbar-inner.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #cccccc;
+  color: #333333;
+}
+#navbar .navbar-inner.transparent .brand .caret,
+#navbar .navbar-inner.transparent .nav > li > a .caret {
+  border-bottom-color: #939393;
+  border-top-color: #939393;
+}
+#navbar .navbar-inner.transparent .brand:hover .caret,
+#navbar .navbar-inner.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.transparent .brand:focus .caret,
+#navbar .navbar-inner.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #636363;
+  border-top-color: #636363;
+}
+#navbar .navbar-inner.transparent .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.transparent .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(224, 224, 224, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(204, 204, 204, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(204, 204, 204, 0.6)), to(rgba(255, 255, 255, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(204, 204, 204, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(204, 204, 204, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(204, 204, 204, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99cccccc', endColorstr='#99ffffff', GradientType=0);
+}
+#navbar .navbar-inner.transparent .nav > li > a:hover {
+  background-color: rgba(222, 222, 222, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(191, 191, 191, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(242, 242, 242, 0.6)), to(rgba(191, 191, 191, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(191, 191, 191, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(191, 191, 191, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(242, 242, 242, 0.6), rgba(191, 191, 191, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f2f2f2', endColorstr='#99bfbfbf', GradientType=0);
+}
+#navbar .navbar-inner.red {
+  background-color: #bb645f;
+  background-image: -moz-linear-gradient(top, #e28e8a, #802420);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#e28e8a), to(#802420));
+  background-image: -webkit-linear-gradient(top, #e28e8a, #802420);
+  background-image: -o-linear-gradient(top, #e28e8a, #802420);
+  background-image: linear-gradient(to bottom, #e28e8a, #802420);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffe28e8a', endColorstr='#ff802420', GradientType=0);
+}
+#navbar .navbar-inner.red .brand,
+#navbar .navbar-inner.red .nav > li > a {
+  text-shadow: 0 1px 0 #d86761;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.red .brand .caret,
+#navbar .navbar-inner.red .nav > li > a .caret {
+  border-bottom-color: #d89491;
+  border-top-color: #d89491;
+}
+#navbar .navbar-inner.red .brand:hover .caret,
+#navbar .navbar-inner.red .nav > li > a:hover .caret,
+#navbar .navbar-inner.red .brand:focus .caret,
+#navbar .navbar-inner.red .nav > li > a:focus .caret {
+  border-bottom-color: #e5c3c1;
+  border-top-color: #e5c3c1;
+}
+#navbar .navbar-inner.red .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.red .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.red .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.red .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.red .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #a74f4a;
+  background-image: -moz-linear-gradient(top, #802420, #e28e8a);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#802420), to(#e28e8a));
+  background-image: -webkit-linear-gradient(top, #802420, #e28e8a);
+  background-image: -o-linear-gradient(top, #802420, #e28e8a);
+  background-image: linear-gradient(to bottom, #802420, #e28e8a);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff802420', endColorstr='#ffe28e8a', GradientType=0);
+}
+#navbar .navbar-inner.red .nav > li > a:hover {
+  background-color: #af5651;
+  background-image: -moz-linear-gradient(top, #dd7a75, #6b1f1b);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#dd7a75), to(#6b1f1b));
+  background-image: -webkit-linear-gradient(top, #dd7a75, #6b1f1b);
+  background-image: -o-linear-gradient(top, #dd7a75, #6b1f1b);
+  background-image: linear-gradient(to bottom, #dd7a75, #6b1f1b);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffdd7a75', endColorstr='#ff6b1f1b', GradientType=0);
+}
+#navbar .navbar-inner.red.transparent {
+  background-color: rgba(187, 100, 95, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(226, 142, 138, 0.6), rgba(128, 36, 32, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(226, 142, 138, 0.6)), to(rgba(128, 36, 32, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(226, 142, 138, 0.6), rgba(128, 36, 32, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(226, 142, 138, 0.6), rgba(128, 36, 32, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(226, 142, 138, 0.6), rgba(128, 36, 32, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99e28e8a', endColorstr='#99802420', GradientType=0);
+}
+#navbar .navbar-inner.red.transparent .brand,
+#navbar .navbar-inner.red.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #d86761;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.red.transparent .brand .caret,
+#navbar .navbar-inner.red.transparent .nav > li > a .caret {
+  border-bottom-color: #d89491;
+  border-top-color: #d89491;
+}
+#navbar .navbar-inner.red.transparent .brand:hover .caret,
+#navbar .navbar-inner.red.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.red.transparent .brand:focus .caret,
+#navbar .navbar-inner.red.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #e5c3c1;
+  border-top-color: #e5c3c1;
+}
+#navbar .navbar-inner.red.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.red.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.red.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.red.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.red.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(167, 79, 74, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(128, 36, 32, 0.6), rgba(226, 142, 138, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(128, 36, 32, 0.6)), to(rgba(226, 142, 138, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(128, 36, 32, 0.6), rgba(226, 142, 138, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(128, 36, 32, 0.6), rgba(226, 142, 138, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(128, 36, 32, 0.6), rgba(226, 142, 138, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99802420', endColorstr='#99e28e8a', GradientType=0);
+}
+#navbar .navbar-inner.red.transparent .nav > li > a:hover {
+  background-color: rgba(175, 86, 81, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(221, 122, 117, 0.6), rgba(107, 31, 27, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(221, 122, 117, 0.6)), to(rgba(107, 31, 27, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(221, 122, 117, 0.6), rgba(107, 31, 27, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(221, 122, 117, 0.6), rgba(107, 31, 27, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(221, 122, 117, 0.6), rgba(107, 31, 27, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99dd7a75', endColorstr='#996b1f1b', GradientType=0);
+}
+#navbar .navbar-inner.orange {
+  background-color: #e39665;
+  background-image: -moz-linear-gradient(top, #f9c3a0, #c2530c);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f9c3a0), to(#c2530c));
+  background-image: -webkit-linear-gradient(top, #f9c3a0, #c2530c);
+  background-image: -o-linear-gradient(top, #f9c3a0, #c2530c);
+  background-image: linear-gradient(to bottom, #f9c3a0, #c2530c);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9c3a0', endColorstr='#ffc2530c', GradientType=0);
+}
+#navbar .navbar-inner.orange .brand,
+#navbar .navbar-inner.orange .nav > li > a {
+  text-shadow: 0 1px 0 #f6a570;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.orange .brand .caret,
+#navbar .navbar-inner.orange .nav > li > a .caret {
+  border-bottom-color: #f2b58d;
+  border-top-color: #f2b58d;
+}
+#navbar .navbar-inner.orange .brand:hover .caret,
+#navbar .navbar-inner.orange .nav > li > a:hover .caret,
+#navbar .navbar-inner.orange .brand:focus .caret,
+#navbar .navbar-inner.orange .nav > li > a:focus .caret {
+  border-bottom-color: #f2d3bf;
+  border-top-color: #f2d3bf;
+}
+#navbar .navbar-inner.orange .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.orange .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.orange .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.orange .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.orange .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #d88047;
+  background-image: -moz-linear-gradient(top, #c2530c, #f9c3a0);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#c2530c), to(#f9c3a0));
+  background-image: -webkit-linear-gradient(top, #c2530c, #f9c3a0);
+  background-image: -o-linear-gradient(top, #c2530c, #f9c3a0);
+  background-image: linear-gradient(to bottom, #c2530c, #f9c3a0);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc2530c', endColorstr='#fff9c3a0', GradientType=0);
+}
+#navbar .navbar-inner.orange .nav > li > a:hover {
+  background-color: #d98956;
+  background-image: -moz-linear-gradient(top, #f8b488, #aa490a);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f8b488), to(#aa490a));
+  background-image: -webkit-linear-gradient(top, #f8b488, #aa490a);
+  background-image: -o-linear-gradient(top, #f8b488, #aa490a);
+  background-image: linear-gradient(to bottom, #f8b488, #aa490a);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff8b488', endColorstr='#ffaa490a', GradientType=0);
+}
+#navbar .navbar-inner.orange.transparent {
+  background-color: rgba(227, 150, 101, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(249, 195, 160, 0.6), rgba(194, 83, 12, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(249, 195, 160, 0.6)), to(rgba(194, 83, 12, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(249, 195, 160, 0.6), rgba(194, 83, 12, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(249, 195, 160, 0.6), rgba(194, 83, 12, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(249, 195, 160, 0.6), rgba(194, 83, 12, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f9c3a0', endColorstr='#99c2530c', GradientType=0);
+}
+#navbar .navbar-inner.orange.transparent .brand,
+#navbar .navbar-inner.orange.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #f6a570;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.orange.transparent .brand .caret,
+#navbar .navbar-inner.orange.transparent .nav > li > a .caret {
+  border-bottom-color: #f2b58d;
+  border-top-color: #f2b58d;
+}
+#navbar .navbar-inner.orange.transparent .brand:hover .caret,
+#navbar .navbar-inner.orange.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.orange.transparent .brand:focus .caret,
+#navbar .navbar-inner.orange.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #f2d3bf;
+  border-top-color: #f2d3bf;
+}
+#navbar .navbar-inner.orange.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.orange.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.orange.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.orange.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.orange.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(216, 128, 71, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(194, 83, 12, 0.6), rgba(249, 195, 160, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(194, 83, 12, 0.6)), to(rgba(249, 195, 160, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(194, 83, 12, 0.6), rgba(249, 195, 160, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(194, 83, 12, 0.6), rgba(249, 195, 160, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(194, 83, 12, 0.6), rgba(249, 195, 160, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c2530c', endColorstr='#99f9c3a0', GradientType=0);
+}
+#navbar .navbar-inner.orange.transparent .nav > li > a:hover {
+  background-color: rgba(217, 137, 86, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(248, 180, 136, 0.6), rgba(170, 73, 10, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(248, 180, 136, 0.6)), to(rgba(170, 73, 10, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(248, 180, 136, 0.6), rgba(170, 73, 10, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(248, 180, 136, 0.6), rgba(170, 73, 10, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(248, 180, 136, 0.6), rgba(170, 73, 10, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f8b488', endColorstr='#99aa490a', GradientType=0);
+}
+#navbar .navbar-inner.yellow {
+  background-color: #e3d765;
+  background-image: -moz-linear-gradient(top, #f9f0a0, #c2b00c);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f9f0a0), to(#c2b00c));
+  background-image: -webkit-linear-gradient(top, #f9f0a0, #c2b00c);
+  background-image: -o-linear-gradient(top, #f9f0a0, #c2b00c);
+  background-image: linear-gradient(to bottom, #f9f0a0, #c2b00c);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff9f0a0', endColorstr='#ffc2b00c', GradientType=0);
+}
+#navbar .navbar-inner.yellow .brand,
+#navbar .navbar-inner.yellow .nav > li > a {
+  text-shadow: 0 1px 0 #c2b00c;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.yellow .brand .caret,
+#navbar .navbar-inner.yellow .nav > li > a .caret {
+  border-bottom-color: #f2e88d;
+  border-top-color: #f2e88d;
+}
+#navbar .navbar-inner.yellow .brand:hover .caret,
+#navbar .navbar-inner.yellow .nav > li > a:hover .caret,
+#navbar .navbar-inner.yellow .brand:focus .caret,
+#navbar .navbar-inner.yellow .nav > li > a:focus .caret {
+  border-bottom-color: #f2edbf;
+  border-top-color: #f2edbf;
+}
+#navbar .navbar-inner.yellow .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.yellow .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.yellow .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.yellow .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.yellow .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #d8ca47;
+  background-image: -moz-linear-gradient(top, #c2b00c, #f9f0a0);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#c2b00c), to(#f9f0a0));
+  background-image: -webkit-linear-gradient(top, #c2b00c, #f9f0a0);
+  background-image: -o-linear-gradient(top, #c2b00c, #f9f0a0);
+  background-image: linear-gradient(to bottom, #c2b00c, #f9f0a0);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc2b00c', endColorstr='#fff9f0a0', GradientType=0);
+}
+#navbar .navbar-inner.yellow .nav > li > a:hover {
+  background-color: #d9cc56;
+  background-image: -moz-linear-gradient(top, #f8ed88, #aa9a0a);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f8ed88), to(#aa9a0a));
+  background-image: -webkit-linear-gradient(top, #f8ed88, #aa9a0a);
+  background-image: -o-linear-gradient(top, #f8ed88, #aa9a0a);
+  background-image: linear-gradient(to bottom, #f8ed88, #aa9a0a);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff8ed88', endColorstr='#ffaa9a0a', GradientType=0);
+}
+#navbar .navbar-inner.yellow.transparent {
+  background-color: rgba(227, 215, 101, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(249, 240, 160, 0.6), rgba(194, 176, 12, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(249, 240, 160, 0.6)), to(rgba(194, 176, 12, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(249, 240, 160, 0.6), rgba(194, 176, 12, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(249, 240, 160, 0.6), rgba(194, 176, 12, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(249, 240, 160, 0.6), rgba(194, 176, 12, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f9f0a0', endColorstr='#99c2b00c', GradientType=0);
+}
+#navbar .navbar-inner.yellow.transparent .brand,
+#navbar .navbar-inner.yellow.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #c2b00c;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.yellow.transparent .brand .caret,
+#navbar .navbar-inner.yellow.transparent .nav > li > a .caret {
+  border-bottom-color: #f2e88d;
+  border-top-color: #f2e88d;
+}
+#navbar .navbar-inner.yellow.transparent .brand:hover .caret,
+#navbar .navbar-inner.yellow.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.yellow.transparent .brand:focus .caret,
+#navbar .navbar-inner.yellow.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #f2edbf;
+  border-top-color: #f2edbf;
+}
+#navbar .navbar-inner.yellow.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.yellow.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.yellow.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.yellow.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.yellow.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(216, 202, 71, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(194, 176, 12, 0.6), rgba(249, 240, 160, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(194, 176, 12, 0.6)), to(rgba(249, 240, 160, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(194, 176, 12, 0.6), rgba(249, 240, 160, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(194, 176, 12, 0.6), rgba(249, 240, 160, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(194, 176, 12, 0.6), rgba(249, 240, 160, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c2b00c', endColorstr='#99f9f0a0', GradientType=0);
+}
+#navbar .navbar-inner.yellow.transparent .nav > li > a:hover {
+  background-color: rgba(217, 204, 86, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(248, 237, 136, 0.6), rgba(170, 154, 10, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(248, 237, 136, 0.6)), to(rgba(170, 154, 10, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(248, 237, 136, 0.6), rgba(170, 154, 10, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(248, 237, 136, 0.6), rgba(170, 154, 10, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(248, 237, 136, 0.6), rgba(170, 154, 10, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f8ed88', endColorstr='#99aa9a0a', GradientType=0);
+}
+#navbar .navbar-inner.green {
+  background-color: #98f064;
+  background-image: -moz-linear-gradient(top, #c8ffa7, #50da00);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#c8ffa7), to(#50da00));
+  background-image: -webkit-linear-gradient(top, #c8ffa7, #50da00);
+  background-image: -o-linear-gradient(top, #c8ffa7, #50da00);
+  background-image: linear-gradient(to bottom, #c8ffa7, #50da00);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8ffa7', endColorstr='#ff50da00', GradientType=0);
+}
+#navbar .navbar-inner.green .brand,
+#navbar .navbar-inner.green .nav > li > a {
+  text-shadow: 0 1px 0 #50da00;
+  color: #333333;
+}
+#navbar .navbar-inner.green .brand .caret,
+#navbar .navbar-inner.green .nav > li > a .caret {
+  border-bottom-color: #55992e;
+  border-top-color: #55992e;
+}
+#navbar .navbar-inner.green .brand:hover .caret,
+#navbar .navbar-inner.green .nav > li > a:hover .caret,
+#navbar .navbar-inner.green .brand:focus .caret,
+#navbar .navbar-inner.green .nav > li > a:focus .caret {
+  border-bottom-color: #446630;
+  border-top-color: #446630;
+}
+#navbar .navbar-inner.green .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.green .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner.green .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.green .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.green .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #80e943;
+  background-image: -moz-linear-gradient(top, #50da00, #c8ffa7);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#50da00), to(#c8ffa7));
+  background-image: -webkit-linear-gradient(top, #50da00, #c8ffa7);
+  background-image: -o-linear-gradient(top, #50da00, #c8ffa7);
+  background-image: linear-gradient(to bottom, #50da00, #c8ffa7);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff50da00', endColorstr='#ffc8ffa7', GradientType=0);
+}
+#navbar .navbar-inner.green .nav > li > a:hover {
+  background-color: #8ae655;
+  background-image: -moz-linear-gradient(top, #b8ff8e, #47c100);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#b8ff8e), to(#47c100));
+  background-image: -webkit-linear-gradient(top, #b8ff8e, #47c100);
+  background-image: -o-linear-gradient(top, #b8ff8e, #47c100);
+  background-image: linear-gradient(to bottom, #b8ff8e, #47c100);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffb8ff8e', endColorstr='#ff47c100', GradientType=0);
+}
+#navbar .navbar-inner.green.transparent {
+  background-color: rgba(152, 240, 100, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(200, 255, 167, 0.6), rgba(80, 218, 0, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(200, 255, 167, 0.6)), to(rgba(80, 218, 0, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(200, 255, 167, 0.6), rgba(80, 218, 0, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(200, 255, 167, 0.6), rgba(80, 218, 0, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(200, 255, 167, 0.6), rgba(80, 218, 0, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8ffa7', endColorstr='#9950da00', GradientType=0);
+}
+#navbar .navbar-inner.green.transparent .brand,
+#navbar .navbar-inner.green.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #50da00;
+  color: #333333;
+}
+#navbar .navbar-inner.green.transparent .brand .caret,
+#navbar .navbar-inner.green.transparent .nav > li > a .caret {
+  border-bottom-color: #55992e;
+  border-top-color: #55992e;
+}
+#navbar .navbar-inner.green.transparent .brand:hover .caret,
+#navbar .navbar-inner.green.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.green.transparent .brand:focus .caret,
+#navbar .navbar-inner.green.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #446630;
+  border-top-color: #446630;
+}
+#navbar .navbar-inner.green.transparent .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.green.transparent .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner.green.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.green.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.green.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(128, 233, 67, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(80, 218, 0, 0.6), rgba(200, 255, 167, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(80, 218, 0, 0.6)), to(rgba(200, 255, 167, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(80, 218, 0, 0.6), rgba(200, 255, 167, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(80, 218, 0, 0.6), rgba(200, 255, 167, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(80, 218, 0, 0.6), rgba(200, 255, 167, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#9950da00', endColorstr='#99c8ffa7', GradientType=0);
+}
+#navbar .navbar-inner.green.transparent .nav > li > a:hover {
+  background-color: rgba(138, 230, 85, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(184, 255, 142, 0.6), rgba(71, 193, 0, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(184, 255, 142, 0.6)), to(rgba(71, 193, 0, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(184, 255, 142, 0.6), rgba(71, 193, 0, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(184, 255, 142, 0.6), rgba(71, 193, 0, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(184, 255, 142, 0.6), rgba(71, 193, 0, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99b8ff8e', endColorstr='#9947c100', GradientType=0);
+}
+#navbar .navbar-inner.blue {
+  background-color: #2e63cc;
+  background-image: -moz-linear-gradient(top, #4d88ff, #002b80);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#4d88ff), to(#002b80));
+  background-image: -webkit-linear-gradient(top, #4d88ff, #002b80);
+  background-image: -o-linear-gradient(top, #4d88ff, #002b80);
+  background-image: linear-gradient(to bottom, #4d88ff, #002b80);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff4d88ff', endColorstr='#ff002b80', GradientType=0);
+}
+#navbar .navbar-inner.blue .brand,
+#navbar .navbar-inner.blue .nav > li > a {
+  text-shadow: 0 1px 0 #1a66ff;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.blue .brand .caret,
+#navbar .navbar-inner.blue .nav > li > a .caret {
+  border-bottom-color: #799bdf;
+  border-top-color: #799bdf;
+}
+#navbar .navbar-inner.blue .brand:hover .caret,
+#navbar .navbar-inner.blue .nav > li > a:hover .caret,
+#navbar .navbar-inner.blue .brand:focus .caret,
+#navbar .navbar-inner.blue .nav > li > a:focus .caret {
+  border-bottom-color: #b6c7e9;
+  border-top-color: #b6c7e9;
+}
+#navbar .navbar-inner.blue .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.blue .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.blue .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.blue .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.blue .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #1f50b3;
+  background-image: -moz-linear-gradient(top, #002b80, #4d88ff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#002b80), to(#4d88ff));
+  background-image: -webkit-linear-gradient(top, #002b80, #4d88ff);
+  background-image: -o-linear-gradient(top, #002b80, #4d88ff);
+  background-image: linear-gradient(to bottom, #002b80, #4d88ff);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff002b80', endColorstr='#ff4d88ff', GradientType=0);
+}
+#navbar .navbar-inner.blue .nav > li > a:hover {
+  background-color: #1f55c2;
+  background-image: -moz-linear-gradient(top, #3377ff, #002266);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#3377ff), to(#002266));
+  background-image: -webkit-linear-gradient(top, #3377ff, #002266);
+  background-image: -o-linear-gradient(top, #3377ff, #002266);
+  background-image: linear-gradient(to bottom, #3377ff, #002266);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff3377ff', endColorstr='#ff002266', GradientType=0);
+}
+#navbar .navbar-inner.blue.transparent {
+  background-color: rgba(46, 99, 204, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(77, 136, 255, 0.6), rgba(0, 43, 128, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(77, 136, 255, 0.6)), to(rgba(0, 43, 128, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(77, 136, 255, 0.6), rgba(0, 43, 128, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(77, 136, 255, 0.6), rgba(0, 43, 128, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(77, 136, 255, 0.6), rgba(0, 43, 128, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#994d88ff', endColorstr='#99002b80', GradientType=0);
+}
+#navbar .navbar-inner.blue.transparent .brand,
+#navbar .navbar-inner.blue.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #1a66ff;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.blue.transparent .brand .caret,
+#navbar .navbar-inner.blue.transparent .nav > li > a .caret {
+  border-bottom-color: #799bdf;
+  border-top-color: #799bdf;
+}
+#navbar .navbar-inner.blue.transparent .brand:hover .caret,
+#navbar .navbar-inner.blue.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.blue.transparent .brand:focus .caret,
+#navbar .navbar-inner.blue.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #b6c7e9;
+  border-top-color: #b6c7e9;
+}
+#navbar .navbar-inner.blue.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.blue.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.blue.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.blue.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.blue.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(31, 80, 179, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(0, 43, 128, 0.6), rgba(77, 136, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(0, 43, 128, 0.6)), to(rgba(77, 136, 255, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(0, 43, 128, 0.6), rgba(77, 136, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(0, 43, 128, 0.6), rgba(77, 136, 255, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(0, 43, 128, 0.6), rgba(77, 136, 255, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99002b80', endColorstr='#994d88ff', GradientType=0);
+}
+#navbar .navbar-inner.blue.transparent .nav > li > a:hover {
+  background-color: rgba(31, 85, 194, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(51, 119, 255, 0.6), rgba(0, 34, 102, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(51, 119, 255, 0.6)), to(rgba(0, 34, 102, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(51, 119, 255, 0.6), rgba(0, 34, 102, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(51, 119, 255, 0.6), rgba(0, 34, 102, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(51, 119, 255, 0.6), rgba(0, 34, 102, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#993377ff', endColorstr='#99002266', GradientType=0);
+}
+#navbar .navbar-inner.violet {
+  background-color: #9864f0;
+  background-image: -moz-linear-gradient(top, #c8a7ff, #5000da);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#c8a7ff), to(#5000da));
+  background-image: -webkit-linear-gradient(top, #c8a7ff, #5000da);
+  background-image: -o-linear-gradient(top, #c8a7ff, #5000da);
+  background-image: linear-gradient(to bottom, #c8a7ff, #5000da);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8a7ff', endColorstr='#ff5000da', GradientType=0);
+}
+#navbar .navbar-inner.violet .brand,
+#navbar .navbar-inner.violet .nav > li > a {
+  text-shadow: 0 1px 0 #a774ff;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.violet .brand .caret,
+#navbar .navbar-inner.violet .nav > li > a .caret {
+  border-bottom-color: #b58df9;
+  border-top-color: #b58df9;
+}
+#navbar .navbar-inner.violet .brand:hover .caret,
+#navbar .navbar-inner.violet .nav > li > a:hover .caret,
+#navbar .navbar-inner.violet .brand:focus .caret,
+#navbar .navbar-inner.violet .nav > li > a:focus .caret {
+  border-bottom-color: #d3bff5;
+  border-top-color: #d3bff5;
+}
+#navbar .navbar-inner.violet .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.violet .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.violet .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.violet .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.violet .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #8043e9;
+  background-image: -moz-linear-gradient(top, #5000da, #c8a7ff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#5000da), to(#c8a7ff));
+  background-image: -webkit-linear-gradient(top, #5000da, #c8a7ff);
+  background-image: -o-linear-gradient(top, #5000da, #c8a7ff);
+  background-image: linear-gradient(to bottom, #5000da, #c8a7ff);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff5000da', endColorstr='#ffc8a7ff', GradientType=0);
+}
+#navbar .navbar-inner.violet .nav > li > a:hover {
+  background-color: #8a55e6;
+  background-image: -moz-linear-gradient(top, #b88eff, #4700c1);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#b88eff), to(#4700c1));
+  background-image: -webkit-linear-gradient(top, #b88eff, #4700c1);
+  background-image: -o-linear-gradient(top, #b88eff, #4700c1);
+  background-image: linear-gradient(to bottom, #b88eff, #4700c1);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffb88eff', endColorstr='#ff4700c1', GradientType=0);
+}
+#navbar .navbar-inner.violet.transparent {
+  background-color: rgba(152, 100, 240, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(200, 167, 255, 0.6), rgba(80, 0, 218, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(200, 167, 255, 0.6)), to(rgba(80, 0, 218, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(200, 167, 255, 0.6), rgba(80, 0, 218, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(200, 167, 255, 0.6), rgba(80, 0, 218, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(200, 167, 255, 0.6), rgba(80, 0, 218, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8a7ff', endColorstr='#995000da', GradientType=0);
+}
+#navbar .navbar-inner.violet.transparent .brand,
+#navbar .navbar-inner.violet.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #a774ff;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.violet.transparent .brand .caret,
+#navbar .navbar-inner.violet.transparent .nav > li > a .caret {
+  border-bottom-color: #b58df9;
+  border-top-color: #b58df9;
+}
+#navbar .navbar-inner.violet.transparent .brand:hover .caret,
+#navbar .navbar-inner.violet.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.violet.transparent .brand:focus .caret,
+#navbar .navbar-inner.violet.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #d3bff5;
+  border-top-color: #d3bff5;
+}
+#navbar .navbar-inner.violet.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.violet.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.violet.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.violet.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.violet.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(128, 67, 233, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(80, 0, 218, 0.6), rgba(200, 167, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(80, 0, 218, 0.6)), to(rgba(200, 167, 255, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(80, 0, 218, 0.6), rgba(200, 167, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(80, 0, 218, 0.6), rgba(200, 167, 255, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(80, 0, 218, 0.6), rgba(200, 167, 255, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#995000da', endColorstr='#99c8a7ff', GradientType=0);
+}
+#navbar .navbar-inner.violet.transparent .nav > li > a:hover {
+  background-color: rgba(138, 85, 230, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(184, 142, 255, 0.6), rgba(71, 0, 193, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(184, 142, 255, 0.6)), to(rgba(71, 0, 193, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(184, 142, 255, 0.6), rgba(71, 0, 193, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(184, 142, 255, 0.6), rgba(71, 0, 193, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(184, 142, 255, 0.6), rgba(71, 0, 193, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99b88eff', endColorstr='#994700c1', GradientType=0);
+}
+#navbar .navbar-inner.black {
+  background-color: #4f4f4f;
+  background-image: -moz-linear-gradient(top, #787878, #121212);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#787878), to(#121212));
+  background-image: -webkit-linear-gradient(top, #787878, #121212);
+  background-image: -o-linear-gradient(top, #787878, #121212);
+  background-image: linear-gradient(to bottom, #787878, #121212);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff787878', endColorstr='#ff121212', GradientType=0);
+}
+#navbar .navbar-inner.black .brand,
+#navbar .navbar-inner.black .nav > li > a {
+  text-shadow: 0 1px 0 #5e5e5e;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.black .brand .caret,
+#navbar .navbar-inner.black .nav > li > a .caret {
+  border-bottom-color: #959595;
+  border-top-color: #959595;
+}
+#navbar .navbar-inner.black .brand:hover .caret,
+#navbar .navbar-inner.black .nav > li > a:hover .caret,
+#navbar .navbar-inner.black .brand:focus .caret,
+#navbar .navbar-inner.black .nav > li > a:focus .caret {
+  border-bottom-color: #c4c4c4;
+  border-top-color: #c4c4c4;
+}
+#navbar .navbar-inner.black .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.black .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.black .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.black .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.black .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #3b3b3b;
+  background-image: -moz-linear-gradient(top, #121212, #787878);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#121212), to(#787878));
+  background-image: -webkit-linear-gradient(top, #121212, #787878);
+  background-image: -o-linear-gradient(top, #121212, #787878);
+  background-image: linear-gradient(to bottom, #121212, #787878);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff121212', endColorstr='#ff787878', GradientType=0);
+}
+#navbar .navbar-inner.black .nav > li > a:hover {
+  background-color: #424242;
+  background-image: -moz-linear-gradient(top, #6b6b6b, #050505);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#6b6b6b), to(#050505));
+  background-image: -webkit-linear-gradient(top, #6b6b6b, #050505);
+  background-image: -o-linear-gradient(top, #6b6b6b, #050505);
+  background-image: linear-gradient(to bottom, #6b6b6b, #050505);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff6b6b6b', endColorstr='#ff050505', GradientType=0);
+}
+#navbar .navbar-inner.black.transparent {
+  background-color: rgba(79, 79, 79, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(120, 120, 120, 0.6), rgba(18, 18, 18, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(120, 120, 120, 0.6)), to(rgba(18, 18, 18, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(120, 120, 120, 0.6), rgba(18, 18, 18, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(120, 120, 120, 0.6), rgba(18, 18, 18, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(120, 120, 120, 0.6), rgba(18, 18, 18, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99787878', endColorstr='#99121212', GradientType=0);
+}
+#navbar .navbar-inner.black.transparent .brand,
+#navbar .navbar-inner.black.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #5e5e5e;
+  color: #f2f2f2;
+}
+#navbar .navbar-inner.black.transparent .brand .caret,
+#navbar .navbar-inner.black.transparent .nav > li > a .caret {
+  border-bottom-color: #959595;
+  border-top-color: #959595;
+}
+#navbar .navbar-inner.black.transparent .brand:hover .caret,
+#navbar .navbar-inner.black.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.black.transparent .brand:focus .caret,
+#navbar .navbar-inner.black.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #c4c4c4;
+  border-top-color: #c4c4c4;
+}
+#navbar .navbar-inner.black.transparent .brand span {
+  background-image: url(../img/tentacle-20x20-light.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.black.transparent .brand span {
+    background-image: url(../img/tentacle-20x20-light@2x.png);
+  }
+}
+#navbar .navbar-inner.black.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.black.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.black.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(59, 59, 59, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(18, 18, 18, 0.6), rgba(120, 120, 120, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(18, 18, 18, 0.6)), to(rgba(120, 120, 120, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(18, 18, 18, 0.6), rgba(120, 120, 120, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(18, 18, 18, 0.6), rgba(120, 120, 120, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(18, 18, 18, 0.6), rgba(120, 120, 120, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99121212', endColorstr='#99787878', GradientType=0);
+}
+#navbar .navbar-inner.black.transparent .nav > li > a:hover {
+  background-color: rgba(66, 66, 66, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(107, 107, 107, 0.6), rgba(5, 5, 5, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(107, 107, 107, 0.6)), to(rgba(5, 5, 5, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(107, 107, 107, 0.6), rgba(5, 5, 5, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(107, 107, 107, 0.6), rgba(5, 5, 5, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(107, 107, 107, 0.6), rgba(5, 5, 5, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#996b6b6b', endColorstr='#99050505', GradientType=0);
+}
+#navbar .navbar-inner.white {
+  background-color: #e9e9e9;
+  background-image: -moz-linear-gradient(top, #ffffff, #c8c8c8);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#ffffff), to(#c8c8c8));
+  background-image: -webkit-linear-gradient(top, #ffffff, #c8c8c8);
+  background-image: -o-linear-gradient(top, #ffffff, #c8c8c8);
+  background-image: linear-gradient(to bottom, #ffffff, #c8c8c8);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffc8c8c8', GradientType=0);
+}
+#navbar .navbar-inner.white .brand,
+#navbar .navbar-inner.white .nav > li > a {
+  text-shadow: 0 1px 0 #c8c8c8;
+  color: #333333;
+}
+#navbar .navbar-inner.white .brand .caret,
+#navbar .navbar-inner.white .nav > li > a .caret {
+  border-bottom-color: #919191;
+  border-top-color: #919191;
+}
+#navbar .navbar-inner.white .brand:hover .caret,
+#navbar .navbar-inner.white .nav > li > a:hover .caret,
+#navbar .navbar-inner.white .brand:focus .caret,
+#navbar .navbar-inner.white .nav > li > a:focus .caret {
+  border-bottom-color: #626262;
+  border-top-color: #626262;
+}
+#navbar .navbar-inner.white .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.white .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner.white .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.white .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.white .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: #dedede;
+  background-image: -moz-linear-gradient(top, #c8c8c8, #ffffff);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#c8c8c8), to(#ffffff));
+  background-image: -webkit-linear-gradient(top, #c8c8c8, #ffffff);
+  background-image: -o-linear-gradient(top, #c8c8c8, #ffffff);
+  background-image: linear-gradient(to bottom, #c8c8c8, #ffffff);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffc8c8c8', endColorstr='#ffffffff', GradientType=0);
+}
+#navbar .navbar-inner.white .nav > li > a:hover {
+  background-color: #dcdcdc;
+  background-image: -moz-linear-gradient(top, #f2f2f2, #bbbbbb);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#f2f2f2), to(#bbbbbb));
+  background-image: -webkit-linear-gradient(top, #f2f2f2, #bbbbbb);
+  background-image: -o-linear-gradient(top, #f2f2f2, #bbbbbb);
+  background-image: linear-gradient(to bottom, #f2f2f2, #bbbbbb);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#fff2f2f2', endColorstr='#ffbbbbbb', GradientType=0);
+}
+#navbar .navbar-inner.white.transparent {
+  background-color: rgba(233, 233, 233, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(200, 200, 200, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(255, 255, 255, 0.6)), to(rgba(200, 200, 200, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(200, 200, 200, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(255, 255, 255, 0.6), rgba(200, 200, 200, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(255, 255, 255, 0.6), rgba(200, 200, 200, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99ffffff', endColorstr='#99c8c8c8', GradientType=0);
+}
+#navbar .navbar-inner.white.transparent .brand,
+#navbar .navbar-inner.white.transparent .nav > li > a {
+  text-shadow: 0 1px 0 #c8c8c8;
+  color: #333333;
+}
+#navbar .navbar-inner.white.transparent .brand .caret,
+#navbar .navbar-inner.white.transparent .nav > li > a .caret {
+  border-bottom-color: #919191;
+  border-top-color: #919191;
+}
+#navbar .navbar-inner.white.transparent .brand:hover .caret,
+#navbar .navbar-inner.white.transparent .nav > li > a:hover .caret,
+#navbar .navbar-inner.white.transparent .brand:focus .caret,
+#navbar .navbar-inner.white.transparent .nav > li > a:focus .caret {
+  border-bottom-color: #626262;
+  border-top-color: #626262;
+}
+#navbar .navbar-inner.white.transparent .brand span {
+  background-image: url(../img/tentacle-20x20.png);
+}
+@media (-webkit-min-device-pixel-ratio: 2), (min-resolution: 192dpi) {
+  #navbar .navbar-inner.white.transparent .brand span {
+    background-image: url(../img/tentacle-20x20@2x.png);
+  }
+}
+#navbar .navbar-inner.white.transparent .nav > li.dropdown.open > .dropdown-toggle,
+#navbar .navbar-inner.white.transparent .nav > li.dropdown.active > .dropdown-toggle,
+#navbar .navbar-inner.white.transparent .nav > li.dropdown.open.active > .dropdown-toggle {
+  background-color: rgba(222, 222, 222, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(200, 200, 200, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(200, 200, 200, 0.6)), to(rgba(255, 255, 255, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(200, 200, 200, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(200, 200, 200, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(200, 200, 200, 0.6), rgba(255, 255, 255, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99c8c8c8', endColorstr='#99ffffff', GradientType=0);
+}
+#navbar .navbar-inner.white.transparent .nav > li > a:hover {
+  background-color: rgba(220, 220, 220, 0.6);
+  background-image: "../img/trans-background.png";
+  background-image: -moz-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(187, 187, 187, 0.6)), url("../img/trans-background.png");
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(rgba(242, 242, 242, 0.6)), to(rgba(187, 187, 187, 0.6))), url("../img/trans-background.png");
+  background-image: -webkit-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(187, 187, 187, 0.6)), url("../img/trans-background.png");
+  background-image: -o-linear-gradient(top, rgba(242, 242, 242, 0.6), rgba(187, 187, 187, 0.6)), url("../img/trans-background.png");
+  background-image: linear-gradient(to bottom, rgba(242, 242, 242, 0.6), rgba(187, 187, 187, 0.6)), url("../img/trans-background.png");
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#99f2f2f2', endColorstr='#99bbbbbb', GradientType=0);
+}
+#navbar .navbar-inner .brand {
+  padding: 10px 20px 6px;
+}
+#navbar .navbar-inner .brand span {
+  padding-left: 26px;
+  background-size: 20px 20px;
+  background-repeat: no-repeat;
+  display: inline-block;
+  max-width: 250px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+  line-height: 20px;
+  height: 24px;
+}
+#navbar_login a.dropdown-toggle span {
+  display: inline-block;
+  max-width: 100px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  vertical-align: top;
+}
+.octoprint-container {
+  margin-top: 20px;
+  /** OctoPrint application tabs */
+  /** Accordions */
+}
+.octoprint-container .tab-content {
+  padding: 9px 15px;
+  border-left: 1px solid #ddd;
+  border-right: 1px solid #ddd;
+  border-bottom: 1px solid #ddd;
+  -webkit-border-bottom-right-radius: 4px;
+  -moz-border-radius-bottomright: 4px;
+  border-bottom-right-radius: 4px;
+  -webkit-border-bottom-left-radius: 4px;
+  -moz-border-radius-bottomleft: 4px;
+  border-bottom-left-radius: 4px;
+}
+.octoprint-container .nav {
+  margin-bottom: 0px;
+}
+.octoprint-container .tab-content h1 {
+  display: block;
+  width: 100%;
+  padding: 0;
+  margin-bottom: 20px;
+  font-size: 21px;
+  line-height: 40px;
+  color: #333;
+  border: 0;
+  border-bottom: 1px solid #e5e5e5;
+  font-weight: normal;
+}
+.octoprint-container .accordion-heading .accordion-heading-button {
+  float: right;
+}
+.octoprint-container .accordion-heading .accordion-heading-button > a {
+  display: inline-block;
+  padding: 8px 15px;
+  font-size: 14px;
+  line-height: 20px;
+  color: #000;
+  text-decoration: none;
+  background: none;
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.octoprint-container .accordion-heading a.accordion-toggle {
+  display: inline-block;
+}
+.octoprint-container .accordion-heading [class^="icon-"],
+.octoprint-container .accordion-heading [class*=" icon-"] {
+  color: #000;
+}
+.print-control .btn {
+  padding-left: 4px;
+  padding-right: 4px;
+}
+.upload-buttons .btn {
+  margin-right: 0;
+}
+/** Tables */
+table {
+  table-layout: fixed;
+}
+table .popover-title {
+  text-overflow: ellipsis;
+  word-break: break-all;
+}
+table th,
+table td {
+  overflow: hidden;
+}
+table th.gcode_files_name,
+table td.gcode_files_name {
+  text-overflow: ellipsis;
+  text-align: left;
+  white-space: nowrap;
+}
+table th.gcode_files_action,
+table td.gcode_files_action {
+  width: 90px;
+  text-align: center;
+  white-space: nowrap;
+}
+table th.gcode_files_action a,
+table td.gcode_files_action a {
+  text-decoration: none;
+  color: #000;
+}
+table th.gcode_files_action a.disabled,
+table td.gcode_files_action a.disabled {
+  color: #ccc;
+  cursor: default;
+}
+table th.timelapse_files_checkbox,
+table td.timelapse_files_checkbox,
+table th.timelapse_unrendered_checkbox,
+table td.timelapse_unrendered_checkbox {
+  text-align: center;
+  vertical-align: middle;
+  width: 10px;
+}
+table th.timelapse_files_checkbox input[type="checkbox"],
+table td.timelapse_files_checkbox input[type="checkbox"],
+table th.timelapse_unrendered_checkbox input[type="checkbox"],
+table td.timelapse_unrendered_checkbox input[type="checkbox"] {
+  margin-top: 0;
+}
+table th.timelapse_unrendered_name,
+table td.timelapse_unrendered_name {
+  text-overflow: ellipsis;
+  text-align: left;
+}
+table th.timelapse_files_details .name,
+table td.timelapse_files_details .name {
+  text-overflow: ellipsis;
+  text-align: left;
+  font-weight: 800;
+  margin: 0 0 0 0;
+}
+table th.timelapse_files_details .detail,
+table td.timelapse_files_details .detail {
+  text-overflow: ellipsis;
+  text-align: left;
+  margin: 0 0 0 0;
+  font-size: 85%;
+  color: #999;
+}
+table th.timelapse_files_thumb,
+table td.timelapse_files_thumb {
+  width: 170px;
+  position: relative;
+}
+table th.timelapse_files_thumb img,
+table td.timelapse_files_thumb img {
+  max-width: 100%;
+  max-height: 170px;
+  border-radius: 3px;
+}
+table th.timelapse_files_thumb div,
+table td.timelapse_files_thumb div {
+  width: 170px;
+  height: calc(170px * 9/16);
+  border-radius: 3px;
+  background-color: #e6e6e6;
+}
+table th.timelapse_files_thumb a,
+table td.timelapse_files_thumb a {
+  background-image: url(/static/img/play.svg);
+  background-size: 40px 40px;
+  background-position: center;
+  background-repeat: no-repeat;
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  content: '';
+}
+table th.timelapse_files_size,
+table td.timelapse_files_size {
+  text-align: right;
+  width: 55px;
+}
+table th.timelapse_unrendered_size,
+table td.timelapse_unrendered_size {
+  text-align: right;
+  width: 55px;
+}
+table th.timelapse_unrendered_count,
+table td.timelapse_unrendered_count {
+  text-align: right;
+  width: 45px;
+}
+table th.timelapse_files_action,
+table td.timelapse_files_action,
+table th.timelapse_unrendered_action,
+table td.timelapse_unrendered_action {
+  width: 60px;
+  position: relative;
+  text-align: center;
+  white-space: nowrap;
+}
+table th.timelapse_files_action a,
+table td.timelapse_files_action a,
+table th.timelapse_unrendered_action a,
+table td.timelapse_unrendered_action a {
+  text-decoration: none;
+  color: #000;
+}
+table th.timelapse_files_action a.disabled,
+table td.timelapse_files_action a.disabled,
+table th.timelapse_unrendered_action a.disabled,
+table td.timelapse_unrendered_action a.disabled {
+  color: #ccc;
+  cursor: default;
+}
+table th.timelapse_files_action .btn-group,
+table td.timelapse_files_action .btn-group,
+table th.timelapse_unrendered_action .btn-group,
+table td.timelapse_unrendered_action .btn-group {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+}
+table th.settings_users_name,
+table td.settings_users_name {
+  text-overflow: ellipsis;
+  text-align: left;
+  width: 100px;
+}
+table th.settings_users_active,
+table td.settings_users_active {
+  text-align: center;
+  width: 55px;
+}
+table th table.settings_users_details_table,
+table td table.settings_users_details_table {
+  font-size: 0.8em;
+  margin-bottom: 0;
+}
+table th table.settings_users_details_table .settings_users_details_key,
+table td table.settings_users_details_table .settings_users_details_key {
+  width: 100px;
+}
+table th table.settings_users_details_table th,
+table td table.settings_users_details_table th,
+table th table.settings_users_details_table td,
+table td table.settings_users_details_table td {
+  border: 0;
+  padding: 0;
+}
+table th.settings_groups_default,
+table td.settings_groups_default {
+  text-align: center;
+  width: 20px;
+}
+table th.settings_groups_name,
+table td.settings_groups_name {
+  width: 180px;
+}
+table th table.settings_groups_details_table,
+table td table.settings_groups_details_table {
+  font-size: 0.8em;
+  margin-bottom: 0;
+}
+table th table.settings_groups_details_table .settings_groups_details_key,
+table td table.settings_groups_details_table .settings_groups_details_key {
+  width: 100px;
+}
+table th table.settings_groups_details_table th,
+table td table.settings_groups_details_table th,
+table th table.settings_groups_details_table td,
+table td table.settings_groups_details_table td {
+  border: 0;
+  padding: 0;
+}
+table th.settings_users_actions,
+table td.settings_users_actions,
+table th.settings_groups_actions,
+table td.settings_groups_actions {
+  width: 60px;
+  text-align: center;
+  white-space: nowrap;
+}
+table th.settings_users_actions a,
+table td.settings_users_actions a,
+table th.settings_groups_actions a,
+table td.settings_groups_actions a {
+  text-decoration: none;
+  color: #000;
+}
+table th.settings_users_actions a.disabled,
+table td.settings_users_actions a.disabled,
+table th.settings_groups_actions a.disabled,
+table td.settings_groups_actions a.disabled {
+  color: #ccc;
+  cursor: default;
+}
+table th.settings_accesscontrol_permissions_list_checkbox,
+table td.settings_accesscontrol_permissions_list_checkbox {
+  width: 20px;
+}
+table th.settings_accesscontrol_groups_list_checkbox,
+table td.settings_accesscontrol_groups_list_checkbox {
+  width: 20px;
+}
+table th.settings_accesscontrol_subgroups_list_checkbox,
+table td.settings_accesscontrol_subgroups_list_checkbox {
+  width: 20px;
+}
+table th #settings-usersDialogAddUser,
+table td #settings-usersDialogAddUser,
+table th #settings-usersDialogEditUser,
+table td #settings-usersDialogEditUser {
+  position: relative;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-top: 0 !important;
+}
+table th.settings_printerProfiles_profiles_name,
+table td.settings_printerProfiles_profiles_name {
+  text-overflow: ellipsis;
+  text-align: left;
+}
+table th.settings_printerProfiles_profiles_model,
+table td.settings_printerProfiles_profiles_model {
+  text-align: left;
+  width: 250px;
+}
+table th.settings_printerProfiles_profiles_action,
+table td.settings_printerProfiles_profiles_action {
+  width: 80px;
+  text-align: center;
+  white-space: nowrap;
+}
+table th.settings_printerProfiles_profiles_action a,
+table td.settings_printerProfiles_profiles_action a {
+  text-decoration: none;
+  color: #000;
+}
+table th.settings_printerProfiles_profiles_action a.disabled,
+table td.settings_printerProfiles_profiles_action a.disabled {
+  color: #ccc;
+  cursor: default;
+}
+/** Temperature tab */
+#temperature-graph {
+  height: 350px;
+  width: 100%;
+  background: url("../img/graph-background.png") no-repeat center;
+}
+#temperature-table {
+  table-layout: fixed;
+  width: 100%;
+  margin-top: 20px;
+}
+#temperature-table th,
+#temperature-table td {
+  line-height: 25px;
+}
+#temperature-table th.temperature_tool,
+#temperature-table td.temperature_tool,
+#temperature-table th.temperature_actual,
+#temperature-table td.temperature_actual,
+#temperature-table th.temperature_target,
+#temperature-table td.temperature_target,
+#temperature-table th.temperature_offset,
+#temperature-table td.temperature_offset {
+  vertical-align: middle;
+  text-align: center;
+}
+#temperature-table th.temperature_tool form,
+#temperature-table td.temperature_tool form,
+#temperature-table th.temperature_actual form,
+#temperature-table td.temperature_actual form,
+#temperature-table th.temperature_target form,
+#temperature-table td.temperature_target form,
+#temperature-table th.temperature_offset form,
+#temperature-table td.temperature_offset form {
+  margin: 0;
+}
+#temperature-table th.temperature_tool .dropdown-menu,
+#temperature-table td.temperature_tool .dropdown-menu,
+#temperature-table th.temperature_actual .dropdown-menu,
+#temperature-table td.temperature_actual .dropdown-menu,
+#temperature-table th.temperature_target .dropdown-menu,
+#temperature-table td.temperature_target .dropdown-menu,
+#temperature-table th.temperature_offset .dropdown-menu,
+#temperature-table td.temperature_offset .dropdown-menu {
+  text-align: left;
+}
+#temperature-table th.temperature_tool,
+#temperature-table td.temperature_tool {
+  width: 16%;
+  text-align: left;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
+#temperature-table th.temperature_actual,
+#temperature-table td.temperature_actual {
+  width: 12%;
+}
+#temperature-table th.temperature_target,
+#temperature-table td.temperature_target {
+  width: 42%;
+  overflow: visible;
+}
+#temperature-table th.temperature_offset,
+#temperature-table td.temperature_offset {
+  width: 30%;
+}
+/** Various */
+.tab-content,
+.tab-pane {
+  overflow: visible;
+}
+#temp_newTemp,
+#temp_newBedTemp,
+#speed_innerWall,
+#speed_outerWall,
+#speed_fill,
+#speed_support,
+#webcam_timelapse_interval,
+#webcam_timelapse_postRoll,
+#webcam_timelapse_fps,
+#webcam_timelapse_retractionZHop {
+  text-align: right;
+}
+ul.dropdown-menu li a {
+  cursor: pointer;
+}
+/** Connection settings */
+#connection_ports,
+#connection_baudrates,
+#connection_printers {
+  width: 100%;
+}
+/** Offline & Reload overlay */
+#offline_overlay,
+#reloadui_overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  display: none;
+}
+#offline_overlay {
+  z-index: 10002;
+}
+#reloadui_overlay {
+  z-index: 10001;
+}
+#offline_overlay_background,
+#reloadui_overlay_background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000000;
+  filter: alpha(opacity=50);
+  -moz-opacity: 0.5;
+  -khtml-opacity: 0.5;
+  opacity: 0.5;
+}
+#offline_overlay_wrapper,
+#reloadui_overlay_wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-top: 60px;
+}
+#offline_overlay_wrapper .container,
+#reloadui_overlay_wrapper .container {
+  margin: auto;
+}
+/** Webcam */
+#webcam_container {
+  width: 100%;
+  position: relative;
+  outline: none;
+  background-color: black;
+}
+#webcam_container .keycontrol_overlay {
+  position: absolute;
+  left: 10px;
+  right: 10px;
+  bottom: 10px;
+  background: rgba(0, 0, 0, 0.5);
+  font-size: 85%;
+  color: white;
+  padding: 0;
+}
+#webcam_container .keycontrol_overlay kbd {
+  border: 1px solid #eeeeee;
+  border-radius: 3px;
+  margin-left: 2px;
+  margin-right: 2px;
+  font-size: 90%;
+  padding: 2px;
+  min-width: 1em;
+}
+#webcam_container .keycontrol_overlay .keycontrol_overlay_heading {
+  position: relative;
+  padding: 10px;
+  font-weight: bold;
+}
+#webcam_container .keycontrol_overlay .keycontrol_overlay_column {
+  position: relative;
+  width: 45%;
+  padding: 10px;
+  float: left;
+}
+#webcam_container .nowebcam {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+}
+#webcam_container .nowebcam .text {
+  color: white;
+  text-align: center;
+  position: relative;
+  margin: auto;
+  width: 80%;
+  top: 50%;
+  transform: translateY(-50%);
+  display: block;
+}
+#webcam_container .nowebcam .text.webcam_loading {
+  animation: pulsate 3s ease-out;
+  animation-iteration-count: infinite;
+}
+#webcam_container .webcam_rotated {
+  position: relative;
+  width: 100%;
+  padding-bottom: 100%;
+  pointer-events: none;
+}
+#webcam_container .webcam_rotated .webcam_fixed_ratio {
+  position: absolute;
+  transform: rotate(-90deg);
+  top: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+#webcam_container .webcam_rotated .webcam_fixed_ratio .webcam_fixed_ratio_inner {
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+#webcam_container .webcam_unrotated .webcam_fixed_ratio {
+  width: 100%;
+  pointer-events: none;
+  padding-bottom: 100%;
+  position: relative;
+}
+#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio43 {
+  padding-bottom: 75%;
+}
+#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio169 {
+  padding-bottom: 56.25%;
+}
+#webcam_container .webcam_unrotated .webcam_fixed_ratio.ratio1610 {
+  padding-bottom: 62.5%;
+}
+#webcam_container .webcam_unrotated .webcam_fixed_ratio .webcam_fixed_ratio_inner {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  pointer-events: none;
+}
+#webcam_container img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+#webcamTestContainer {
+  min-height: 384px;
+}
+/** State sidebar panel */
+#state_wrapper hr {
+  margin: 5px 0;
+}
+/** GCODE file manager */
+#files .gcode_files .scroll-wrapper {
+  overflow-x: hidden;
+  overflow-y: scroll;
+  height: 306px;
+  padding-right: 2px;
+}
+#files .gcode_files .entry {
+  padding: 5px;
+  line-height: 20px;
+  border-bottom: 1px solid #ddd;
+  position: relative;
+}
+#files .gcode_files .entry:hover {
+  background-color: #f5f5f5;
+}
+#files .gcode_files .entry .title {
+  text-overflow: ellipsis;
+  word-break: break-all;
+  margin-right: 30px;
+}
+#files .gcode_files .entry .internal,
+#files .gcode_files .entry .uploaded,
+#files .gcode_files .entry .size,
+#files .gcode_files .entry .additionalInfo {
+  font-size: 85%;
+  color: #999;
+}
+#files .gcode_files .entry .uploaded *[title] {
+  cursor: help;
+}
+#files .gcode_files .entry .internal {
+  word-break: break-all;
+}
+#files .gcode_files .entry .action-buttons {
+  position: absolute;
+  bottom: 5px;
+  right: 5px;
+}
+#files .gcode_files .entry .additionalInfo {
+  padding-bottom: 22px;
+}
+@keyframes highlightframes {
+  0% {
+    background: yellow;
+  }
+  100% {
+    background: transparent;
+  }
+}
+#files .gcode_files .entry.highlight {
+  animation: highlightframes 2s;
+}
+#files .gcode_files .back .back-path {
+  white-space: nowrap;
+}
+#files .gcode_files .back .back-path span {
+  word-wrap: break-word;
+  white-space: pre-line;
+}
+#files .upload-buttons {
+  margin-top: 10px;
+}
+#files .form-search {
+  text-align: center;
+  margin-bottom: 5px !important;
+}
+/** Control tab */
+#control .jog-panel {
+  float: left;
+  margin-right: 19px;
+}
+#control h1 {
+  text-align: left;
+}
+#control .jog-panel > div {
+  text-align: center;
+}
+#control .jog-panel > div.distance {
+  text-align: left;
+}
+#control .jog-panel .slider {
+  margin-bottom: 10px;
+}
+#control .box {
+  width: 30px;
+  height: 30px;
+  margin-right: 10px;
+  margin-bottom: 10px;
+  padding: 0;
+}
+#control .control-box {
+  display: block;
+  height: 30px;
+  margin-bottom: 10px;
+}
+#control .btn-group {
+  margin-bottom: 10px;
+}
+#control .btn-group.distance > .btn {
+  width: 43px;
+  padding: 3px 0;
+  height: 30px;
+}
+#control .slider-handle {
+  width: 14px;
+  height: 14px;
+  margin-left: -7px;
+  margin-top: -3px;
+}
+#control .custom_section h1 {
+  cursor: pointer;
+}
+#control .custom_section_horizontal > .custom_control {
+  display: inline-block;
+}
+#control .custom_section_vertical > .custom_control {
+  display: block;
+}
+#control .custom_control .slider {
+  margin-left: 10px;
+  margin-right: 10px;
+  margin-bottom: 2px;
+}
+#control .pulsate_text_opacity {
+  animation: pulsate_input 1s ease-out;
+  animation-iteration-count: infinite;
+}
+@keyframes pulsate_input {
+  0% {
+    color: #555;
+  }
+  50% {
+    color: rgba(85, 85, 85, 0.2);
+  }
+  100% {
+    color: #555;
+  }
+}
+/** Terminal output */
+#term .terminal {
+  margin-bottom: 30px;
+}
+#term .terminal #terminal-output,
+#term .terminal #terminal-output-lowfi {
+  min-height: 340px;
+  margin-bottom: 5px;
+}
+#settings_dialog .aboutlink,
+#settings_dialog .systeminfolink {
+  float: left;
+}
+#settings_dialog_menu,
+#wizard_dialog_menu {
+  margin-left: 0;
+}
+#wizard_firstrun_acl .acl_decision {
+  margin-top: 1em;
+}
+#wizard_firstrun_start p,
+#wizard_firstrun_end p {
+  margin-bottom: 1.5em;
+  line-height: 1.5;
+}
+#settings_appearance_managelanguagesdialog_list {
+  width: auto;
+  height: 300px;
+  overflow-x: hidden;
+  overflow-y: scroll;
+  padding-right: 2px;
+}
+#settings_appearance_managelanguagesdialog_emptylist {
+  overflow: hidden;
+  width: 100%;
+  height: 300px;
+  text-align: center;
+  display: table;
+}
+#settings_appearance_managelanguagesdialog_emptylist div {
+  display: table-cell;
+  vertical-align: middle;
+}
+#about_sponsors ul {
+  columns: 3;
+  -webkit-columns: 3;
+  -moz-columns: 3;
+}
+#about_authors ul {
+  columns: 3;
+  -webkit-columns: 3;
+  -moz-columns: 3;
+}
+/** Footer */
+.footer ul {
+  margin: 0;
+}
+.footer ul li {
+  display: inline;
+  margin-left: 1em;
+  font-size: 85%;
+}
+.footer ul li:first-child {
+  margin-left: 0;
+}
+.footer ul li a {
+  color: #555;
+}
+.footer #footer_version,
+.footer #footer_links {
+  max-width: 50%;
+}
+/** Notifications */
+.ui-pnotify {
+  position: fixed;
+}
+.ui-pnotify .alert a {
+  color: #c09853;
+}
+.ui-pnotify .alert-error a,
+.ui-pnotify .alert-danger a {
+  color: #b94a48;
+}
+.ui-pnotify .alert-success a {
+  color: #468847;
+}
+.ui-pnotify .alert-info a {
+  color: #3a87ad;
+}
+.pnotify_additional_info .pnotify_more {
+  font-size: 85%;
+}
+/** General helper classes */
+.text-right {
+  text-align: right;
+}
+.text-center {
+  text-align: center;
+}
+.text-block {
+  display: block;
+}
+.overflow_visible {
+  overflow: visible !important;
+}
+.clickable {
+  cursor: pointer;
+}
+.border_box {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+}
+.hidden {
+  display: none;
+}
+textarea.block {
+  -webkit-box-sizing: border-box;
+  -moz-box-sizing: border-box;
+  box-sizing: border-box;
+  width: 100%;
+}
+@keyframes pulsate {
+  0% {
+    opacity: 0.5;
+  }
+  50% {
+    opacity: 1;
+  }
+  100% {
+    opacity: 0.5;
+  }
+}
+#drop_overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 10000;
+  display: none;
+}
+#drop_overlay.in {
+  display: block;
+}
+#drop_overlay #drop_overlay_background {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #000000;
+  filter: alpha(opacity=50);
+  -moz-opacity: 0.5;
+  -khtml-opacity: 0.5;
+  opacity: 0.5;
+}
+#drop_overlay #drop_overlay_wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  padding-top: 60px;
+}
+#drop_overlay #drop_overlay_wrapper #drop,
+#drop_overlay #drop_overlay_wrapper #drop_background {
+  position: absolute;
+  top: 0;
+  left: 0;
+  margin-left: 0;
+  width: 100%;
+}
+#drop_overlay #drop_overlay_wrapper #drop_locally,
+#drop_overlay #drop_overlay_wrapper #drop_locally_background {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  margin-left: -50%;
+  width: 50%;
+  border-right: 2px dashed #cccccc;
+}
+#drop_overlay #drop_overlay_wrapper #drop_sd,
+#drop_overlay #drop_overlay_wrapper #drop_sd_background {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  margin-left: 0;
+  width: 50%;
+  border-left: 2px dashed #cccccc;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone {
+  height: 100%;
+  z-index: 10001;
+  color: #ffffff;
+  font-size: 30px;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone i {
+  font-size: 50px;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone .text {
+  display: block;
+  text-align: center;
+  line-height: 40px;
+  position: absolute;
+  width: 100%;
+  bottom: 5%;
+  filter: alpha(opacity=100);
+  -moz-opacity: 1;
+  -khtml-opacity: 1;
+  opacity: 1;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone_background {
+  width: 50%;
+  height: 100%;
+  background-color: #000000;
+  filter: alpha(opacity=25);
+  -moz-opacity: 0.25;
+  -khtml-opacity: 0.25;
+  opacity: 0.25;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone_background.hover {
+  background-color: #000000;
+  filter: alpha(opacity=50);
+  -moz-opacity: 0.5;
+  -khtml-opacity: 0.5;
+  opacity: 0.5;
+}
+#drop_overlay #drop_overlay_wrapper .dropzone_background.fade {
+  -webkit-transition: all 0.3s ease-out;
+  -moz-transition: all 0.3s ease-out;
+  -ms-transition: all 0.3s ease-out;
+  -o-transition: all 0.3s ease-out;
+  transition: all 0.3s ease-out;
+  opacity: 1;
+}
+.center {
+  float: none;
+  margin-left: auto;
+  margin-right: auto;
+}
+.flipH {
+  -webkit-transform: scaleX(-1);
+  -moz-transform: scaleX(-1);
+  -ms-transform: scaleX(-1);
+  transform: scaleX(-1);
+}
+.flipV {
+  -webkit-transform: scaleY(-1);
+  -moz-transform: scaleY(-1);
+  -ms-transform: scaleY(-1);
+  transform: scaleY(-1);
+}
+.flipH.flipV {
+  -webkit-transform: scaleX(-1) scaleY(-1);
+  -moz-transform: scaleX(-1) scaleY(-1);
+  -ms-transform: scaleX(-1) scaleY(-1);
+  transform: scaleX(-1) scaleY(-1);
+}
+.rotate90 {
+  -webkit-transform: rotate(-90deg);
+  transform: rotate(-90deg);
+}
+.ui-pnotify a {
+  text-decoration: underline;
+}
+.btn-mini .caret,
+.btn-small .caret {
+  margin-top: 8px;
+}
+.dropdown-menu-right {
+  right: 0;
+  left: auto;
+}
+/** Styles for Bootstrap Slider */
+.slider .slider-selection {
+  color: #fff;
+  text-shadow: 0 -1px 0 rgba(0, 0, 0, 0.25);
+  background-color: #006dcc;
+  background-image: -moz-linear-gradient(top, #08c, #0044cc);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#08c), to(#0044cc));
+  background-image: -webkit-linear-gradient(top, #08c, #0044cc);
+  background-image: -o-linear-gradient(top, #08c, #0044cc);
+  background-image: linear-gradient(to bottom, #08c, #0044cc);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ff0088cc', endColorstr='#ff0044cc', GradientType=0);
+  border-color: #0044cc #0044cc #002a80;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #0044cc;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+}
+.slider .slider-selection:hover,
+.slider .slider-selection:focus,
+.slider .slider-selection:active,
+.slider .slider-selection.active,
+.slider .slider-selection.disabled,
+.slider .slider-selection[disabled] {
+  color: #fff;
+  background-color: #0044cc;
+  *background-color: #003bb3;
+}
+.slider .slider-selection:active,
+.slider .slider-selection.active {
+  background-color: #003399 \9;
+}
+.slider.slider-disabled .slider-selection {
+  background-image: none;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.slider .slider-track {
+  background-color: #f5f5f5;
+  border: 1px solid #e3e3e3;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  -moz-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+}
+.slider.slider-disabled .slider-track {
+  background-image: none;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.slider .slider-handle {
+  display: inline-block;
+  *display: inline;
+  /* IE7 inline-block hack */
+  *zoom: 1;
+  padding: 4px 12px;
+  font-size: 14px;
+  line-height: 20px;
+  text-align: center;
+  vertical-align: middle;
+  cursor: pointer;
+  color: #333;
+  text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+  background-color: #f5f5f5;
+  background-image: -moz-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -webkit-gradient(linear, 0 0, 0 100%, from(#fff), to(#e6e6e6));
+  background-image: -webkit-linear-gradient(top, #fff, #e6e6e6);
+  background-image: -o-linear-gradient(top, #fff, #e6e6e6);
+  background-image: linear-gradient(to bottom, #fff, #e6e6e6);
+  background-repeat: repeat-x;
+  filter: progid:DXImageTransform.Microsoft.gradient(startColorstr='#ffffffff', endColorstr='#ffe6e6e6', GradientType=0);
+  border-color: #e6e6e6 #e6e6e6 #bfbfbf;
+  border-color: rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.1) rgba(0, 0, 0, 0.25);
+  *background-color: #e6e6e6;
+  /* Darken IE7 buttons by default so they stand out more given they won't have borders */
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  border: 1px solid #ccc;
+  *border: 0;
+  border-bottom-color: #b3b3b3;
+  -webkit-border-radius: 4px;
+  -moz-border-radius: 4px;
+  border-radius: 4px;
+  *margin-left: 0.3em;
+  -webkit-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+  -moz-box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+  box-shadow: inset 0 1px 0 rgba(255,255,255,.2), 0 1px 2px rgba(0,0,0,.05);
+  padding: 0;
+  margin-bottom: 0;
+  opacity: 1;
+  filter: alpha(opacity=100);
+}
+.slider .slider-handle:hover,
+.slider .slider-handle:focus,
+.slider .slider-handle:active,
+.slider .slider-handle.active,
+.slider .slider-handle.disabled,
+.slider .slider-handle[disabled] {
+  color: #333;
+  background-color: #e6e6e6;
+  *background-color: #d9d9d9;
+}
+.slider .slider-handle:active,
+.slider .slider-handle.active {
+  background-color: #cccccc \9;
+}
+.slider .slider-handle:first-child {
+  *margin-left: 0;
+}
+.slider .slider-handle:hover,
+.slider .slider-handle:focus {
+  color: #333;
+  text-decoration: none;
+  background-position: 0 -15px;
+  -webkit-transition: background-position 0.1s linear;
+  -moz-transition: background-position 0.1s linear;
+  -o-transition: background-position 0.1s linear;
+  transition: background-position 0.1s linear;
+}
+.slider .slider-handle:focus {
+  outline: thin dotted #333;
+  outline: 5px auto -webkit-focus-ring-color;
+  outline-offset: -2px;
+}
+.slider .slider-handle.active,
+.slider .slider-handle:active {
+  background-image: none;
+  outline: 0;
+  -webkit-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+  -moz-box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+  box-shadow: inset 0 2px 4px rgba(0,0,0,.15), 0 1px 2px rgba(0,0,0,.05);
+}
+.slider .slider-handle.disabled,
+.slider .slider-handle[disabled] {
+  cursor: default;
+  background-image: none;
+  opacity: 0.65;
+  filter: alpha(opacity=65);
+  -webkit-box-shadow: none;
+  -moz-box-shadow: none;
+  box-shadow: none;
+}
+.slider .slider-handle.hide {
+  display: none;
+}
+.slider .slider-handle.round {
+  -webkit-border-radius: 50%;
+  -moz-border-radius: 50%;
+  border-radius: 50%;
+}
+.modal.large {
+  width: 975px;
+  margin-left: -487px;
+}
+.full-sized-box {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  top: 0;
+  padding: 15px;
+}
+.full-sized-box .row-fluid {
+  height: 100%;
+}
+@media (max-width: 979px) {
+  .full-sized-box {
+    position: static;
+  }
+}
+_::-webkit-full-page-media,
+_:future,
+:root .full-sized-box {
+  position: static;
+}
+.safari ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.safari ::-webkit-scrollbar-track {
+  border-radius: 10px;
+  -webkit-border-radius: 10px;
+}
+.safari ::-webkit-scrollbar-thumb {
+  -webkit-border-radius: 10px;
+  border-radius: 10px;
+  background: rgba(100, 100, 100, 0.8);
+}
+.scrollable {
+  height: 100%;
+  overflow: auto;
+  -webkit-overflow-scrolling: touch;
+}
+.pre-output span {
+  display: block;
+}
+.input-append .add-on.add-on-limited,
+.input-prepend .add-on.add-on-limited {
+  overflow-x: hidden;
+  text-overflow: ellipsis;
+  width: inherit;
+}
+.input-append .btn-group:first-child .btn:first-child,
+.input-prepend .btn-group:first-child .btn:first-child {
+  -webkit-border-radius: 4px 0 0 4px;
+  -moz-border-radius: 4px 0 0 4px;
+  border-radius: 4px 0 0 4px;
+}
+.input-append .btn-group .btn:first-child,
+.input-prepend .btn-group .btn:first-child {
+  -webkit-border-radius: 0;
+  -moz-border-radius: 0;
+  border-radius: 0;
+}
+.input-append.input-block-level,
+.input-prepend.input-block-level {
+  display: table;
+}
+.input-append.input-block-level .add-on,
+.input-prepend.input-block-level .add-on {
+  display: table-cell;
+  width: 1%;
+  /* remove this if you want default bootstrap button width */
+}
+.input-append.input-block-level > input,
+.input-prepend.input-block-level > input {
+  box-sizing: border-box;
+  /* use bootstrap mixin or include vendor variants */
+  display: table;
+  /* table-cell is not working well in Chrome for small widths */
+  min-height: inherit;
+  width: 100%;
+}
+.input-append.input-block-level :not(:last-child),
+.input-prepend.input-block-level :not(:last-child) {
+  border-right: 0;
+}
+.control-group.error .input-prepend .fileinput-button,
+.control-group.error .input-append .fileinput-button {
+  border-color: #b94a48;
+}
+.control-text {
+  padding-top: 5px;
+  cursor: default;
+}
+input[type="number"] {
+  text-align: right;
+}
+input[type="number"].input-nospin::-webkit-outer-spin-button,
+input[type="number"].input-nospin::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+input[type="number"].input-nospin {
+  -moz-appearance: textfield;
+}
+.dropdown-menu li a.disabled,
+.dropdown-menu li a.disabled:visited,
+.dropdown-menu li a.disabled:active,
+.dropdown-menu li a.disabled:hover {
+  background-color: transparent;
+  background-image: none;
+  color: #aaa;
+  cursor: default;
+}
+textarea.monospace {
+  font-family: monospace;
+}
+.progress-text-centered {
+  position: relative;
+}
+.progress-text-centered .bar {
+  z-index: 1;
+  position: absolute;
+  overflow: hidden;
+}
+.progress-text-centered .progress-text-front,
+.progress-text-centered .progress-text-back {
+  position: absolute;
+  top: 0;
+  z-index: 2;
+  text-align: center;
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0 10px;
+  font-size: 12px;
+  line-height: 20px;
+}
+.progress-text-centered .progress-text-front {
+  color: #fff;
+}
+.search-query-with-clear {
+  position: relative;
+}
+.search-query-with-clear .search-clear {
+  display: inline-block;
+  color: #ccc;
+  position: absolute;
+  right: 28px;
+  height: 20px;
+  padding: 4px 0;
+  cursor: pointer;
+  visibility: hidden;
+}
+.search-query-with-clear.active-clear .search-query {
+  padding-right: 28px;
+  width: 192px;
+}
+.search-query-with-clear.active-clear .search-clear {
+  visibility: visible;
+}
+.search-query-with-clear input::-ms-clear {
+  display: none;
+}
+.search-query-with-clear input[type="search"]::-webkit-search-decoration,
+.search-query-with-clear input[type="search"]::-webkit-search-cancel-button,
+.search-query-with-clear input[type="search"]::-webkit-search-results-button,
+.search-query-with-clear input[type="search"]::-webkit-search-results-decoration {
+  -webkit-appearance: none;
+}
+#navbar_login:not(.open) #login_dropdown_loggedout {
+  display: block;
+  z-index: -1;
+  height: 0;
+  width: 0;
+  padding: 0 !important;
+  overflow: hidden;
+  border: 0;
+  box-shadow: none;
+  left: -9999px;
+}
+#navbar_login:not(.open) #login_dropdown_loggedout.hide {
+  display: none;
+}
+#loginForm {
+  margin: 0;
+}
+#loginForm button {
+  margin-top: 20px;
+}
+#page-container-loading {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #ffffff;
+  z-index: 12301;
+}
+#page-container-loading .wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+#page-container-loading .wrapper .outer {
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+#page-container-loading .wrapper .outer .inner {
+  display: table-cell;
+  vertical-align: middle;
+}
+#page-container-loading .wrapper .outer .inner .content {
+  text-align: center;
+}
+#page-container-noscript {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background-color: #ffffff;
+  z-index: 12310;
+}
+#page-container-noscript .wrapper {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 0;
+  right: 0;
+}
+#page-container-noscript .wrapper .outer {
+  display: table;
+  width: 100%;
+  height: 100%;
+}
+#page-container-noscript .wrapper .outer .inner {
+  display: table-cell;
+  vertical-align: middle;
+}
+#page-container-noscript .wrapper .outer .inner .content {
+  text-align: center;
+}
+/* Custom animations for the dialogs
+ * These animations override the default bootstrap 2 slow Javascript based animations.
+ * Usage: Add the class `fade-in` to any modal instead of the `fade` class
+ */
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+@keyframes backgroundFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 0.7;
+  }
+}
+.fade-in {
+  animation-name: fadeIn;
+  animation-duration: 0.3s;
+}
+.modal-backdrop:not(.fade) {
+  animation-name: backgroundFadeIn;
+  animation-duration: 0.3s;
+}

--- a/src/octoprint/static/css/octoprint.css
+++ b/src/octoprint/static/css/octoprint.css
@@ -1645,22 +1645,26 @@ table td.timelapse_files_thumb img {
 table th.timelapse_files_thumb div,
 table td.timelapse_files_thumb div {
   width: 170px;
-  height: calc(170px * 9/16);
+  height: calc(170px * 9 / 16);
   border-radius: 3px;
-  background-color: #e6e6e6;
+  background-color: #eeeeee;
 }
 table th.timelapse_files_thumb a,
 table td.timelapse_files_thumb a {
   background-image: url(/static/img/play.svg);
-  background-size: 40px 40px;
   background-position: center;
   background-repeat: no-repeat;
   width: 100%;
   height: 100%;
+  opacity: 0.8;
   position: absolute;
   top: 0;
   left: 0;
-  content: '';
+  content: "";
+}
+table th.timelapse_files_thumb a:hover,
+table td.timelapse_files_thumb a:hover {
+  opacity: 1;
 }
 table th.timelapse_files_size,
 table td.timelapse_files_size {

--- a/src/octoprint/static/css/octoprint.css
+++ b/src/octoprint/static/css/octoprint.css
@@ -1633,19 +1633,19 @@ table td.timelapse_files_details .detail {
 }
 table th.timelapse_files_thumb,
 table td.timelapse_files_thumb {
-  width: 170px;
+  width: 110px;
   position: relative;
 }
 table th.timelapse_files_thumb img,
 table td.timelapse_files_thumb img {
   max-width: 100%;
-  max-height: 170px;
+  max-height: 110px;
   border-radius: 3px;
 }
 table th.timelapse_files_thumb div,
 table td.timelapse_files_thumb div {
-  width: 170px;
-  height: calc(170px * 9 / 16);
+  width: 110px;
+  height: calc(110px * 9 / 16);
   border-radius: 3px;
   background-color: #eeeeee;
 }
@@ -1654,6 +1654,7 @@ table td.timelapse_files_thumb a {
   background-image: url(/static/img/play.svg);
   background-position: center;
   background-repeat: no-repeat;
+  background-size: 32px 32px;
   width: 100%;
   height: 100%;
   opacity: 0.8;

--- a/src/octoprint/static/img/play.svg
+++ b/src/octoprint/static/img/play.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="32" cy="32" r="32" fill="#C4C4C4" fill-opacity="0.6"/>
+<path d="M50 33.5L23.75 48.6554L23.75 18.3446L50 33.5Z" fill="white" fill-opacity="0.9"/>
+</svg>

--- a/src/octoprint/static/img/play.svg
+++ b/src/octoprint/static/img/play.svg
@@ -1,4 +1,5 @@
-<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
-<circle cx="32" cy="32" r="32" fill="#C4C4C4" fill-opacity="0.6"/>
-<path d="M50 33.5L23.75 48.6554L23.75 18.3446L50 33.5Z" fill="white" fill-opacity="0.9"/>
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<circle cx="20" cy="20" r="20" fill="#A8A8A8" fill-opacity="0.6"/>
+<circle cx="20" cy="20" r="19.75" stroke="#A8A8A8" stroke-opacity="0.6" stroke-width="0.5"/>
+<path d="M31.25 20.9375L14.8437 30.4097L14.8437 11.4653L31.25 20.9375Z" fill="white"/>
 </svg>

--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -318,6 +318,7 @@ table {
     &.timelapse_files_checkbox,
     &.timelapse_unrendered_checkbox {
       text-align: center;
+      vertical-align: middle;
       width: 10px;
 
       input[type="checkbox"] {
@@ -325,10 +326,58 @@ table {
       }
     }
 
-    &.timelapse_files_name,
     &.timelapse_unrendered_name {
       text-overflow: ellipsis;
       text-align: left;
+    }
+
+    &.timelapse_files_details {
+      .name {
+        text-overflow: ellipsis;
+        text-align: left;
+        font-weight: 800;
+        margin: 0 0 0 0;
+      }
+      .detail {
+        text-overflow: ellipsis;
+        text-align: left;
+        margin: 0 0 0 0;
+        font-size: 85%;
+        color: #999;
+      }
+    }
+
+    &.timelapse_files_thumb {
+      @thumb-size: 170px;
+      @thumb-coner: 3px;
+      width: @thumb-size;
+      position: relative;
+
+      img {
+        max-width: 100%;
+        max-height: @thumb-size;
+        border-radius: @thumb-coner;
+      }
+
+      div {
+        width: @thumb-size;
+        height: calc(@thumb-size * 9 / 16);
+        border-radius: @thumb-coner;
+        background-color: rgb(230, 230, 230);
+      }
+
+      a {
+        background-image: url(/static/img/play.svg);
+        background-size: 40px 40px;
+        background-position: center;
+        background-repeat: no-repeat;
+        width: 100%;
+        height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        content: "";
+      }
     }
 
     &.timelapse_files_size {
@@ -349,7 +398,14 @@ table {
     &.timelapse_files_action,
     &.timelapse_unrendered_action {
       width: 60px;
+      position: relative;
+
       .actioncol;
+      .btn-group {
+        position: absolute;
+        bottom: 5px;
+        right: 5px;
+      }
     }
 
     // user settings

--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -348,7 +348,7 @@ table {
     }
 
     &.timelapse_files_thumb {
-      @thumb-size: 170px;
+      @thumb-size: 110px;
       @thumb-coner: 3px;
       width: @thumb-size;
       position: relative;
@@ -370,6 +370,7 @@ table {
         background-image: url(/static/img/play.svg);
         background-position: center;
         background-repeat: no-repeat;
+        background-size: 32px 32px;
         width: 100%;
         height: 100%;
         opacity: 0.8;

--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -363,20 +363,24 @@ table {
         width: @thumb-size;
         height: calc(@thumb-size * 9 / 16);
         border-radius: @thumb-coner;
-        background-color: rgb(230, 230, 230);
+        background-color: rgb(238, 238, 238);
       }
 
       a {
         background-image: url(/static/img/play.svg);
-        background-size: 40px 40px;
         background-position: center;
         background-repeat: no-repeat;
         width: 100%;
         height: 100%;
+        opacity: 0.8;
         position: absolute;
         top: 0;
         left: 0;
         content: "";
+
+        &:hover {
+          opacity: 1;
+        }
       }
     }
 

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -133,7 +133,7 @@
     <button class="btn btn-small" data-bind="click: removeMarkedFiles, enable: markedForFileDeletion().length > 0">{{ _('Delete selected') }}</button>
     <a class="btn btn-small" data-bind="css: { disabled: !enableBulkDownload() }, attr: { href: bulkDownloadButtonUrl }">{{_('Download selected')}}</a>
 </div>
-<table class="table table-striped table-hover table-condensed table-hover" id="timelapse_files">
+<table class="table table-hover table-condensed table-hover" id="timelapse_files">
     <thead>
     <tr>
         <th class="timelapse_files_checkbox"></th>

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -156,7 +156,7 @@
         </td>
         <td class="timelapse_files_details">
             <p class="name" data-bind="text: name"></p>
-            <p class="detail">{{ _('Recorded:') }} <span data-bind="text: date"/></p>
+            <p class="detail">{{ _('Recorded:') }} <span data-bind="text: formatTimeAgo(timestamp)"/></p>
             <p class="detail">{{ _('Size:') }} <span data-bind="text: size"/></p>
         </td>
         <td class="timelapse_files_action">

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -137,17 +137,34 @@
     <thead>
     <tr>
         <th class="timelapse_files_checkbox"></th>
-        <th class="timelapse_files_name">{{ _('Name') }}</th>
-        <th class="timelapse_files_size">{{ _('Size') }}</th>
+        <th class="timelapse_files_thumb">{{ _('Preview') }}</th>
+        <th class="timelapse_files_details">{{ _('Details') }}</th>
         <th class="timelapse_files_action">{{ _('Action') }}</th>
     </tr>
     </thead>
     <tbody data-bind="foreach: listHelper.paginatedItems">
     <tr data-bind="attr: {title: name}">
         <td class="timelapse_files_checkbox"><input type="checkbox" data-bind="value: name, checked: $root.markedForFileDeletion, invisible: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_DELETE)()"></td>
-        <td class="timelapse_files_name" data-bind="text: name"></td>
-        <td class="timelapse_files_size" data-bind="text: size"></td>
-        <td class="timelapse_files_action"><a href="javascript:void(0)" class="far fa-trash-alt" data-bind="click: function() { $parent.removeFile($data.name); }, css: {disabled: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_DELETE)() }"></a>&nbsp;|&nbsp;<a href="javascript:void(0)" class="fas fa-download" data-bind="css: {disabled: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_DOWNLOAD)()}, attr: { href: ($root.loginState.hasPermission($root.access.permissions.TIMELAPSE_DOWNLOAD)) ? $data.url : 'javascript:void(0)' }"></a>&nbsp;|&nbsp;<a href="javascript:void(0)" class="fas fa-camera" data-bind="css: {disabled: !$root.isTimelapseViewable($data)}, click: $root.showTimelapsePreview"></a></td>
+        <td class="timelapse_files_thumb">
+            <!-- ko if: $data.thumbnail -->
+            <img data-bind="attr:{src: thumbnail}" loading="lazy" />
+            <!-- /ko -->
+            <!-- ko ifnot: $data.thumbnail -->
+            <div></div>
+            <!-- /ko -->
+            <a href="javascript:void(0)" data-bind="css: {disabled: !$root.isTimelapseViewable($data)}, click: $root.showTimelapsePreview"></a>
+        </td>
+        <td class="timelapse_files_details">
+            <p class="name" data-bind="text: name"></p>
+            <p class="detail">{{ _('Recorded:') }} <span data-bind="text: date"/></p>
+            <p class="detail">{{ _('Size:') }} <span data-bind="text: size"/></p>
+        </td>
+        <td class="timelapse_files_action">
+            <div class="btn-group action-buttons">
+                <div href="javascript:void(0)" class="btn btn-mini" data-bind="click: function() { $parent.removeFile($data.name); }, css: {disabled: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_DELETE)() }"><i class="far fa-trash-alt"></i></div>
+                <a href="javascript:void(0)" class="btn btn-mini" data-bind="css: {disabled: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_DOWNLOAD)()}, attr: { href: ($root.loginState.hasPermission($root.access.permissions.TIMELAPSE_DOWNLOAD)) ? $data.url : 'javascript:void(0)' }"><i class="fas fa-download"></i></a>
+            </div>
+        </td>
     </tr>
     </tbody>
 </table>

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -146,10 +146,10 @@ def get_finished_timelapses():
             continue
 
         thumb = _thumbnail_format.format(entry.path)
-        if os.path.isfile(thumb) is not True:
-            thumb = None
-        else:
+        if os.path.isfile(thumb) is True:
             thumb = os.path.basename(thumb)
+        else:
+            thumb = None
 
         files.append(
             {

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -1033,8 +1033,7 @@ class TimelapseRenderJob(object):
             extension=extension,
         )
         temporary = os.path.join(self._output_dir, ".{}".format(output_name))
-        movie_output = os.path.join(self._output_dir, output_name)
-        thumb_output = create_thumbnail_path(movie_output)
+        output = os.path.join(self._output_dir, output_name)
 
         for i in range(4):
             if os.path.exists(input % i):
@@ -1042,12 +1041,7 @@ class TimelapseRenderJob(object):
         else:
             self._logger.warning("Cannot create a movie, no frames captured")
             self._notify_callback(
-                "fail",
-                movie_output,
-                returncode=0,
-                stdout="",
-                stderr="",
-                reason="no_frames",
+                "fail", output, returncode=0, stdout="", stderr="", reason="no_frames"
             )
             return
 
@@ -1066,7 +1060,7 @@ class TimelapseRenderJob(object):
                 watermark = watermark.replace("\\", "/").replace(":", "\\\\:")
 
         # prepare ffmpeg command
-        movie_command_str = self._create_ffmpeg_command_string(
+        command_str = self._create_ffmpeg_command_string(
             commandline,
             ffmpeg,
             self._fps,
@@ -1080,30 +1074,29 @@ class TimelapseRenderJob(object):
             rotate=rotate,
             watermark=watermark,
         )
-        self._logger.debug("Executing command: {}".format(movie_command_str))
+        self._logger.debug("Executing command: {}".format(command_str))
 
         with self.render_job_lock:
             try:
-                self._notify_callback("start", movie_output)
+                self._notify_callback("start", output)
 
                 self._logger.debug("Parsing ffmpeg output")
 
                 c = CommandlineCaller()
                 c.on_log_stderr = self._process_ffmpeg_output
                 returncode, stdout_text, stderr_text = c.call(
-                    movie_command_str, delimiter=b"\r", buffer_size=512
+                    command_str, delimiter=b"\r", buffer_size=512
                 )
 
                 self._logger.debug("Done with parsing")
 
                 if returncode == 0:
-                    shutil.move(temporary, movie_output)
+                    shutil.move(temporary, output)
                     self._try_generate_thumbnail(
                         ffmpeg=ffmpeg,
-                        movie_path=movie_output,
-                        thumb_path=thumb_output,
+                        movie_path=output,
                     )
-                    self._notify_callback("success", movie_output)
+                    self._notify_callback("success", output)
                 else:
                     self._logger.warning(
                         "Could not render movie, got return code %r: %s"
@@ -1111,7 +1104,7 @@ class TimelapseRenderJob(object):
                     )
                     self._notify_callback(
                         "fail",
-                        movie_output,
+                        output,
                         returncode=returncode,
                         stdout=stdout_text,
                         stderr=stderr_text,
@@ -1119,7 +1112,7 @@ class TimelapseRenderJob(object):
                     )
             except Exception:
                 self._logger.exception("Could not render movie due to unknown error")
-                self._notify_callback("fail", movie_output, reason="unknown")
+                self._notify_callback("fail", output, reason="unknown")
             finally:
                 try:
                     if os.path.exists(temporary):
@@ -1128,7 +1121,7 @@ class TimelapseRenderJob(object):
                     self._logger.warning(
                         "Could not delete temporary timelapse {}".format(temporary)
                     )
-                self._notify_callback("always", movie_output)
+                self._notify_callback("always", output)
 
     def _process_ffmpeg_output(self, *lines):
         for line in lines:
@@ -1150,8 +1143,9 @@ class TimelapseRenderJob(object):
                 if duration is not None:
                     self._parsed_duration = self._convert_time(*duration.groups())
 
-    def _try_generate_thumbnail(self, ffmpeg, movie_path, thumb_path):
+    def _try_generate_thumbnail(self, ffmpeg, movie_path):
         try:
+            thumb_path = create_thumbnail_path(movie_path)
             commandline = settings().get(["webcam", "ffmpegThumbnailCommandline"])
             thumb_command_str = self._create_ffmpeg_command_string(
                 commandline=commandline,
@@ -1172,10 +1166,10 @@ class TimelapseRenderJob(object):
                     "Failed to generate optional thumbnail %r: %s"
                     % (returncode, stderr_text)
                 )
-        except Exception:
+        except Exception as ex:
             self._logger.warning(
-                "Failed to generate thumbnail from {} to {}".format(
-                    movie_path, thumb_path
+                "Failed to generate thumbnail from {} to {} ({})".format(
+                    movie_path, thumb_path, ex
                 )
             )
 

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -80,6 +80,10 @@ _job_lock = threading.RLock()
 _extensions = None
 
 
+def create_thumbnail_path(movie_path):
+    return _thumbnail_format.format(movie_path)
+
+
 def valid_timelapse(path):
     global _extensions
 
@@ -145,7 +149,7 @@ def get_finished_timelapses():
         if util.is_hidden_path(entry.path) or not valid_timelapse(entry.path):
             continue
 
-        thumb = _thumbnail_format.format(entry.path)
+        thumb = create_thumbnail_path(entry.path)
         if os.path.isfile(thumb) is True:
             thumb = os.path.basename(thumb)
         else:
@@ -1030,7 +1034,7 @@ class TimelapseRenderJob(object):
         )
         temporary = os.path.join(self._output_dir, ".{}".format(output_name))
         movie_output = os.path.join(self._output_dir, output_name)
-        thumb_output = _thumbnail_format.format(movie_output)
+        thumb_output = create_thumbnail_path(movie_output)
 
         for i in range(4):
             if os.path.exists(input % i):

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -161,6 +161,7 @@ def get_finished_timelapses():
                 "size": util.get_formatted_size(entry.stat().st_size),
                 "bytes": entry.stat().st_size,
                 "thumbnail": thumb,
+                "timestamp": entry.stat().st_mtime,
                 "date": util.get_formatted_datetime(
                     datetime.datetime.fromtimestamp(entry.stat().st_mtime)
                 ),


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds an additional step when rendering a timelapse to also generate a thumbnail from the last frame of the timelapse. This is handy to see the final state of the print, making it easy to identify a timelapse. Thumbnails are completely optional, e.g. if we fail to generate a thumbnail we do not fail the overall render process. Generally thumbnails are optional to maintain backwards compatibility with previously rendered timelapses as well as old clients.

The thumbnails piggy back the existing storage and download mechanic for timlapses. They are stored in the same folder and share the same filename as the timlapse with the `.thumb.jpg` suffix. This means the same access permissions apply and they share the same E-Tag validation for caching.

The timlapse model now contains an additional (optional) field `thumbnail` with a download URL in the same scheme as the actual timelapse file.

In the UI the timelapse tab was modified to show the thumbnails. The design on the list was updated to more closely align with e.g. the file list. This means the actions are now mini buttons. The "preview" button was removed and the user can now click the thumbnail to open the player, this is indicated by a "play" symbol overlaying the thumbnail. A second new field `timestamp` was added to the model in order to include the date of the file as timestamp. This is used to show the recording date in the UI in the same style as for file upload times.

#### How was it tested? How can it be tested by the reviewer?
This was tested on a macOS and OctoPi host. The UI changes are tested on Safari and Chrome.

#### Any background context you want to provide?
/

#### What are the relevant tickets if any?
/

#### Screenshots (if appropriate)
<img width="1473" alt="Screenshot 2022-01-16 at 15 16 53" src="https://user-images.githubusercontent.com/5859228/149663746-34170843-9c93-47a2-9371-cce52883eda0.png">

#### Further notes
The images in the UI use the native lazy loading mechanic of the browser. This is not yet supported by Safari (but available in technology preview and confirmed working as intended), which means the images of the first page of the thumbnail list load with the page. As the images come with an E-Tag, subsequent page loads will not load the images again as OctoPrint returns 304. My hope is that the lazy loading mechanic will be part of the next major version of Safari as it's already working fine in TP.

I did not update the documentation yet as this would cause potential conflicts with my other PR. My plan is to merge #4349 first and then update this PR with the documentation. My idea was to keep the two PRs separate as they have different scopes and goals and I expect this PR to be "harder" to merge than the other one :)