### PR TITLE
:bug: SWU used wrong "ignore_throttled" setting

### DIFF
--- a/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
+++ b/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
@@ -159,7 +159,7 @@ $(function () {
             return (
                 self.piSupport &&
                 self.piSupport.currentIssue() &&
-                !self.settings.settings.plugins.pluginmanager.ignore_throttled()
+                !self.settings.settings.plugins.softwareupdate.ignore_throttled()
             );
         });
 


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Found some maybe copied code for the ignore_throttle setting that the pluginmanager is using and is also used from the softwareupdater-plugin. But the softwareupdater-plugin has its own setting for this.
Default Setting: https://github.com/OctoPrint/OctoPrint/blob/67631d3950f73b2f213ecdb224b3eb89188e1360/src/octoprint/plugins/softwareupdate/__init__.py#L698

And it gets the setting here in the frontend: https://github.com/OctoPrint/OctoPrint/blob/67631d3950f73b2f213ecdb224b3eb89188e1360/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js#L158-L164


#### How was it tested? How can it be tested by the reviewer?
Not actually tested.

