### PR TITLE
🔨  Add `octoprint dev css:build` command

### DIFF
--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -255,11 +255,11 @@ class OctoPrintDevelCommands(click.MultiCommand):
             "-f",
             "files",
             multiple=True,
-            help="Specify files to build, for a list use --list",
+            help="Specify files to build, for a list of options use --list",
         )
         @click.option("--all", "all_files", is_flag=True, help="Build all less files")
         @click.option(
-            "--list", "list_files", is_flag=True, help="List all available files"
+            "--list", "list_files", is_flag=True, help="List all available files and exit"
         )
         def command(files, all_files, list_files):
             import os.path
@@ -323,9 +323,9 @@ class OctoPrintDevelCommands(click.MultiCommand):
 
             if not files:
                 click.echo(
-                    "No files specified, building all. Use `--file <file>` to specify individual files."
+                    "No files specified. Use `--file <file>` to specify individual files, or `--all` to build all."
                 )
-                files = available_files.keys()
+                sys.exit(1)
 
             # Check that lessc is installed
             less = shutil.which("lessc")

--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -270,6 +270,14 @@ class OctoPrintDevelCommands(click.MultiCommand):
                     "source": "static/less/octoprint.less",
                     "output": "static/css/octoprint.css",
                 },
+                "login": {
+                    "source": "static/less/login.less",
+                    "output": "static/css/login.css",
+                },
+                "recovery": {
+                    "source": "static/less/recovery.less",
+                    "output": "static/css/recovery.css",
+                },
                 "plugin_announcements": {
                     "source": "plugins/announcements/static/less/announcments.less",
                     "output": "plugins/announcements/static/css/announcements.css",

--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -279,7 +279,7 @@ class OctoPrintDevelCommands(click.MultiCommand):
                     "output": "static/css/recovery.css",
                 },
                 "plugin_announcements": {
-                    "source": "plugins/announcements/static/less/announcments.less",
+                    "source": "plugins/announcements/static/less/announcements.less",
                     "output": "plugins/announcements/static/css/announcements.css",
                 },
                 "plugin_appkeys_core": {

--- a/src/octoprint/cli/dev.py
+++ b/src/octoprint/cli/dev.py
@@ -2,6 +2,7 @@ __author__ = "Gina Häußge <osd@foosel.net>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2015 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
+import sys
 
 import click
 
@@ -16,7 +17,7 @@ class OctoPrintDevelCommands(click.MultiCommand):
     """
 
     sep = ":"
-    groups = ("plugin",)
+    groups = ("plugin", "css")
 
     def __init__(self, *args, **kwargs):
         click.MultiCommand.__init__(self, *args, **kwargs)
@@ -214,7 +215,6 @@ class OctoPrintDevelCommands(click.MultiCommand):
             """
 
             import os
-            import sys
 
             if not path:
                 path = os.getcwd()
@@ -235,7 +235,6 @@ class OctoPrintDevelCommands(click.MultiCommand):
         @click.argument("name")
         def command(name):
             """Uninstalls the plugin with the given name."""
-            import sys
 
             lower_name = name.lower()
             if not lower_name.startswith("octoprint_") and not lower_name.startswith(
@@ -246,6 +245,114 @@ class OctoPrintDevelCommands(click.MultiCommand):
 
             call = [sys.executable, "-m", "pip", "uninstall", "--yes", name]
             self.command_caller.call(call)
+
+        return command
+
+    def css_build(self):
+        @click.command("build")
+        @click.option(
+            "--file",
+            "-f",
+            "files",
+            multiple=True,
+            help="Specify files to build, for a list use --list",
+        )
+        @click.option("--all", "all_files", is_flag=True, help="Build all less files")
+        @click.option(
+            "--list", "list_files", is_flag=True, help="List all available files"
+        )
+        def command(files, all_files, list_files):
+            import os.path
+            import shutil
+
+            available_files = {
+                "core": {
+                    "source": "static/less/octoprint.less",
+                    "output": "static/css/octoprint.css",
+                },
+                "plugin_announcements": {
+                    "source": "plugins/announcements/static/less/announcments.less",
+                    "output": "plugins/announcements/static/css/announcements.css",
+                },
+                "plugin_appkeys_core": {
+                    "source": "plugins/appkeys/static/less/appkeys.less",
+                    "output": "plugins/appkeys/static/css/appkeys.css",
+                },
+                "plugin_appkeys_authdialog": {
+                    "source": "plugins/appkeys/static/less/authdialog.less",
+                    "output": "plugins/appkeys/static/css/authdialog.css",
+                },
+                "plugin_backup": {
+                    "source": "plugins/backup/static/less/backup.less",
+                    "output": "plugins/backup/static/css/backup.css",
+                },
+                "plugin_gcodeviewer": {
+                    "source": "plugins/gcodeviewer/static/less/gcodeviewer.less",
+                    "output": "plugins/gcodeviewer/static/css/gcodeviewer.css",
+                },
+                "plugin_logging": {
+                    "source": "plugins/logging/static/less/logging.less",
+                    "output": "plugins/logging/static/css/logging.css",
+                },
+                "plugin_pluginmanager": {
+                    "source": "plugins/pluginmanager/static/less/pluginmanager.less",
+                    "output": "plugins/pluginmanager/static/css/pluginmanager.css",
+                },
+                "plugin_softwareupdate": {
+                    "source": "plugins/softwareupdate/static/less/softwareupdate.less",
+                    "output": "plugins/softwareupdate/static/css/softwareupdate.css",
+                },
+            }
+
+            if list_files:
+                click.echo("Available files to build:")
+                for name in available_files.keys():
+                    click.echo(f"- {name}")
+                sys.exit(0)
+
+            if all_files:
+                files = available_files.keys()
+
+            if not files:
+                click.echo(
+                    "No files specified, building all. Use `--file <file>` to specify individual files."
+                )
+                files = available_files.keys()
+
+            # Check that lessc is installed
+            less = shutil.which("lessc")
+
+            if not less:
+                click.echo(
+                    "lessc is not installed/not available, please install it first"
+                )
+                click.echo(
+                    "Try `npm i -g less` to install it (NOT lessc in this command!)"
+                )
+                sys.exit(1)
+
+            # Find the folder of the `octoprint` package
+            # Two folders up from this file
+            octoprint = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+            for file in files:
+                if file not in available_files.keys():
+                    click.echo(f"Unknown file {file}")
+                    sys.exit(1)
+
+                source_path = os.path.join(octoprint, available_files[file]["source"])
+                output_path = os.path.join(octoprint, available_files[file]["output"])
+
+                # Check the target file exists
+                if not os.path.exists(source_path):
+                    click.echo(f"Target file {source_path} does not exist")
+                    continue
+
+                # Build command line, with necessary options
+                # TODO -x is deprecated, find replacement?
+                less_command = [less, "-x", source_path, output_path]
+
+                self.command_caller.call(less_command)
 
         return command
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Has the necessary paths pre-configured and can build all the less files in one go, if you so wish.

#### How was it tested? How can it be tested by the reviewer?

Manually

#### Any background context you want to provide?

Several times asked on discord how the less files are built, people are expecting some kind of easy command like this, rather than typing out the paths manually/individually. So I made one.

#### Details

```
> octoprint dev css:build --help
Usage: octoprint dev css:build [OPTIONS]

Options:
  -f, --file TEXT  Specify files to build, for a list use --list
  --all            Build all less files
  --list           List all available files
  --help           Show this message and exit.
```

If the `--all` option is specified, then all the files are built.

`-f` or `--file` can be used multiple times, for example:
```
octoprint dev css:build -f core -f login -f plugin_backup
```

List of available files/identifiers can be found using:
```
> octoprint dev css:build --all --list
Available files to build:
- core
- login
- recovery
- plugin_announcements
- plugin_appkeys_core
- plugin_appkeys_authdialog
- plugin_backup
- plugin_gcodeviewer
- plugin_logging
- plugin_pluginmanager
- plugin_softwareupdate
```

It then iterates through the files, building them!

#### Additional Information

I added the `-x` option, because all the files are compressed at the moment. However, the `-x` is deprecated, so a replacement may need to be found.

Tested with `less` 4.1.2 - there's a separate incompatibility blocking the core build with less 4.