### PR TITLE
Documentation: Replace Speeds 'mm/s' with 'mm/min'

### DIFF
--- a/docs/features/custom_controls.rst
+++ b/docs/features/custom_controls.rst
@@ -44,7 +44,7 @@ a GCODE script including user input.
      - name: Example for multiple commands
        children:
        - name: Move X (static)
-         confirm: You are about to move the X axis right by 10mm with 3000mm/s.
+         confirm: You are about to move the X axis right by 10mm with 3000mm/min.
          commands:
          - G91
          - G1 X10 F3000

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -94,7 +94,7 @@ A printer profile is a ``dict`` of the following structure:
      - Information about the printer's X axis
    * - ``axes.x.speed``
      - ``float``
-     - Speed of the X axis in mm/s
+     - Speed of the X axis in mm/min
    * - ``axes.x.inverted``
      - ``bool``
      - Whether a positive value change moves the nozzle away from the print bed's origin (False, default) or towards it (True)
@@ -103,7 +103,7 @@ A printer profile is a ``dict`` of the following structure:
      - Information about the printer's Y axis
    * - ``axes.y.speed``
      - ``float``
-     - Speed of the Y axis in mm/s
+     - Speed of the Y axis in mm/min
    * - ``axes.y.inverted``
      - ``bool``
      - Whether a positive value change moves the nozzle away from the print bed's origin (False, default) or towards it (True)
@@ -112,7 +112,7 @@ A printer profile is a ``dict`` of the following structure:
      - Information about the printer's Z axis
    * - ``axes.z.speed``
      - ``float``
-     - Speed of the Z axis in mm/s
+     - Speed of the Z axis in mm/min
    * - ``axes.z.inverted``
      - ``bool``
      - Whether a positive value change moves the nozzle away from the print bed (False, default) or towards it (True)
@@ -121,7 +121,7 @@ A printer profile is a ``dict`` of the following structure:
      - Information about the printer's E axis
    * - ``axes.e.speed``
      - ``float``
-     - Speed of the E axis in mm/s
+     - Speed of the E axis in mm/min
    * - ``axes.e.inverted``
      - ``bool``
      - Whether a positive value change extrudes (False, default) or retracts (True) filament


### PR DESCRIPTION
The User Casper#3607 in Discord found that there is a typo in the custom_controls.rst documentation about the speeds being stated as mm/s while they are mm/min (see https://marlinfw.org/docs/gcode/G000-G001.html for example)
Since Casper did not have the time to do a fix i had a look, and also found the same typo in the comment section of profile.py (whereas printerprofiles.rst states it correctly as mm/min)

Since this is a PR for a pure documentation fix, i don't see it fit to add me or Casper to the Authors file, i hope that's alright ;)

greetings
Lamensis