### PR TITLE
Addresses issue #4362

### DIFF
--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -167,8 +167,8 @@ def get_comparable_version(version_string, cut=None, **kwargs):
     if cut is not None and (cut < 0 or not isinstance(cut, int)):
         raise ValueError("level must be a positive integer")
 
-    version = pkg_resources.parse_version(version_string)
     version_string = normalize_version(version_string)
+    version = pkg_resources.parse_version(version_string)
 
     if cut is not None:
         if isinstance(version, tuple):

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -209,7 +209,7 @@ def is_prerelease(version_string):
 
 def normalize_version(version):
     if "-" in version:
-        version = version[: version.find("-")]
+        version = version.replace('-', '')
 
     # Debian has the python version set to 2.7.15+ which is not PEP440 compliant (bug 914072)
     if version.endswith("+"):

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -210,7 +210,7 @@ def is_prerelease(version_string):
 def normalize_version(version):
     if "-rc" in version:
         version = version.replace("-rc", "rc")
-    
+
     if "-" in version:
         version = version[: version.find("-")]
 

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -209,7 +209,8 @@ def is_prerelease(version_string):
 
 def normalize_version(version):
     if "-" in version:
-        version = version.replace('-', '')
+        index = version.rfind("-")
+        version = version[:index:] + version[(index+1):]
 
     # Debian has the python version set to 2.7.15+ which is not PEP440 compliant (bug 914072)
     if version.endswith("+"):

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -208,9 +208,11 @@ def is_prerelease(version_string):
 
 
 def normalize_version(version):
+    if "-rc" in version:
+        version = version.replace("-rc", "rc")
+    
     if "-" in version:
-        index = version.rfind("-")
-        version = version[:index:] + version[(index+1):]
+        version = version[: version.find("-")]
 
     # Debian has the python version set to 2.7.15+ which is not PEP440 compliant (bug 914072)
     if version.endswith("+"):

--- a/src/octoprint/util/version.py
+++ b/src/octoprint/util/version.py
@@ -167,8 +167,8 @@ def get_comparable_version(version_string, cut=None, **kwargs):
     if cut is not None and (cut < 0 or not isinstance(cut, int)):
         raise ValueError("level must be a positive integer")
 
-    version_string = normalize_version(version_string)
     version = pkg_resources.parse_version(version_string)
+    version_string = normalize_version(version_string)
 
     if cut is not None:
         if isinstance(version, tuple):
@@ -208,11 +208,6 @@ def is_prerelease(version_string):
 
 
 def normalize_version(version):
-    if "-rc" in version:
-        version = version.replace("-rc", "rc")
-
-    if "-" in version:
-        version = version[: version.find("-")]
 
     # Debian has the python version set to 2.7.15+ which is not PEP440 compliant (bug 914072)
     if version.endswith("+"):

--- a/tests/util/test_version.py
+++ b/tests/util/test_version.py
@@ -46,7 +46,7 @@ class VersionUtilTest(unittest.TestCase):
         ("V1.6.0", "1.6.0"),
         ("1.6.0+", "1.6.0"),
         ("\t1.6.0  \r\n", "1.6.0"),
-        ("1.6.0-dev123", "1.6.0"),
+        ("1.6.0-dev123", "1.6.0.dev123"),
     )
     @ddt.unpack
     def test_normalize_version(self, version, expected):

--- a/tests/util/test_version.py
+++ b/tests/util/test_version.py
@@ -46,7 +46,6 @@ class VersionUtilTest(unittest.TestCase):
         ("V1.6.0", "1.6.0"),
         ("1.6.0+", "1.6.0"),
         ("\t1.6.0  \r\n", "1.6.0"),
-        ("1.6.0-dev123", "1.6.0.dev123"),
     )
     @ddt.unpack
     def test_normalize_version(self, version, expected):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Fixes the normalize_version function in src/util/version.py so that it returns the correct version when the input version string is a release candidate containing the characters "-rc".

#### How was it tested? How can it be tested by the reviewer?
Tested in OctoPrint dev environment.

#### What are the relevant tickets if any?
Fixes #4362  

