### PR TITLE
Record last_fan_speed

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -432,6 +432,21 @@ class TemperatureRecord(object):
         else:
             return actual, target
 
+class FanspeedRecord(object):
+    def __init__(self):
+        self._fanspeed = None
+
+    def copy_from(self, other):
+        self._fanspeed = other.fanspeed
+
+    def set_speed(self, speed):
+        self._fanspeed = speed
+    
+    @property
+    def fanspeed(self):
+        return self._fanspeed
+
+
 
 class MachineCom(object):
     STATE_NONE = 0
@@ -762,6 +777,10 @@ class MachineCom(object):
         self.last_position = PositionRecord()
         self.pause_position = PositionRecord()
         self.cancel_position = PositionRecord()
+
+        self.last_fanspeed = FanspeedRecord()
+        self.pause_fanspeed = FanspeedRecord()
+        self.cancel_fanspeed = FanspeedRecord()
 
         self._record_pause_data = False
         self._record_cancel_data = False
@@ -1294,6 +1313,7 @@ class MachineCom(object):
                 "printer_profile": self._printerProfileManager.get_current_or_default(),
                 "last_position": self.last_position,
                 "last_temperature": self.last_temperature.as_script_dict(),
+                "last_fanspeed": self.last_fanspeed,
             }
         )
 
@@ -1302,6 +1322,7 @@ class MachineCom(object):
                 {
                     "pause_position": self.pause_position,
                     "pause_temperature": self.pause_temperature.as_script_dict(),
+                    "pause_fanspeed": self.pause_fanspeed,
                 }
             )
         elif scriptName == "afterPrintCancelled":
@@ -1309,6 +1330,7 @@ class MachineCom(object):
                 {
                     "cancel_position": self.cancel_position,
                     "cancel_temperature": self.cancel_temperature.as_script_dict(),
+                    "cancel_fanspeed": self.cancel_fanspeed,
                 }
             )
 
@@ -2573,6 +2595,7 @@ class MachineCom(object):
                             self._record_pause_data = False
                             self.pause_position.copy_from(self.last_position)
                             self.pause_temperature.copy_from(self.last_temperature)
+                            self.pause_fanspeed.copy_from(self.last_fanspeed)
                             self._pause_preparation_done()
 
                         if self._record_cancel_data:
@@ -2580,6 +2603,7 @@ class MachineCom(object):
                             self._record_cancel_data = False
                             self.cancel_position.copy_from(self.last_position)
                             self.cancel_temperature.copy_from(self.last_temperature)
+                            self.cancel_fanspeed.copy_from(self.last_fanspeed)
                             self._cancel_preparation_done()
 
                         self._callback.on_comm_position_update(


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds pause_fan_speed variable, like the temperature and position, so that we can pause and resume the fan.

#### What are the relevant tickets if any?
This PR was done in response to [#4040](https://github.com/OctoPrint/OctoPrint/issues/4040#issue-823483281)

#### Further notes
I would appreciate any feedback since it's my first contribution to an open source project!

**List of Tasks** taken from 
https://github.com/OctoPrint/OctoPrint/issues/4040#issuecomment-937778779

- [x] Added `self.last_fanspeed`, `self.pause_fanspeed`, `self.cancel_fanspeed` to `MachineCom` object
- [x] Injected into https://github.com/OctoPrint/OctoPrint/blob/34c46f6a1b5f731934807f9e2944ea5b0c1bfd3c/src/octoprint/util/comm.py#L1287-L1313
like temperature and position
- [x] Record on pause/cancel in https://github.com/OctoPrint/OctoPrint/blob/34c46f6a1b5f731934807f9e2944ea5b0c1bfd3c/src/octoprint/util/comm.py#L2571-L2583
- [ ] Add _gcode_M106_sent to parse and set fan speed when sent to printer *(probably need some help with that)*
- [ ] Update docs 
