### PR TITLE
Support two-digit flavors for G00 G01 G02 G03

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
@@ -380,7 +380,7 @@ var doParse = function () {
 
         var log = false;
 
-        if (/^(?:G0|G1|G2|G3)(\.\d+)?\s/i.test(line)) {
+        if (/^(?:G0|G1|G2|G3|G00|G01|G02|G03)(\.\d+)?\s/i.test(line)) {
             args = line.split(/\s/);
 
             for (j = 0; j < args.length; j++) {

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -425,7 +425,7 @@ class gcode(object):
                     tool = int(values["tool"])
 
             # G codes
-            if gcode in ("G0", "G1"):  # Move
+            if gcode in ("G0", "G1", "G00", "G01"):  # Move
                 x = getCodeFloat(line, "X")
                 y = getCodeFloat(line, "Y")
                 z = getCodeFloat(line, "Z")
@@ -500,7 +500,7 @@ class gcode(object):
                 if e:
                     self._track_layer(pos)
 
-            if gcode in ("G2", "G3"):  # Arc Move
+            if gcode in ("G2", "G3", "G02", "G03"):  # Arc Move
                 x = getCodeFloat(line, "X")
                 y = getCodeFloat(line, "Y")
                 z = getCodeFloat(line, "Z")


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This adds support for these four commands: G00 G01 G02 and G03, treating them the same as G0, G1, G2, and G3.

Many CAM processors generate two-digit movement commands.  These are legal movement commands but the viewer is currently blind to them.  In my opinion, this is a bug.  (Evidently slicers never generate these, or this would have already been an issue.)

This does not fully solve rendering of non-extruding toolpaths, but it enables a workaround in combination with M101 added to the preamble.  Without recognition of two-digit movement commands, a more involved preprocessor is necessary.

#### How was it tested? How can it be tested by the reviewer?
A reviewer should be able to validate it by inspection, but I also made the modification locally while I was checking that M101 would produce a rendering.  During testing is also when I discovered that G02 and G03 are necessary, and G00 and G01 are not sufficient.  Arcs are much more common in CAM-generated paths, compared to sliced polyhedra.

#### Any background context you want to provide?
A more complete CNC viewer plugin could overlap in functionality, but IMO failing to recognize G00 and G01 is _also_ a bug, and this PR targets the bug specifically and brings none of the other CNC considerations.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
