### PR TITLE
Record last fan speed

### DIFF
--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -84,6 +84,8 @@ All GCODE scripts have access to the following template variables through the te
     to the corresponding temperature in degrees Celsius. Note that not all tools your printer has must necessarily be
     present here, neither must the heated bed - it depends on whether OctoPrint has values for a tool or the bed. Also
     note that ``actual`` and ``target`` might be ``None``.
+  * ``last_fanspeed``: Last fan speed set. Consist of ``fanspeed`` taken from command (M106 and M107) sent through OctoPrint.
+    The ``fanspeed`` might be ``None`` if no fan speed has been set.
   * ``script``: An object wrapping the script's type (``gcode``) and name (e.g. ``afterPrintCancelled``) as ``script.type``
     and ``script.name`` respectively.
   * ``plugins``: An object containing variables provided by plugins (e.g ``plugins.myplugin.myvariable``)
@@ -99,6 +101,7 @@ There are a few additional template variables available for the following specif
       "Log position on pause" under Settings > Serial > Advanced options!
     * ``pause_temperature``: Last known temperature values when the print was paused. See ``last_temperature`` above
       for the structure to expect here.
+    * ``pause_fanspeed``: Last known fan speed value when the print was paused. See ``last_fanspeed`` above for the structure to expect here.
 
   * ``afterPrintCancelled``
 
@@ -109,6 +112,7 @@ There are a few additional template variables available for the following specif
       "Log position on cancel" under Settings > Serial > Advanced options!
     * ``cancel_temperature``: Last known temperature values when the print was cancelled. See ``last_temperature`` above
       for the structure to expect here.
+    * ``cancel_fanspeed``: Last known fan speed value when the print was cancelled. See ``last_fanspeed`` above for the structure to expect here.
 
   * ``beforeToolChange`` and ``afterToolChange``
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Implementation of #4040 
This PR adds last_fanspeed, pause_fanspeed and cancel_fanspeed, so we can pause and resume the fan directly from GCode scripts.

#### Task
* [x] Add self.last_fanspeed, self.pause_fanspeed, self.cancel_fanspeed to MachineCom object
* [x] Inject into
https://github.com/OctoPrint/OctoPrint/blob/5f7679b11baafc0bb58861c462b9e4568041080b/src/octoprint/util/comm.py#L1268-L1361
* [x] Record on pause/cancel in
https://github.com/OctoPrint/OctoPrint/blob/5f7679b11baafc0bb58861c462b9e4568041080b/src/octoprint/util/comm.py#L2516-L2528
* [x] Add _gcode_M106_sent to parse and set fan speed when sent to printer
* [x] Update docs

#### How was it tested? How can it be tested by the reviewer?
Tested with virtual printer, adding in pause and cancel GCode scripts:
`Fan speed when paused: {{ pause_fanspeed.fanspeed }}`
`Fan speed when canceled: {{ cancel_fanspeed.fanspeed }}`

#### What are the relevant tickets if any?
#4040

#### Further notes
In the settings, within Behaviour, there are the settings 'Log potision on pouse' and 'Log position on cancel'. Would it be appropriate to indicate that these settings are the same as those for the fan speed?