### PR TITLE
⚡  Don't load FontAwesome twice

### DIFF
--- a/src/octoprint/templates/stylesheets-preload.jinja2
+++ b/src/octoprint/templates/stylesheets-preload.jinja2
@@ -7,6 +7,5 @@
 
 {% for fa in ("fa-brands-400", "fa-regular-400", "fa-solid-900") %}
     <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff2') }}" type="font/woff2" crossorigin="anonymous">
-    <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff') }}" type="font/woff" crossorigin="anonymous">
 {% endfor %}
 <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-3.2.1/fonts/fontawesome-webfont.woff') }}" type="font/woff" crossorigin="anonymous">

--- a/src/octoprint/templates/stylesheets-preload.jinja2
+++ b/src/octoprint/templates/stylesheets-preload.jinja2
@@ -6,7 +6,7 @@
 {% assets "less_plugins" %}<link rel="preload" as="style" href="{{ ASSET_URL }}">{% endassets %}
 
 {% for fa in ("fa-brands-400", "fa-regular-400", "fa-solid-900") %}
-    <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff2') }}?v=5.15.1" type="font/woff2" crossorigin="anonymous">
-    <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff') }}?v=5.15.1" type="font/woff" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff2') }}" type="font/woff2" crossorigin="anonymous">
+    <link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-5.15.1/webfonts/' + fa + '.woff') }}" type="font/woff" crossorigin="anonymous">
 {% endfor %}
-<link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-3.2.1/fonts/fontawesome-webfont.woff') }}?v=3.2.1" type="font/woff" crossorigin="anonymous">
+<link rel="preload" as="font" href="{{ url_for('static', filename='vendor/font-awesome-3.2.1/fonts/fontawesome-webfont.woff') }}" type="font/woff" crossorigin="anonymous">


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

In the preload templates, an extra `?v=version` was added on the end of the URL. In the CSS file however, this was not used so the resource was fetched again, unnecessarily. The version number is embedded in the path, so it will be refetched if that changes.

![image](https://user-images.githubusercontent.com/31997505/154822274-a7bc18e6-97cf-4c6c-a6a0-9405bb30c732.png)

This has actually been logging to the warnings all the time, but I never actually looked at why:
![image](https://user-images.githubusercontent.com/31997505/154822290-de34e826-bace-4de5-b3a0-b24ff04c8068.png)

Additionally, both the `woff2` and `woff` files are not required by everyone - the woff2 files are preferred, with woff only used for those that don't support it. And [woff2 has a 96% compatibility](https://caniuse.com/woff2), everything except IE supports it, and it will be loaded automatically if required by the css file.

#### How was it tested? How can it be tested by the reviewer?

Manually in the browser

With this change, the number of FontAwesome related requests drops to a nice little 3:
![image](https://user-images.githubusercontent.com/31997505/154822497-fb2ff06b-7df7-4cbe-a3ba-fecf6a3a6d09.png)

#### Any background context you want to provide?

I was testing out FontAwesome 6, so I was poking in these kinds of areas... 👀 

#### Further Notes

The final unnecessary loading is of FontAwesome 3, but that is for backwards compatibility with plugins. Should be axed at some point IMO.
