### PR TITLE
🐛 Remove use of HTML entity degree symbol in temperature title attribute

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -165,6 +165,7 @@ date of first contribution):
   * [Johan Verrept](https://github.com/JoveToo)
   * [Nicu Surdu](https://github.com/surdu)
   * [Zack Lewis](https://github.com/lima3w)
+  * [Billy Richardson](https://github.com/richardsondev)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -652,13 +652,19 @@ function cleanTemperature(temp, offThreshold) {
     return temp;
 }
 
-function formatTemperature(temp, showF, offThreshold) {
+function formatTemperature(temp, showF, offThreshold, returnUnicode) {
     if (temp === undefined || !_.isNumber(temp)) return "-";
     if (offThreshold !== undefined && temp < offThreshold) return gettext("off");
+
+    var degreeSymbol = "&deg;";
+    if (returnUnicode !== undefined && returnUnicode) {
+        degreeSymbol = "\u00B0";
+    }
+
     if (showF) {
-        return _.sprintf("%.1f&deg;C (%.1f&deg;F)", temp, (temp * 9) / 5 + 32);
+        return _.sprintf("%.1f%sC (%.1f%sF)", temp, degreeSymbol, (temp * 9) / 5 + 32, degreeSymbol);
     } else {
-        return _.sprintf("%.1f&deg;C", temp);
+        return _.sprintf("%.1f%sC", temp, degreeSymbol);
     }
 }
 

--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -662,7 +662,13 @@ function formatTemperature(temp, showF, offThreshold, returnUnicode) {
     }
 
     if (showF) {
-        return _.sprintf("%.1f%sC (%.1f%sF)", temp, degreeSymbol, (temp * 9) / 5 + 32, degreeSymbol);
+        return _.sprintf(
+            "%.1f%sC (%.1f%sF)",
+            temp,
+            degreeSymbol,
+            (temp * 9) / 5 + 32,
+            degreeSymbol
+        );
     } else {
         return _.sprintf("%.1f%sC", temp, degreeSymbol);
     }

--- a/src/octoprint/templates/tabs/temperature.jinja2
+++ b/src/octoprint/templates/tabs/temperature.jinja2
@@ -49,7 +49,7 @@
 
     <script type="text/html" id="temprow-template">
         <th class="temperature_tool" data-bind="text: name, attr: {title: name}"></th>
-        <td class="temperature_actual" data-bind="html: formatTemperature(actual()), attr: {title: formatTemperature(actual())}"></td>
+        <td class="temperature_actual" data-bind="html: formatTemperature(actual()), attr: {title: formatTemperature(actual(), undefined, undefined, true)}"></td>
         <td class="temperature_target">
             <form class="form-inline" style="margin:0" data-bind="submit: function(element) { $root.setTarget($data, element) }">
                 <div class="input-prepend input-append">

--- a/tests/static/js/test-helpers.html
+++ b/tests/static/js/test-helpers.html
@@ -10,9 +10,22 @@
         <div id="qunit-fixture"></div>
         <script src="lib/qunit-1.18.0.js"></script>
         <script src="lib/qunit-parameterize.js"></script>
+        <script src="../../../src/octoprint/static/js/lib/babel.js"></script>
         <script src="../../../src/octoprint/static/js/lib/lodash.min.js"></script>
         <script src="../../../src/octoprint/static/js/lib/sprintf.min.js"></script>
         <script src="../../../src/octoprint/static/js/app/helpers.js"></script>
+        
+        <script>
+            var catalog = {
+                messages: undefined,
+                plural_expr: undefined,
+                locale: undefined,
+                domain: undefined
+            };
+
+            babel.Translations.load(catalog).install();
+        </script>
+        
         <script src="test-helpers.js"></script>
     </body>
 </html>

--- a/tests/static/js/test-helpers.html
+++ b/tests/static/js/test-helpers.html
@@ -14,7 +14,7 @@
         <script src="../../../src/octoprint/static/js/lib/lodash.min.js"></script>
         <script src="../../../src/octoprint/static/js/lib/sprintf.min.js"></script>
         <script src="../../../src/octoprint/static/js/app/helpers.js"></script>
-        
+
         <script>
             var catalog = {
                 messages: undefined,
@@ -25,7 +25,7 @@
 
             babel.Translations.load(catalog).install();
         </script>
-        
+
         <script src="test-helpers.js"></script>
     </body>
 </html>

--- a/tests/static/js/test-helpers.js
+++ b/tests/static/js/test-helpers.js
@@ -92,22 +92,86 @@ QUnit.cases(
         var cases = [];
 
         var params = [
-            {input: undefined, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "-"},
-            {input: "", showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "-"},
-            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: 1.1, expected: "off"},
-            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: 1.0, expected: "1.0&deg;C"},
-            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "1.0&deg;C"},
-            {input: 1.0, showF: true, useUnicode: undefined, offThreshold: undefined, expected: "1.0&deg;C (33.8&deg;F)"},
-            {input: 1.0, showF: true, useUnicode: true, offThreshold: undefined, expected: "1.0\u00B0C (33.8\u00B0F)"},
-            {input: 1.0, showF: undefined, useUnicode: false, offThreshold: undefined, expected: "1.0&deg;C"},
-            {input: 1.0, showF: undefined, useUnicode: true, offThreshold: undefined, expected: "1.0\u00B0C"},
-            {input: 1.1, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "1.1&deg;C"}
+            {
+                input: undefined,
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: undefined,
+                expected: "-"
+            },
+            {
+                input: "",
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: undefined,
+                expected: "-"
+            },
+            {
+                input: 1.0,
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: 1.1,
+                expected: "off"
+            },
+            {
+                input: 1.0,
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: 1.0,
+                expected: "1.0&deg;C"
+            },
+            {
+                input: 1.0,
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: undefined,
+                expected: "1.0&deg;C"
+            },
+            {
+                input: 1.0,
+                showF: true,
+                useUnicode: undefined,
+                offThreshold: undefined,
+                expected: "1.0&deg;C (33.8&deg;F)"
+            },
+            {
+                input: 1.0,
+                showF: true,
+                useUnicode: true,
+                offThreshold: undefined,
+                expected: "1.0\u00B0C (33.8\u00B0F)"
+            },
+            {
+                input: 1.0,
+                showF: undefined,
+                useUnicode: false,
+                offThreshold: undefined,
+                expected: "1.0&deg;C"
+            },
+            {
+                input: 1.0,
+                showF: undefined,
+                useUnicode: true,
+                offThreshold: undefined,
+                expected: "1.0\u00B0C"
+            },
+            {
+                input: 1.1,
+                showF: undefined,
+                useUnicode: undefined,
+                offThreshold: undefined,
+                expected: "1.1&deg;C"
+            }
         ];
 
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] = String(param.input) + String(param.showF) + String(param.useUnicode);
+            param["title"] =
+                String(param.input) +
+                String(param.showF) +
+                String(param.offThreshold) +
+                String(param.useUnicode);
             cases.push(param);
         }
 
@@ -116,7 +180,12 @@ QUnit.cases(
 ).test("formatTemperature", function (params, assert) {
     assert.equal(
         params.expected,
-        formatTemperature(params.input, params.showF, params.offThreshold, params.useUnicode),
+        formatTemperature(
+            params.input,
+            params.showF,
+            params.offThreshold,
+            params.useUnicode
+        ),
         "As expected: " + String(params.expected)
     );
 });

--- a/tests/static/js/test-helpers.js
+++ b/tests/static/js/test-helpers.js
@@ -85,3 +85,38 @@ QUnit.cases(
         "As expected: " + String(params.expected)
     );
 });
+
+QUnit.module("formatTemperature");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {input: undefined, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "-"},
+            {input: "", showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "-"},
+            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: 1.1, expected: "off"},
+            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: 1.0, expected: "1.0&deg;C"},
+            {input: 1.0, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "1.0&deg;C"},
+            {input: 1.0, showF: true, useUnicode: undefined, offThreshold: undefined, expected: "1.0&deg;C (33.8&deg;F)"},
+            {input: 1.0, showF: true, useUnicode: true, offThreshold: undefined, expected: "1.0\u00B0C (33.8\u00B0F)"},
+            {input: 1.0, showF: undefined, useUnicode: false, offThreshold: undefined, expected: "1.0&deg;C"},
+            {input: 1.0, showF: undefined, useUnicode: true, offThreshold: undefined, expected: "1.0\u00B0C"},
+            {input: 1.1, showF: undefined, useUnicode: undefined, offThreshold: undefined, expected: "1.1&deg;C"}
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            param["title"] = String(param.input) + String(param.showF) + String(param.useUnicode);
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatTemperature", function (params, assert) {
+    assert.equal(
+        params.expected,
+        formatTemperature(params.input, params.showF, params.offThreshold, params.useUnicode),
+        "As expected: " + String(params.expected)
+    );
+});


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Currently, when using a screen reader or hovering over the "Actual" temperature in the web UI, the degree symbol HTML entity is not being resolved and showing in a raw form (See screenshot below). From my investigation, this occurs on all browsers except Internet Explorer (where the title attribute is not shown at all on hover).

#### How was it tested? How can it be tested by the reviewer?

Built OctoPrint locally and validated the web UI in several browsers to ensure the title attribute is working as expected on hover. Added several unit tests to validate the changed method. 

Steps:
1. Load OctoPrint (don't need to connect a printer)
2. Click on the Temperature tab
3. Hover over "0.0°C" in the Actual column for the Tool. 
4. Notice the hover title is "0.0&amp;deg;C" when it should be "0.0°C"

#### Any background context you want to provide?
Discovered this initially on Firefox but found it reproduces on all browsers I had access to. A simple display issue but with screen readers, it can cause issues.

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)

##### Screenshot of current UI / Before screenshot
![image](https://user-images.githubusercontent.com/48865951/163942989-2ec4aaa9-eda8-4dab-b8e5-3eabff1ed1e5.png)

##### After screenshots
###### Chrome screenshot
![image](https://user-images.githubusercontent.com/48865951/163943159-e73c3207-041b-44a2-a072-b3fa073fc77c.png)

###### Edge (Chromium based) screenshot
![image](https://user-images.githubusercontent.com/48865951/163943208-6ffa48fb-1526-470c-b095-ba2255a52cb0.png)

###### Firefox screenshot
![image](https://user-images.githubusercontent.com/48865951/163943234-5e6ec0b6-ff76-4b4d-bcbc-d9c5b8f17ca4.png)


#### Further notes
I added the optional parameter for extendability and to help ensure there are no breaking changes here. I did test this with always using the unicode (/u00B0) and everything appeared to work correctly but my thinking is that it's safer with this optional parameter approach.

For the unit tests, the `formatTemperature` method calls "gettext" which required babel to be initialized. I have added the babel initialization to the test-helpers.html file to resolve this and confirmed the new unit tests are all passing here. 