### PR TITLE
:bug: Fix temperatures API

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -844,6 +844,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
                 "offset": offsets[key] if offsets.get(key) is not None else 0,
             }
             for key, value in last.items()
+            if key != "time"
         }
 
     def get_temperature_history(self, *args, **kwargs):


### PR DESCRIPTION
There was a `time` field in there, which was an integer, and so didn't work with the loop so it's excluded

I quite like how compact the whole section is 🙂 