### PR TITLE
Tiny documentation typo, timeouts -> timeout

### DIFF
--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -654,7 +654,7 @@ class Settings(object):
         serial:
             port: "/dev/ttyACM0"
             baudrate: 250000
-            timeouts:
+            timeout:
                 communication: 20.0
                 temperature: 5.0
                 sdStatus: 1.0


### PR DESCRIPTION
Sorry for the annoyance.  I saw this small error in the documentation on docs.octoprint.org and this looked like the source.