### PR TITLE
Added Try/Except test to prevent I/O errors…

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -3745,7 +3745,7 @@ class MachineCom(object):
                 serial_obj.open()
 
             except serial.SerialException:
-                self._logger.info("Failed to connect: Port {} does not exist".format(p))
+                self._logger.info("Failed to connect: Port {} is busy or does not exist".format(p))
                 return None
 
             # Set close_exec flag on serial handle, see #3212

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -3745,7 +3745,9 @@ class MachineCom(object):
                 serial_obj.open()
 
             except serial.SerialException:
-                self._logger.info("Failed to connect: Port {} is busy or does not exist".format(p))
+                self._logger.info(
+                    "Failed to connect: Port {} is busy or does not exist".format(p)
+                )
                 return None
 
             # Set close_exec flag on serial handle, see #3212

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -3725,23 +3725,28 @@ class MachineCom(object):
             if settings().getBoolean(["serial", "exclusive"]):
                 serial_port_args["exclusive"] = True
 
-            serial_obj = serial.Serial(**serial_port_args)
-            serial_obj.port = str(p)
+            try:
+                serial_obj = serial.Serial(**serial_port_args)
+                serial_obj.port = str(p)
 
-            use_parity_workaround = settings().get(["serial", "useParityWorkaround"])
-            needs_parity_workaround = get_os() == "linux" and os.path.exists(
-                "/etc/debian_version"
-            )  # See #673
+                use_parity_workaround = settings().get(["serial", "useParityWorkaround"])
+                needs_parity_workaround = get_os() == "linux" and os.path.exists(
+                    "/etc/debian_version"
+                )  # See #673
 
-            if use_parity_workaround == "always" or (
-                needs_parity_workaround and use_parity_workaround == "detect"
-            ):
-                serial_obj.parity = serial.PARITY_ODD
+                if use_parity_workaround == "always" or (
+                    needs_parity_workaround and use_parity_workaround == "detect"
+                ):
+                    serial_obj.parity = serial.PARITY_ODD
+                    serial_obj.open()
+                    serial_obj.close()
+                    serial_obj.parity = serial.PARITY_NONE
+
                 serial_obj.open()
-                serial_obj.close()
-                serial_obj.parity = serial.PARITY_NONE
 
-            serial_obj.open()
+            except serial.SerialException:
+                self._logger.info("Failed to connect: Port {} does not exist".format(p))
+                return None
 
             # Set close_exec flag on serial handle, see #3212
             if hasattr(serial_obj, "fd"):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This change handles serial posix I/O errors generated when attempting to connect to a nonexistent or busy serial port.
If a SerialException occurs when attempting to connect to a port it is handled and a log of the failed connection attempt is generated, finally None is returned, which is handled properly by the existing checks.

#### How was it tested? How can it be tested by the reviewer?
Tested in OctoPrint dev environment. The bug can be reproduced by setting the serial port to AUTO and connecting the virtual printer in a dev environment. In the real world it could potentially occur with a faulty serial connection, if linux fails to update port availability in a timely manner or when a port is improperly closed.

#### Any background context you want to provide
I am developing a plugin for automating serial communications between OctoPrint and peripheral (non-printer) devices. I stumbled across this problem while testing my plugin.

#### What are the relevant tickets if any?
None, I fixed the issue before thinking to submit a ticket.

Best regards,
-Andrew O'Shei

This is my first PR on OctoPrint, I took a look through the guidelines but I apologize in advance if I slipped up somewhere.

