### PR TITLE
⬆️  Bump wrapt to fix Python 3.11 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -63,7 +63,7 @@ core_deps = [
     "watchdog>=1,<2",
     "websocket-client>=1.2.1,<2",
     "werkzeug>=2.1,<2.2",  # breaking changes can happen on minor version increases
-    "wrapt>=1.13.3,<1.14",
+    "wrapt>=1.14,<1.15",
     "zeroconf>=0.33,<0.34",  # breaking changes can happen on minor version increases
     "zipstream-ng>=1.3.4,<2.0.0",
 ]


### PR DESCRIPTION

#### What does this PR do and why is it necessary?
Bumps wrapt to a Python 3.11 compatible version.

#### How was it tested? How can it be tested by the reviewer?
Fully tested on 3.7, 3.10 and 3.11.0b1 - any issues that did exist appear to have been resolved. Windows install.

#### What are the relevant tickets if any?
#4488 