### PR TITLE
Don't block unused keys when keyboard control is active

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -728,9 +728,12 @@ $(function () {
                     // z home
                     button = $("#control-zhome");
                     break;
-                default:
+                case 9: // prevent tab key from removing focus from webcam
                     event.preventDefault();
                     return false;
+                default:
+                    // don't prevent other keys
+                    return true;
             }
 
             if (button === undefined) {


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] Your PR targets OctoPrint's maintenance branch
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Currently when they keyboard controls are active by hovering over the webcam, all key events will be captured and prevented. This means that if the user wants to use some other keyboard shortcut (for example ctrl+r or f5 to refresh the page) while they happen to have keyboard controls active, they cannot do so.

This PR allows any other keys that are not used by the keyboard controls to still do their normal action. 
I have also added a case for the tab key to prevent it from un-focusing the webcam and un-intentionally deactivating keyboard controls. 

#### How was it tested? How can it be tested by the reviewer?
This can be tested this by trying other keyboard shortcuts (such as to refresh the page) while the keyboard controls are active, and they should now work.

Additionally all of the keyboard controls still function correctly. 