### PR TITLE
✨  Add `--no-color` option to disable colored output on console

### DIFF
--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -68,6 +68,7 @@ def init_platform(
     verbosity=0,
     uncaught_logger=None,
     uncaught_handler=None,
+    disable_color=True,
     safe_mode=False,
     ignore_blacklist=False,
     after_preinit_logging=None,
@@ -109,6 +110,7 @@ def init_platform(
             verbosity=verbosity,
             uncaught_logger=uncaught_logger,
             uncaught_handler=uncaught_handler,
+            disable_color=disable_color,
         )
     except Exception as ex:
         raise FatalStartupError("Could not initialize logging", cause=ex)
@@ -252,6 +254,7 @@ def init_logging(
     verbosity=0,
     uncaught_logger=None,
     uncaught_handler=None,
+    disable_color=True,
 ):
     """Sets up logging."""
 
@@ -272,7 +275,6 @@ def init_logging(
                     "reset": True,
                     "log_colors": {
                         "DEBUG": "cyan",
-                        "INFO": "white",
                         "WARNING": "yellow",
                         "ERROR": "red",
                         "CRITICAL": "bold_red",
@@ -286,7 +288,7 @@ def init_logging(
                 "console": {
                     "class": "octoprint.logging.handlers.OctoPrintStreamHandler",
                     "level": "DEBUG",
-                    "formatter": "colored",
+                    "formatter": "simple" if disable_color else "colored",
                     "stream": "ext://sys.stdout",
                 },
                 "file": {

--- a/src/octoprint/cli/__init__.py
+++ b/src/octoprint/cli/__init__.py
@@ -62,6 +62,7 @@ def init_platform_for_cli(ctx):
         get_ctx_obj_option(ctx, "configfile", None),
         overlays=get_ctx_obj_option(ctx, "overlays", None),
         safe_mode=True,
+        disable_color=get_ctx_obj_option(ctx, "no_color", False),
     )
 
     (
@@ -235,6 +236,15 @@ def standard_options(hidden=False):
             is_eager=True,
             expose_value=False,
             help="Enable safe mode; disables all third party plugins.",
+        ),
+        factory(
+            "--no-color",
+            "no_color",
+            is_flag=True,
+            callback=set_ctx_obj_option,
+            is_eager=True,
+            expose_value=False,
+            help="Disable colored console output",
         ),
     ]
 

--- a/src/octoprint/cli/server.py
+++ b/src/octoprint/cli/server.py
@@ -31,6 +31,7 @@ def run_server(
     ignore_blacklist,
     octoprint_daemon=None,
     overlays=None,
+    disable_color=False,
 ):
     """Initializes the environment and starts up the server."""
 
@@ -120,6 +121,7 @@ def run_server(
             ignore_blacklist=ignore_blacklist,
             after_safe_mode=log_startup,
             after_environment_detector=log_register_rollover,
+            disable_color=disable_color,
         )
         (
             settings,
@@ -307,6 +309,7 @@ def serve_command(ctx, **kwargs):
     safe_mode = "flag" if get_value("safe_mode") else None
     ignore_blacklist = get_value("ignore_blacklist")
     overlays = get_value("overlays")
+    no_color = bool(get_value("no_color"))
 
     if v4 and not host:
         host = "0.0.0.0"
@@ -324,6 +327,7 @@ def serve_command(ctx, **kwargs):
         safe_mode,
         ignore_blacklist,
         overlays=overlays,
+        disable_color=no_color,
     )
 
 


### PR DESCRIPTION


#### What does this PR do and why is it necessary?

Add `--no-color` option to disable colored output on console.

Closes #4396

Also removed the setting of INFO logs to white, instead it will be left as default. If there is a light-colored background (such as white) then it becomes unreadable. Can then just use whatever user has configured for their default and not worry about contrast issues.

```
> octoprint --help
Usage: octoprint [OPTIONS] COMMAND [ARGS]...

Options:
  -b, --basedir PATH  Specify the basedir to use for configs, uploads,
                      timelapses etc.
  -c, --config PATH   Specify the config file to use.
  --overlay PATH      Specify additional config overlays to use.
  -v, --verbose       Increase logging verbosity.
  --safe              Enable safe mode; disables all third party plugins.
  --no-color          Disable colored console output
  --version           Show the version and exit.
  --help              Show this message and exit.
```

#### How was it tested? How can it be tested by the reviewer?

Manually by starting with and without the flag.
