### PR TITLE
⚡ Reduce gcode viewer memory usage when loading file

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/reader.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/reader.js
@@ -154,7 +154,8 @@ GCODE.gCodeReader = (function () {
             this.clear();
 
             var totalSize = reader.target.result.length;
-            lines = reader.target.result.split(/[\r\n]/g);
+            // With a regex split below as previous, memory usage is huge & takes longer.
+            lines = reader.target.result.replace("\r\n", "\n").split("\n");
             reader.target.result = null;
             prepareGCode(totalSize);
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

When loading a gcode file, it must be split into lines from a single string as it is downloaded. This process used a *ton* of memory to do, for no apparent reason I could find. So maybe it is a browser problem with the regex splitting.

Previously to this change, I would find a spike in memory usage when this line was executed. In the example below I'm using a 20mb file:
![image](https://user-images.githubusercontent.com/31997505/154810250-381b996c-3282-4769-99d0-2fe44def1bea.png)

With a 60MB file, the spike was more pronounced (and maybe the problem is exponential?) - in this case, I set a breakpoint for the following line, to test that it was all contained in the single call. So before the following line could be executed, the memory dropped off a cliff - it took so long the start is off the graph, but the cliff gives us an idea of what the spike looks like:

![image](https://user-images.githubusercontent.com/31997505/154810289-1cfdc90f-e882-4bf9-93e5-8a2ae9f3ba20.png)

Following this change, the difference is huge:
![image](https://user-images.githubusercontent.com/31997505/154810359-4c3e1279-b4bc-4466-aedb-bc76b301b347.png)

The first red line is when I pressed 'load'. The file is downloaded and split up, then parsing starts at the second red line. Some memory increase is expected - we've just downloaded and manipulated a 60mb string. 

This was not a completely fair test - I would have had different tabs, different software running at the same time. But the difference is large enough and repeatable enough that I can be confident.

#### How was it tested? How can it be tested by the reviewer?

Manually on my laptop (Chromium Edge, Windows 11, Intel i7-1165G7, 16GB RAM)

I will also try and test the combination these same files on BrowserStack, to make sure I have not made it worse for another browser.

*Update*: I tried browserstack. And as good of a platform as it is, the available memory was far too low and it crashed very quickly.

#### Any background context you want to provide?

Inspired by the PR #4430, and other discussions about memory usage.

#### Further Notes

I have successfully loaded 200mb files with the changes in #4430, all that is limiting me now is the size of the files I have!

Attempted a 480mb file, and while it loaded and (imo) has plenty of memory left, it fails at the next hurdle - it can't send the result to the worker, because there is not enough memory to clone the data.