### PR TITLE
Tiny documentation typo, timeouts -> timeout

### DIFF
--- a/src/octoprint/settings.py
+++ b/src/octoprint/settings.py
@@ -654,7 +654,7 @@ class Settings(object):
         serial:
             port: "/dev/ttyACM0"
             baudrate: 250000
-            timeouts:
+            timeout:
                 communication: 20.0
                 temperature: 5.0
                 sdStatus: 1.0


### PR DESCRIPTION
Within the internal module documentation for settings
 https://docs.octoprint.org/en/master/modules/settings.html#octoprint.settings.Settings
there is an inconsistency between the example definition and how it is referred to:
![image](https://user-images.githubusercontent.com/955138/159094825-d91138bf-6e40-4140-a60c-ba897b3cd9ca.png)

This documentation appears to be automatically generated from an autodoc string in the source code.

This PR changes "timeouts" to "timeout" in the autodoc string to bring them into agreement.  This also happens to match the actual configuration variable but that is somewhat beside the point.