### PR TITLE
Remove spell check in plugin search

### DIFF
--- a/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
+++ b/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
@@ -104,7 +104,7 @@
             <h3>{{ _('Installed Plugins') }}</h3>
 
             <div style="margin-bottom: 1em" class="clearfix">
-                <input type="text" class="input-block search-query pull-left" data-bind="value: listingSearchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}">
+                <input type="text" class="input-block search-query pull-left" data-bind="value: listingSearchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}" spellcheck="false">
 
                 <div class="pull-right">
                     <div class="btn-group">
@@ -235,7 +235,7 @@
 
             <div style="margin-bottom: 1em" class="clearfix">
                 <form class="form-search" data-bind="submit: performRepositorySearch">
-                    <input type="text" class="input-block search-query pull-left" data-bind="value: repositorySearchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}">
+                    <input type="text" class="input-block search-query pull-left" data-bind="value: repositorySearchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}" spellcheck="false">
                 </form>
                 <div class="dropdown pull-right">
                     <div class="btn-group">

--- a/src/octoprint/templates/sidebar/files.jinja2
+++ b/src/octoprint/templates/sidebar/files.jinja2
@@ -1,6 +1,6 @@
 <form class="form-search" data-bind="submit: performSearch, visible: $root.loginState.hasPermissionKo($root.access.permissions.FILES_LIST)">
     <div class="search-query-with-clear" data-bind="css: {'active-clear': searchQuery}">
-        <input type="search" class="input-block search-query" data-bind="value: searchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}">
+        <input type="search" class="input-block search-query" data-bind="value: searchQuery, valueUpdate: 'input'" placeholder="{{ _('Search...')|edq }}" spellcheck="false">
         <span class="search-clear" data-bind="click: clearSearchQuery"><i class="fas fa-times"></i></span>
     </div>
 </form>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR removes the spell check in the search boxes of the plugin manager settings. The spell check is extremely annoying on Safari as the browser auto-fixes "misspellings" when the search box looses focus or a space is typed. If you e.g. search `tplink` the correct results show up, but when you want to click "Install", the search box looses focus and Safari converts `tplink` into `uplink` and the search updates as well.

See videos below for before / after

Uploading before.mov…

#### How was it tested? How can it be tested by the reviewer?
Tested on latest Safari and Chrome

#### Any background context you want to provide?
/

#### What are the relevant tickets if any?
/

#### Screenshots (if appropriate)


*Before*           |  *After*
:-------------------------:|:-------------------------:
![](https://user-images.githubusercontent.com/5859228/151697944-9cec00b6-be85-4a9d-a736-1e221e6d7c51.gif)  |  ![](https://user-images.githubusercontent.com/5859228/151697951-ecd0a046-bde1-469e-be50-03fd409db299.gif)

#### Further notes
/
