### PR TITLE
Use lazy logging in octoprint. module

### DIFF
--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -497,8 +497,8 @@ def init_settings_plugin_config_migration_and_cleanup(plugin_manager):
             )
         except Exception:
             logging.getLogger(__name__).exception(
-                "Error while trying to migrate settings for "
-                "plugin {}, ignoring it".format(implementation._identifier),
+                "Error while trying to migrate settings for " "plugin %s, ignoring it",
+                implementation._identifier,
                 extra={"plugin": implementation._identifier},
             )
 
@@ -526,13 +526,16 @@ def init_custom_events(plugin_manager):
                         event, prefix=f"plugin_{name}_"
                     )
                     logger.debug(
-                        'Registered event {} of plugin {} as Events.{} = "{}"'.format(
-                            event, name, constant, value
-                        )
+                        'Registered event %s of plugin %s as Events. %s = "%s"',
+                        event,
+                        name,
+                        constant,
+                        value,
                     )
         except Exception:
             logger.exception(
-                f"Error while retrieving custom event list from plugin {name}",
+                "Error while retrieving custom event list from plugin %s",
+                name,
                 extra={"plugin": name},
             )
 
@@ -661,7 +664,7 @@ def init_pluginsystem(
                 disabled_from_overlays[name] = (disabled_plugins, order)
 
             settings_overlays[name] = overlay
-            logger.debug(f"Found settings overlay on plugin {name}")
+            logger.debug("Found settings overlay on plugin %s", name)
 
     def handle_plugins_loaded(
         startup=False, initialize_implementations=True, force_reload=None
@@ -686,24 +689,22 @@ def init_pluginsystem(
 
                     if addon in already_processed:
                         logger.info(
-                            "Plugin {} wants to disable plugin {}, but that was already processed".format(
-                                name, addon
-                            )
+                            "Plugin %s wants to disable plugin %s, but that was already processed",
+                            name,
+                            addon,
                         )
 
                     if addon not in already_processed and addon not in disabled_list:
                         disabled_list.append(addon)
                         logger.info(
-                            "Disabling plugin {} as defined by plugin {}".format(
-                                addon, name
-                            )
+                            "Disabling plugin %s as defined by plugin %s", addon, name
                         )
                 already_processed.append(name)
 
     def handle_plugin_enabled(name, plugin):
         if name in settings_overlays:
             settings.add_overlay(settings_overlays[name])
-            logger.info(f"Added settings overlay from plugin {name}")
+            logger.info("Added settings overlay from plugin %s", name)
 
     pm.on_plugin_loaded = handle_plugin_loaded
     pm.on_plugins_loaded = handle_plugins_loaded
@@ -756,22 +757,22 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
 
             if "pluginversions" in entry:
                 logger.debug(
-                    "Blacklisted plugin: {}, versions: {}".format(
-                        entry["plugin"], ", ".join(entry["pluginversions"])
-                    )
+                    "Blacklisted plugin: %s, versions: %s",
+                    entry["plugin"],
+                    ", ".join(entry["pluginversions"]),
                 )
                 for version in entry["pluginversions"]:
                     result.append((entry["plugin"], version))
             elif "versions" in entry:
                 logger.debug(
-                    "Blacklisted plugin: {}, versions: {}".format(
-                        entry["plugin"], ", ".join(entry["versions"])
-                    )
+                    "Blacklisted plugin: %s, versions: %s",
+                    entry["plugin"],
+                    ", ".join(entry["versions"]),
                 )
                 for version in entry["versions"]:
                     result.append((entry["plugin"], f"=={version}"))
             else:
-                logger.debug("Blacklisted plugin: {}".format(entry["plugin"]))
+                logger.debug("Blacklisted plugin: %s", entry["plugin"])
                 result.append(entry["plugin"])
 
         return result
@@ -808,9 +809,9 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
                     )
         except Exception as e:
             logger.info(
-                "Unable to fetch plugin blacklist from {}, proceeding without it: {}".format(
-                    url, e
-                )
+                "Unable to fetch plugin blacklist from %s, proceeding without it: %s",
+                url,
+                e,
             )
         return result
 
@@ -832,10 +833,9 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
 
         if blacklist:
             logger.info(
-                "Blacklist processing done, "
-                "adding {} blacklisted plugin versions: {}".format(
-                    len(blacklist), format_blacklist(blacklist)
-                )
+                "Blacklist processing done, adding %s blacklisted plugin versions: %s",
+                len(blacklist),
+                format_blacklist(blacklist),
             )
         else:
             logger.info("Blacklist processing done")


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed how OctoPrint uses eager logging almost everywhere, instead of lazy logging.
Lazy logging has a performance advantage, as the string interpolation will only take place if the logger is active.

Took the main `octoprint` module as a concept for acceptance.

#### How was it tested? How can it be tested by the reviewer?

Run it!

#### Any background context you want to provide?

See above :)

#### What are the relevant tickets if any?

🎟️  🙅 

#### Screenshots (if appropriate)

No, but I do have a nice picture of a taco rocket (Yeah SpaceX beat that!)

<img src="https://media1.giphy.com/media/3o7TKCTt7cNHg10utO/giphy.gif"/>

#### Further notes
