### PR TITLE
♻ Provide a content-length for streaming zip downloads

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -154,6 +154,7 @@ date of first contribution):
   * [Bryan Kenote](https://github.com/bryankenote)
   * [Quinn Damerell](https://github.com/QuinnDamerell)
   * [Sven Samoray](https://github.com/thelastWallE)
+  * [Carey Metcalfe](https://github.com/pR0Ps)
   * [Christian Würthner](https://github.com/crysxd)
   * [Maciej Urbański](https://github.com/rooterkyberian)
   * [Adam Wolf](https://github.com/adamwolf)

--- a/THIRDPARTYLICENSES.md
+++ b/THIRDPARTYLICENSES.md
@@ -74,6 +74,7 @@
   * [watchdog](http://github.com/gorakhargosh/watchdog): Apache License 2.0
   * [websocket-client](https://github.com/liris/websocket-client): LGPLv3
   * [wrapt](http://wrapt.readthedocs.org/): BSD
+  * [zipstream-ng](https://github.com/pR0Ps/zipstream-ng): LGPLv3
 
 ## Development (testing, documentation generation, etc)
 

--- a/setup.py
+++ b/setup.py
@@ -64,7 +64,7 @@ core_deps = [
     "websocket-client>=1.2.1,<2",
     "wrapt>=1.13.3,<1.14",
     "zeroconf>=0.33,<0.34",  # breaking changes can happen on minor version increases
-    "zipstream-new>=1.1.8,<1.2",
+    "zipstream-ng>=1.3.4,<2.0.0",
 ]
 vendored_deps = [
     "blinker>=1.4,<2",  # dependency of flask_principal


### PR DESCRIPTION
This allows browsers and other clients to calculate download progress and detect if the download fails (they get less data than expected). This is most useful when downloading multiple timelapses due to their potential size.

This is a backport of PR #4313 that was already merged to `devel`. Now that the `maintenance` branch has dropped Python 2 support, this functionality can be backported into it.