### PR TITLE
LOW: Documentation, use const ADMIN_GROUP (2nd attempt)

### DIFF
--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -228,7 +228,7 @@ octoprint.access.permissions
        suffice.
      * ``dangerous``: Whether this permission should be considered dangerous (``True``) or not (``False``)
      * ``default_groups``: A list of standard groups this permission should be apply to by default. Standard groups
-       are ``admins``, ``users``, ``readonly`` and ``guests``
+       are ``octoprint.access.ADMIN_GROUP``, ``octoprint.access.USER_GROUP``, ``octoprint.access.READONLY_GROUP`` and ``octoprint.access.GUEST_GROUP``
 
    The following example is based on some actual code included in the bundled Application Keys plugin and defines
    one additional permission called ``ADMIN`` with a role ``admin`` which is marked as dangerous (since it gives
@@ -237,6 +237,8 @@ octoprint.access.permissions
 
    .. code-block:: python
 
+      from octoprint.access import ADMIN_GROUP
+      
       def get_additional_permissions(*args, **kwargs):
           return [
               dict(key="ADMIN",


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Patch of documentation
```ADMIN_GROUP``` is not available without an import in that example. Also replacing the "group-strings" in the description with const-values

#### How was it tested? How can it be tested by the reviewer?
-

#### Any background context you want to provide?
-

#### What are the relevant tickets if any?
-

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/24205767/149679242-f1cc0042-3359-4a86-a765-836da4423eb2.png)

#### Further notes
- 