### PR TITLE
Fixing a short WS connect timeout in SockJs

### DIFF
--- a/src/octoprint/static/js/app/client/socket.js
+++ b/src/octoprint/static/js/app/client/socket.js
@@ -15,7 +15,7 @@
         this.options = {
             timeouts: [0, 1, 1, 2, 3, 5, 8, 13, 20, 40, 100],
             connectTimeout: 5000,
-            sockjsWebsocketConnectTimeout: 3500,
+            sockjsWebsocketConnectTimeout: 4000,
             rateSlidingWindowSize: 20
         };
 
@@ -169,18 +169,26 @@
             }, timeout);
         }
 
-        // We define both a connectTimeout and a sockjsWebsocketConnectTimeout because they do different things.
-        // - connectTimeout defines how long this socket class abstraction will wait for sockjs to get to a connected state, regardless of which transport connects.
-        // - sockjsWebsocketConnectTimeout defines how long sockjs will wait on the initial websocket to connect before falling back to a worse (but might work) transport.
-        // We need to define sockjsWebsocketConnectTimeout because the default in sockjs is very low, around 200ms. This limit hinders the performance of remote OctoPrint plugins
-        // and other remote OctoPrint connections and forces them to fall back to the inferior http polling based sockjs transports. This change will also help lower powered OctoPrint
-        // devices that might need more time to process the influx of requests on OctoPrint initial load.
-        var sockjsTimeout = self.options.sockjsWebsocketConnectTimeout
-        if(opts.hasOwnProperty("sockjsWebsocketConnectTimeout")) {
+        // We define both a connectTimeout and a sockjsWebsocketConnectTimeout because
+        // they do different things.
+        // - connectTimeout defines how long this socket class abstraction will wait
+        //   for sockjs to get to a connected state, regardless of which transport
+        //   connects.
+        // - sockjsWebsocketConnectTimeout defines how long sockjs will wait on the
+        //   initial websocket to connect before falling back to a worse
+        //   (but might work) transport.
+        // We need to define sockjsWebsocketConnectTimeout because the default in
+        // sockjs is very low, around 200ms. This limit hinders the performance of
+        // remote OctoPrint plugins and other remote OctoPrint connections and forces
+        // them to fall back to the inferior http polling based sockjs transports.
+        // This change will also help lower powered OctoPrint devices that might
+        // need more time to process the influx of requests on OctoPrint initial load.
+        var sockjsTimeout = self.options.sockjsWebsocketConnectTimeout;
+        if (opts.hasOwnProperty("sockjsWebsocketConnectTimeout")) {
             sockjsTimeout = opts.sockjsWebsocketConnectTimeout;
             delete opts.sockjsWebsocketConnectTimeout;
         }
-        opts.timeout = sockjsTimeout
+        opts.timeout = sockjsTimeout;
 
         self.socket = new SockJS(url + "sockjs", undefined, opts);
         self.socket.onopen = onOpen;

--- a/src/octoprint/static/js/app/client/socket.js
+++ b/src/octoprint/static/js/app/client/socket.js
@@ -15,7 +15,7 @@
         this.options = {
             timeouts: [0, 1, 1, 2, 3, 5, 8, 13, 20, 40, 100],
             connectTimeout: 5000,
-            sockjsWebsocketConnectTimeout: 4000,
+            transportTimeout: 4000,
             rateSlidingWindowSize: 20
         };
 
@@ -169,26 +169,30 @@
             }, timeout);
         }
 
-        // We define both a connectTimeout and a sockjsWebsocketConnectTimeout because
-        // they do different things.
-        // - connectTimeout defines how long this socket class abstraction will wait
-        //   for sockjs to get to a connected state, regardless of which transport
-        //   connects.
-        // - sockjsWebsocketConnectTimeout defines how long sockjs will wait on the
-        //   initial websocket to connect before falling back to a worse
-        //   (but might work) transport.
-        // We need to define sockjsWebsocketConnectTimeout because the default in
-        // sockjs is very low, around 200ms. This limit hinders the performance of
-        // remote OctoPrint plugins and other remote OctoPrint connections and forces
-        // them to fall back to the inferior http polling based sockjs transports.
-        // This change will also help lower powered OctoPrint devices that might
-        // need more time to process the influx of requests on OctoPrint initial load.
-        var sockjsTimeout = self.options.sockjsWebsocketConnectTimeout;
-        if (opts.hasOwnProperty("sockjsWebsocketConnectTimeout")) {
-            sockjsTimeout = opts.sockjsWebsocketConnectTimeout;
-            delete opts.sockjsWebsocketConnectTimeout;
+        /*
+         * We define both a connectTimeout and a transportTimeout because they do
+         * different things:
+         *
+         * - connectTimeout defines how long this socket class abstraction will wait
+         *   for sockjs to get to a connected state, regardless of which transport
+         *   connects.
+         * - transportTimeout defines how long sockjs will wait on the
+         *   initial websocket to connect before falling back to a worse
+         *   (but might work) transport.
+         *
+         * We need to define transportTimeout because the default in
+         * sockjs is very low, around 200ms. This limit hinders the performance of
+         * remote OctoPrint plugins and other remote OctoPrint connections and forces
+         * them to fall back to the inferior http polling based sockjs transports.
+         * This change will also help lower powered OctoPrint devices that might
+         * need more time to process the influx of requests on OctoPrint initial load.
+         */
+        var transportTimeout = self.options.transportTimeout;
+        if (opts.hasOwnProperty("transportTimeout")) {
+            transportTimeout = opts.transportTimeout;
+            delete opts.transportTimeout;
         }
-        opts.timeout = sockjsTimeout;
+        opts.timeout = transportTimeout;
 
         self.socket = new SockJS(url + "sockjs", undefined, opts);
         self.socket.onopen = onOpen;


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

Sockjs provides the critical backbone of real-time information between the OctoPrint frontend and backend. SockJs supports many different real-time transports, the best being WebSockets, but also provides fallbacks to HTTP polling and such.

The issue this PR fixes is that sockjs first tries to connect with a WebSocket, but then quickly falls back to inferior polling methods when the WS fails. Since the WebSocket connection timeout is so short, any remote access to OctoPrint via plugins or any other methods might fail to connect the WebSocket, and then rely on inferior HTTP polling. 

This change adds logic to set the WS timeout of SockJS, which when unset is about ~200ms from my testing. Increasing the time allows the WebSocket more time to connect, and thus makes it more likely to succeed.

#### How was it tested? How can it be tested by the reviewer?

I tested this on my local OctoPrint setups, PY2 and PY3, running on RasPi 2 & 3.

#### Any background context you want to provide?

None

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

None

#### Further notes

None