### PR TITLE
Add quotes to pip argument to resolve zsh incompatibility

### DIFF
--- a/docs/plugins/gettingstarted.rst
+++ b/docs/plugins/gettingstarted.rst
@@ -20,7 +20,7 @@ development environment::
   $ virtualenv venv
   [...]
   $ source venv/bin/activate
-  (venv) $ pip install -e .[develop,plugins]
+  (venv) $ pip install -e '.[develop,plugins]'
   [...]
   (venv) $ octoprint --help
   Usage: octoprint [OPTIONS] COMMAND [ARGS]...


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Update plugin dev "getting started" docs to avoid mysterious zsh error message, will now match the rest of the dev docs which already use the quotes

#### How was it tested? How can it be tested by the reviewer?
Manually execute command with bash and zsh, leave off with zsh to reproduce issue

#### Any background context you want to provide?
It appears the quoting is already done elsewhere in the docs, I spent 30 trying to resolve the issue before noticing that the quotes are used in other parts of the docs

#### What are the relevant tickets if any?
n/a

#### Screenshots (if appropriate)

#### Further notes
