### PR TITLE
move defaultExtrusionLength from settings into printer profile

### DIFF
--- a/docs/api/printerprofiles.rst
+++ b/docs/api/printerprofiles.rst
@@ -626,6 +626,12 @@ Profile
      - 0..1
      - ``float``
      - The diameter of the printer's nozzle(s) in mm.
+   * - ``extruder.sharedNozzle``
+     - ``boolean``
+     - Whether there's only one nozzle shared among all extruders (true) or one nozzle per extruder (false).
+   * - ``extruder.defaultExtrusionLength``
+     - ``int``
+     - Default extrusion length used in Control tab on initial page load in mm.
    * - ``extruder.count``
      - 0..1
      - ``int``

--- a/docs/api/settings.rst
+++ b/docs/api/settings.rst
@@ -372,8 +372,6 @@ mapped, with the following exceptions:
      - Maps to ``folder.timelapse_tmp`` in ``config.yaml``
    * - ``plugins``
      - Plugin settings as available from ``config.yaml`` and :class:`~octoprint.plugin.SettingsPlugin` implementations
-   * - ``printer.defaultExtrusionLength``
-     - Maps to ``printerParameters.defaultExtrusionLength`` in ``config.yaml``
    * - ``scripts.gcode``
      - Whole subtree of configured :ref:`GCODE scripts <sec-features-gcode_scripts>`
    * - ``serial.port``

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -83,6 +83,9 @@ A printer profile is a ``dict`` of the following structure:
    * - ``extruder.sharedNozzle``
      - ``boolean``
      - Whether there's only one nozzle shared among all extruders (true) or one nozzle per extruder (false).
+   * - ``extruder.defaultExtrusionLength``
+     - ``int``
+     - Default extrusion length used in Control tab on initial page load in mm.
    * - ``axes``
      - ``dict``
      - Information about the printer axes
@@ -242,6 +245,7 @@ class PrinterProfileManager:
             "offsets": [(0, 0)],
             "nozzleDiameter": 0.4,
             "sharedNozzle": False,
+            "defaultExtrusionLength": 5,
         },
         "axes": {
             "x": {"speed": 6000, "inverted": False},

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -114,11 +114,6 @@ def getSettings():
             "closeModalsWithClick": s.getBoolean(["appearance", "closeModalsWithClick"]),
             "showInternalFilename": s.getBoolean(["appearance", "showInternalFilename"]),
         },
-        "printer": {
-            "defaultExtrusionLength": s.getInt(
-                ["printerParameters", "defaultExtrusionLength"]
-            )
-        },
         "webcam": {
             "webcamEnabled": s.getBoolean(["webcam", "webcamEnabled"]),
             "timelapseEnabled": s.getBoolean(["webcam", "timelapseEnabled"]),

--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -305,7 +305,7 @@ default_settings = {
         "sendAutomaticallyAfter": 1,
     },
     "printerProfiles": {"default": None},
-    "printerParameters": {"pauseTriggers": [], "defaultExtrusionLength": 5},
+    "printerParameters": {"pauseTriggers": []},
     "appearance": {
         "name": "",
         "color": "default",

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -22,6 +22,7 @@ $(function () {
         self.isLoading = ko.observable(undefined);
 
         self.extrusionAmount = ko.observable(undefined);
+
         self.controls = ko.observableArray([]);
 
         self.distances = ko.observableArray([0.1, 1, 10, 100]);
@@ -82,10 +83,18 @@ $(function () {
 
         self.settings.printerProfiles.currentProfileData.subscribe(function () {
             self._updateExtruderCount();
+            self._updateExtrusionAmount();
             self.settings.printerProfiles
                 .currentProfileData()
                 .extruder.count.subscribe(self._updateExtruderCount);
         });
+        self._updateExtrusionAmount = function () {
+            self.extrusionAmount(
+                self.settings.printerProfiles
+                    .currentProfileData()
+                    .extruder.defaultExtrusionLength()
+            );
+        };
         self._updateExtruderCount = function () {
             var tools = [];
 
@@ -617,7 +626,11 @@ $(function () {
             }
             self._enableWebcam();
 
-            self.extrusionAmount(self.settings.printer_defaultExtrusionLength());
+            self.extrusionAmount(
+                self.settings.printerProfiles
+                    .currentProfileData()
+                    .extruder.defaultExtrusionLength()
+            );
         };
 
         self.syncWebcamElements = function () {

--- a/src/octoprint/static/js/app/viewmodels/printerprofiles.js
+++ b/src/octoprint/static/js/app/viewmodels/printerprofiles.js
@@ -25,7 +25,8 @@ $(function () {
                 count: 1,
                 offsets: [[0, 0]],
                 nozzleDiameter: 0.4,
-                sharedNozzle: false
+                sharedNozzle: false,
+                defaultExtrusionLength: 5
             }
         };
     };
@@ -72,6 +73,7 @@ $(function () {
         self.extruders = ko.observable();
         self.extruderOffsets = ko.observableArray();
         self.sharedNozzle = ko.observable();
+        self.defaultExtrusionLength = ko.observable();
 
         self.axisXSpeed = ko.observable();
         self.axisYSpeed = ko.observable();
@@ -233,6 +235,7 @@ $(function () {
 
             self.nozzleDiameter(data.extruder.nozzleDiameter);
             self.sharedNozzle(data.extruder.sharedNozzle);
+            self.defaultExtrusionLength(data.extruder.defaultExtrusionLength);
             self.extruders(data.extruder.count);
             var offsets = [];
             if (data.extruder.count > 1) {
@@ -298,7 +301,11 @@ $(function () {
                         self.nozzleDiameter(),
                         defaultProfile.extruder.nozzleDiameter
                     ),
-                    sharedNozzle: self.sharedNozzle()
+                    sharedNozzle: self.sharedNozzle(),
+                    defaultExtrusionLength: validInt(
+                        self.defaultExtrusionLength(),
+                        defaultProfile.extruder.defaultExtrusionLength
+                    )
                 },
                 axes: {
                     x: {

--- a/src/octoprint/templates/snippets/settings/printerprofiles/profileEditorExtruder.jinja2
+++ b/src/octoprint/templates/snippets/settings/printerprofiles/profileEditorExtruder.jinja2
@@ -51,7 +51,15 @@
             <!-- /ko -->
         </div>
     </div>
-
+    <div class="control-group">
+        <label class="control-label" for="settings-defaultExtrusionLength">{{ _('Default extrusion length') }}</label>
+        <div class="controls">
+            <div class="input-append">
+                <input type="number" class="input-mini text-right" min="1" data-bind="value: defaultExtrusionLength" id="settings-defaultExtrusionLength">
+                <span class="add-on">mm</span>
+            </div>
+        </div>
+    </div>
     <p>
         <small>{{ _('This information is used for the graph and controls available in the "Temperature" tab, the GCODE viewer, when slicing from within OctoPrint and for deciding which toolchange commands are safe to send to the printer.') }}</small>
     </p>


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?
Moves defaultExtrusionLength to be part of the printer profile's settings.

#### How was it tested? How can it be tested by the reviewer?
Ran local in dev machine and clicked around.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#4353 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/5249455/153693574-785aec29-5a02-4579-9206-1a2f2b34e183.png)

#### Further notes
Wasn't sure if it was necessary to keep the previous setting or not so I went ahead and removed it. Figured since it was missing from the UI and not really documented in config.yaml that wouldn't be that big an issue. 