### PR TITLE
Add more unit tests for `helpers.js`

### DIFF
--- a/src/octoprint/static/js/app/helpers.js
+++ b/src/octoprint/static/js/app/helpers.js
@@ -1497,7 +1497,7 @@ var sizeObservable = function (observable) {
 var getQueryParameterByName = function (name, url) {
     // from http://stackoverflow.com/a/901144/2028598
     if (!url) {
-        url = window.location.href;
+        url = fetchWindowLocation().href;
     }
     name = name.replace(/[\[\]]/g, "\\$&");
     var regex = new RegExp("[?&]" + name + "(=([^&#]*)|&|#|$)"),

--- a/tests/static/js/test-helpers.html
+++ b/tests/static/js/test-helpers.html
@@ -10,6 +10,7 @@
         <div id="qunit-fixture"></div>
         <script src="lib/qunit-1.18.0.js"></script>
         <script src="lib/qunit-parameterize.js"></script>
+        <script src="../../../src/octoprint/static/js/lib/moment-with-locales.min.js"></script>
         <script src="../../../src/octoprint/static/js/lib/babel.js"></script>
         <script src="../../../src/octoprint/static/js/lib/lodash.min.js"></script>
         <script src="../../../src/octoprint/static/js/lib/sprintf.min.js"></script>

--- a/tests/static/js/test-helpers.js
+++ b/tests/static/js/test-helpers.js
@@ -7,36 +7,34 @@ QUnit.cases(
 
         var params = [
             // empty inputs
-            {input: undefined, expected: undefined},
-            {input: "", expected: undefined},
+            {title: "UndefinedSize", input: undefined, expected: undefined},
+            {title: "EmptySize", input: "", expected: undefined},
 
             // unknown units
-            {input: "1 PB", expected: undefined},
-            {input: "234.5 unknown", expected: undefined},
-            {input: "234.5unknown", expected: undefined},
+            {title: "UnknownPBSuffix", input: "1 PB", expected: undefined},
+            {title: "UnknownSuffixSpace", input: "234.5 unknown", expected: undefined},
+            {title: "UnknownSuffix", input: "234.5unknown", expected: undefined},
 
             // conversion
-            {input: "1", expected: 1},
-            {input: "1b", expected: 1},
-            {input: "1 B", expected: 1},
-            {input: "1 byte", expected: 1},
-            {input: "1 bYtES", expected: 1},
-            {input: "1.1", expected: 1.1},
-            {input: ".1", expected: 0.1},
-            {input: "1 KB", expected: 1024},
-            {input: "2 KB", expected: 2048},
-            {input: "1 MB", expected: Math.pow(1024, 2)},
-            {input: "500mb", expected: 500 * Math.pow(1024, 2)},
-            {input: "500.2mb", expected: 500.2 * Math.pow(1024, 2)},
-            {input: "1 GB", expected: Math.pow(1024, 3)},
-            {input: "1 TB", expected: Math.pow(1024, 4)}
+            {title: "WholeByteNoSuffix", input: "1", expected: 1},
+            {title: "WholeByteAbbreviatedSuffix", input: "1b", expected: 1},
+            {title: "WholeByteAbbreviatedSuffixSpace", input: "1 B", expected: 1},
+            {title: "WholeByteWordSuffix", input: "1 byte", expected: 1},
+            {title: "WholeByteWordSuffixCapitalization", input: "1 bYtES", expected: 1},
+            {title: "WholeFractionalBytesNoSuffix", input: "1.1", expected: 1.1},
+            {title: "FractionalBytesNoSuffix", input: ".1", expected: 0.1},
+            {title: "OneKilobyte", input: "1 KB", expected: 1024},
+            {title: "TwoKilobytes", input: "2 KB", expected: 2048},
+            {title: "OneMegabyte", input: "1 MB", expected: Math.pow(1024, 2)},
+            {title: "WholeMB", input: "500mb", expected: 500 * Math.pow(1024, 2)},
+            {title: "DecimalMB", input: "500.2mb", expected: 500.2 * Math.pow(1024, 2)},
+            {title: "OneGigabyte", input: "1 GB", expected: Math.pow(1024, 3)},
+            {title: "OneTerabyte", input: "1 TB", expected: Math.pow(1024, 4)}
         ];
 
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] =
-                param.input != undefined ? '"' + String(param.input) + '"' : "undefined";
             cases.push(param);
         }
 
@@ -44,8 +42,8 @@ QUnit.cases(
     })()
 ).test("bytesFromSize", function (params, assert) {
     assert.equal(
-        params.expected,
         bytesFromSize(params.input),
+        params.expected,
         "As expected: " + String(params.expected)
     );
 });
@@ -56,23 +54,22 @@ QUnit.cases(
         var cases = [];
 
         var params = [
-            {input: undefined, expected: "-"},
-            {input: "", expected: "-"},
-            {input: 1, expected: "1.0bytes"},
-            {input: 1.1, expected: "1.1bytes"},
-            {input: 1024, expected: "1.0KB"},
-            {input: 2048, expected: "2.0KB"},
-            {input: 2.2 * 1024, expected: "2.2KB"},
-            {input: 23.5 * Math.pow(1024, 2), expected: "23.5MB"},
-            {input: 23.5 * Math.pow(1024, 3), expected: "23.5GB"},
-            {input: 23.5 * Math.pow(1024, 4), expected: "23.5TB"},
-            {input: 2 * Math.pow(1024, 5), expected: "2048.0TB"}
+            {title: "UndefinedSize", input: undefined, expected: "-"},
+            {title: "EmptySize", input: "", expected: "-"},
+            {title: "WholeByte", input: 1, expected: "1.0bytes"},
+            {title: "FractionalBytes", input: 1.1, expected: "1.1bytes"},
+            {title: "OneKilobyte", input: 1024, expected: "1.0KB"},
+            {title: "TwoKilobytes", input: 2048, expected: "2.0KB"},
+            {title: "FractionalKilobytes", input: 2.2 * 1024, expected: "2.2KB"},
+            {title: "FractionalMB", input: 23.5 * Math.pow(1024, 2), expected: "23.5MB"},
+            {title: "FractionalGB", input: 23.5 * Math.pow(1024, 3), expected: "23.5GB"},
+            {title: "FractionalTB", input: 23.5 * Math.pow(1024, 4), expected: "23.5TB"},
+            {title: "PetabyteAsTB", input: 2 * Math.pow(1024, 5), expected: "2048.0TB"}
         ];
 
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] = String(param.input);
             cases.push(param);
         }
 
@@ -80,8 +77,8 @@ QUnit.cases(
     })()
 ).test("formatSize", function (params, assert) {
     assert.equal(
-        params.expected,
         formatSize(params.input),
+        params.expected,
         "As expected: " + String(params.expected)
     );
 });
@@ -93,6 +90,7 @@ QUnit.cases(
 
         var params = [
             {
+                title: "UndefinedTemperature",
                 input: undefined,
                 showF: undefined,
                 useUnicode: undefined,
@@ -100,6 +98,7 @@ QUnit.cases(
                 expected: "-"
             },
             {
+                title: "EmptyTemperature",
                 input: "",
                 showF: undefined,
                 useUnicode: undefined,
@@ -107,6 +106,7 @@ QUnit.cases(
                 expected: "-"
             },
             {
+                title: "TemperatureUnderOffThreshold",
                 input: 1.0,
                 showF: undefined,
                 useUnicode: undefined,
@@ -114,6 +114,7 @@ QUnit.cases(
                 expected: "off"
             },
             {
+                title: "TemperatureEqualToOffThreshold",
                 input: 1.0,
                 showF: undefined,
                 useUnicode: undefined,
@@ -121,6 +122,7 @@ QUnit.cases(
                 expected: "1.0&deg;C"
             },
             {
+                title: "TemperatureWithNoOffThreshold",
                 input: 1.0,
                 showF: undefined,
                 useUnicode: undefined,
@@ -128,6 +130,7 @@ QUnit.cases(
                 expected: "1.0&deg;C"
             },
             {
+                title: "TemperatureWithFahrenheit",
                 input: 1.0,
                 showF: true,
                 useUnicode: undefined,
@@ -135,6 +138,7 @@ QUnit.cases(
                 expected: "1.0&deg;C (33.8&deg;F)"
             },
             {
+                title: "TemperatureWithFahrenheitUnicode",
                 input: 1.0,
                 showF: true,
                 useUnicode: true,
@@ -142,6 +146,7 @@ QUnit.cases(
                 expected: "1.0\u00B0C (33.8\u00B0F)"
             },
             {
+                title: "TemperatureHtmlEntities",
                 input: 1.0,
                 showF: undefined,
                 useUnicode: false,
@@ -149,6 +154,7 @@ QUnit.cases(
                 expected: "1.0&deg;C"
             },
             {
+                title: "TemperatureUnicode",
                 input: 1.0,
                 showF: undefined,
                 useUnicode: true,
@@ -156,6 +162,7 @@ QUnit.cases(
                 expected: "1.0\u00B0C"
             },
             {
+                title: "TemperatureIncrease",
                 input: 1.1,
                 showF: undefined,
                 useUnicode: undefined,
@@ -167,11 +174,6 @@ QUnit.cases(
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] =
-                String(param.input) +
-                String(param.showF) +
-                String(param.offThreshold) +
-                String(param.useUnicode);
             cases.push(param);
         }
 
@@ -179,13 +181,13 @@ QUnit.cases(
     })()
 ).test("formatTemperature", function (params, assert) {
     assert.equal(
-        params.expected,
         formatTemperature(
             params.input,
             params.showF,
             params.offThreshold,
             params.useUnicode
         ),
+        params.expected,
         "As expected: " + String(params.expected)
     );
 });
@@ -197,31 +199,37 @@ QUnit.cases(
 
         var params = [
             {
+                title: "UndefinedUrlThrowsException",
                 streamUrl: undefined,
                 exceptionExpected: "Empty streamUrl. Cannot determine stream type.",
                 expectedResult: undefined
             },
             {
+                title: "InvalidUrlThrowsException",
                 streamUrl: "invalidUrl",
                 exceptionExpected: "Invalid streamUrl. Cannot determine stream type.",
                 expectedResult: undefined
             },
             {
+                title: "Webrtc",
                 streamUrl: "webrtc://localhost/stream",
                 exceptionExpected: undefined,
                 expectedResult: "webrtc"
             },
             {
+                title: "Webrtcs",
                 streamUrl: "webrtcs://localhost/stream",
                 exceptionExpected: undefined,
                 expectedResult: "webrtc"
             },
             {
+                title: "HlsPlaylist",
                 streamUrl: "https://localhost/stream.m3u8",
                 exceptionExpected: undefined,
                 expectedResult: "hls"
             },
             {
+                title: "DefaultMjpg",
                 streamUrl: "https://localhost/stream",
                 exceptionExpected: undefined,
                 expectedResult: "mjpg"
@@ -231,10 +239,6 @@ QUnit.cases(
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] =
-                String(param.streamUrl) +
-                String(param.exceptionExpected) +
-                String(param.expectedResult);
             cases.push(param);
         }
 
@@ -251,14 +255,14 @@ QUnit.cases(
     }
 
     assert.equal(
-        params.exceptionExpected,
         exceptionMessage,
+        params.exceptionExpected,
         "Exception expected: " + String(params.exceptionExpected)
     );
 
     assert.equal(
-        params.expectedResult,
         result,
+        params.expectedResult,
         "As expected: " + String(params.expectedResult)
     );
 });
@@ -270,60 +274,68 @@ QUnit.cases(
 
         var params = [
             {
+                title: "UndefinedUrlReturnsFalse",
                 streamUrl: undefined,
-                expected: false,
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: false
             },
             {
+                title: "RelativeProtocolUrl",
                 streamUrl: "//localhost/stream",
-                expected: new URL("https://localhost/stream"),
-                windowLocationOverride: {protocol: "https:"}
+                windowLocationOverride: {protocol: "https:"},
+                expected: new URL("https://localhost/stream")
             },
             {
+                title: "RelativePathUrl",
                 streamUrl: "/stream",
-                expected: new URL("https://localhost/stream"),
                 windowLocationOverride: {
                     protocol: "https:",
                     port: "443",
                     hostname: "localhost"
-                }
+                },
+                expected: new URL("https://localhost/stream")
             },
             {
+                title: "Http",
                 streamUrl: "http://localhost/stream",
-                expected: new URL("http://localhost/stream"),
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: new URL("http://localhost/stream")
             },
             {
+                title: "Https",
                 streamUrl: "https://localhost/stream",
-                expected: new URL("https://localhost/stream"),
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: new URL("https://localhost/stream")
             },
             {
+                title: "Webrtc",
                 streamUrl: "webrtc://localhost/stream",
-                expected: new URL("webrtc://localhost/stream"),
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: new URL("webrtc://localhost/stream")
             },
             {
+                title: "Webrtcs",
                 streamUrl: "webrtcs://localhost/stream",
-                expected: new URL("webrtcs://localhost/stream"),
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: new URL("webrtcs://localhost/stream")
             },
             {
+                title: "InvalidUrlReturnsFalse",
                 streamUrl: "invalid",
-                expected: false,
-                windowLocationOverride: undefined
+                windowLocationOverride: undefined,
+                expected: false
             },
             {
+                title: "ParsingExceptionReturnsFalse",
                 streamUrl: "//exception",
-                expected: false,
-                windowLocationOverride: {protocol: ":"}
+                windowLocationOverride: {protocol: ":"},
+                expected: false
             }
         ];
 
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] = String(param.streamUrl) + String(param.expected);
             cases.push(param);
         }
 
@@ -339,8 +351,8 @@ QUnit.cases(
     var result = validateWebcamUrl(params.streamUrl);
 
     assert.equal(
-        params.expected.toString(),
         result.toString(),
+        params.expected.toString(),
         "As expected: " + String(params.expected)
     );
 });
@@ -352,6 +364,7 @@ QUnit.cases(
 
         var params = [
             {
+                title: "HttpsDefaultPortOmitted",
                 windowLocation: {
                     protocol: "https:",
                     port: "443",
@@ -360,6 +373,7 @@ QUnit.cases(
                 expected: "https://localhost"
             },
             {
+                title: "HttpsNonDefaultPortNotOmitted",
                 windowLocation: {
                     protocol: "https:",
                     port: "8000",
@@ -367,8 +381,8 @@ QUnit.cases(
                 },
                 expected: "https://localhost:8000"
             },
-
             {
+                title: "HttpDefaultPortOmitted",
                 windowLocation: {
                     protocol: "http:",
                     port: "80",
@@ -377,6 +391,7 @@ QUnit.cases(
                 expected: "http://localhost"
             },
             {
+                title: "HttpNonDefaultPortNotOmitted",
                 windowLocation: {
                     protocol: "http:",
                     port: "8000",
@@ -389,11 +404,6 @@ QUnit.cases(
         var param, i;
         for (i = 0; i < params.length; i++) {
             param = params[i];
-            param["title"] =
-                String(param.windowLocation.protocol) +
-                "//" +
-                String(param.windowLocation.hostname) +
-                String(param.windowLocation.port);
             cases.push(param);
         }
 
@@ -407,6 +417,668 @@ QUnit.cases(
     }
 
     var result = getExternalHostUrl();
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
 
-    assert.equal(params.expected, result, "As expected: " + String(params.expected));
+QUnit.module("escapeUnprintableCharacters");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "EmptyText",
+                input: "",
+                isExpectingException: false,
+                expectedResult: ""
+            },
+            {
+                title: "UndefinedText",
+                input: undefined,
+                isExpectingException: true,
+                expectedResult: undefined
+            },
+            {
+                title: "PrintableTextUnchanged",
+                input: "Test123",
+                isExpectingException: false,
+                expectedResult: "Test123"
+            },
+            {
+                title: "MultipleCharacterAsHex",
+                input: "\x00\x01\x02",
+                isExpectingException: false,
+                expectedResult: "\\x00\\x01\\x02"
+            },
+            {
+                title: "MixedPrintableNonPrintable",
+                input: "\x00Hello123\x01",
+                isExpectingException: false,
+                expectedResult: "\\x00Hello123\\x01"
+            },
+            {
+                title: "NullCharacterAsHex",
+                input: "\x00",
+                isExpectingException: false,
+                expectedResult: "\\x00"
+            },
+            {
+                title: "UnitSeparatorCharacterAsHex",
+                input: "\x1F",
+                isExpectingException: false,
+                expectedResult: "\\x1f"
+            },
+            {
+                title: "DeleteCharacterAsHex",
+                input: "\x7F",
+                isExpectingException: false,
+                expectedResult: "\\x7f"
+            },
+            {
+                title: "ExtendedAsciiEuroAsHex",
+                input: "\x80",
+                isExpectingException: false,
+                expectedResult: "\\x80"
+            },
+            {
+                title: "ExtendedAsciiCapitalYumlAsHex",
+                input: "\x9F",
+                isExpectingException: false,
+                expectedResult: "\\x9f"
+            },
+            {
+                title: "ExtendedAsciiYumlAsHex",
+                input: "\xFF",
+                isExpectingException: false,
+                expectedResult: "\\xff"
+            },
+            {
+                title: "SpaceCharacterUnchanged",
+                input: " ",
+                isExpectingException: false,
+                expectedResult: " "
+            },
+            {
+                title: "TabCharacterUnchanged",
+                input: "\t",
+                isExpectingException: false,
+                expectedResult: "\t"
+            },
+            {
+                title: "LineFeedCharacterUnchanged",
+                input: "\x0A",
+                isExpectingException: false,
+                expectedResult: "\x0A"
+            },
+            {
+                title: "CarriageReturnCharacterUnchanged",
+                input: "\x0D",
+                isExpectingException: false,
+                expectedResult: "\x0D"
+            },
+            {
+                title: "UnicodeUnchanged",
+                input: "\u1F419",
+                isExpectingException: false,
+                expectedResult: "\u1F419"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("escapeUnprintableCharacters", function (params, assert) {
+    var result = undefined;
+    var exceptionThrown = false;
+
+    try {
+        result = escapeUnprintableCharacters(params.input);
+    } catch (ex) {
+        exceptionThrown = true;
+    }
+
+    assert.equal(
+        result,
+        params.expectedResult,
+        "As expected: " + String(params.expectedResult)
+    );
+    assert.equal(
+        exceptionThrown,
+        params.isExpectingException,
+        "As expected: " + String(params.expectedException)
+    );
+});
+
+QUnit.module("getQueryParameterByName");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "WindowLocationFirstParameter",
+                inputName: "parameter1",
+                inputUrl: undefined,
+                windowLocation: {
+                    href: "https://localhost/stream?parameter1=test&parameter2=value"
+                },
+                expected: "test"
+            },
+            {
+                title: "WindowLocationSecondParameter",
+                inputName: "parameter2",
+                inputUrl: undefined,
+                windowLocation: {
+                    href: "https://localhost/stream?parameter1=test&parameter2=value"
+                },
+                expected: "value"
+            },
+            {
+                title: "UrlFirstParameter",
+                inputName: "parameter1",
+                inputUrl: "https://localhost/stream?parameter1=test&parameter2=value",
+                windowLocation: undefined,
+                expected: "test"
+            },
+            {
+                title: "UrlSecondParameter",
+                inputName: "parameter2",
+                inputUrl: "https://localhost/stream?parameter1=test&parameter2=value",
+                windowLocation: undefined,
+                expected: "value"
+            },
+            {
+                title: "ArrayParameter",
+                inputName: "array[0]",
+                inputUrl: "https://localhost/stream?array[0]=first&array[1]=second",
+                windowLocation: undefined,
+                expected: "first"
+            },
+            {
+                title: "NoParameters",
+                inputName: "array[0]",
+                inputUrl: "https://localhost/stream",
+                windowLocation: undefined,
+                expected: null
+            },
+            {
+                title: "UnknownParameter",
+                inputName: "unknown",
+                inputUrl: "https://localhost/stream?parameter=first",
+                windowLocation: undefined,
+                expected: null
+            },
+            {
+                title: "EmptyParameter",
+                inputName: "parameter",
+                inputUrl: "https://localhost/stream?parameter=",
+                windowLocation: undefined,
+                expected: ""
+            },
+            {
+                title: "EmptyParameterNoEqual",
+                inputName: "parameter",
+                inputUrl: "https://localhost/stream?parameter",
+                windowLocation: undefined,
+                expected: ""
+            },
+            {
+                title: "PlusReplacedBySpace",
+                inputName: "Sentence",
+                inputUrl: "https://localhost/stream?Sentence=Hello+World",
+                windowLocation: undefined,
+                expected: "Hello World"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("getQueryParameterByName", function (params, assert) {
+    if (params.windowLocation) {
+        fetchWindowLocation = function () {
+            return params.windowLocation;
+        };
+    }
+
+    var result = getQueryParameterByName(params.inputName, params.inputUrl);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
+
+QUnit.module("formatNumberK");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedNumber",
+                input: undefined,
+                expectedException: "[sprintf] expecting number but found undefined",
+                expectedResult: undefined
+            },
+            {
+                title: "Text",
+                input: "text",
+                expectedException: "[sprintf] expecting number but found string",
+                expectedResult: undefined
+            },
+            {
+                title: "Zero",
+                input: 0,
+                expectedException: undefined,
+                expectedResult: "0"
+            },
+            {
+                title: "Thousand",
+                input: 1000,
+                expectedException: undefined,
+                expectedResult: "1000"
+            },
+            {
+                title: "ThousandOne",
+                input: 1001,
+                expectedException: undefined,
+                expectedResult: "1.00k"
+            },
+            {
+                title: "ThousandTen",
+                input: 1010,
+                expectedException: undefined,
+                expectedResult: "1.01k"
+            },
+            {
+                title: "Decimal",
+                input: 0.1,
+                expectedException: undefined,
+                expectedResult: "0"
+            },
+            {
+                title: "Negative",
+                input: -1,
+                expectedException: undefined,
+                expectedResult: "-1"
+            },
+            {
+                title: "NegativeThousandOne",
+                input: -1001,
+                expectedException: undefined,
+                expectedResult: "-1001"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatNumberK", function (params, assert) {
+    var result = undefined;
+    var exceptionMessage = undefined;
+
+    try {
+        result = formatNumberK(params.input);
+    } catch (ex) {
+        exceptionMessage = ex.message;
+    }
+
+    assert.equal(
+        result,
+        params.expectedResult,
+        "As expected: " + String(params.expectedResult)
+    );
+    assert.equal(
+        exceptionMessage,
+        params.expectedException,
+        "As expected: " + String(params.expectedException)
+    );
+});
+
+QUnit.module("formatHuman");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedNumber",
+                input: undefined,
+                expected: "-"
+            },
+            {
+                title: "Text",
+                input: "text",
+                expected: "-NaNK"
+            },
+            {
+                title: "Zero",
+                input: 0,
+                expected: "0"
+            },
+            {
+                title: "Thousand",
+                input: 1000,
+                expected: "1.0K"
+            },
+            {
+                title: "ThousandOne",
+                input: 1001,
+                expected: "1.0K"
+            },
+            {
+                title: "ThousandTen",
+                input: 1100,
+                expected: "1.1K"
+            },
+            {
+                title: "Decimal",
+                input: 0.1,
+                expected: "0.1"
+            },
+            {
+                title: "Negative",
+                input: -1,
+                expected: "-1"
+            },
+            {
+                title: "NegativeThousandOne",
+                input: -1001,
+                expected: "-1001"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatHuman", function (params, assert) {
+    var result = formatHuman(params.input);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
+
+QUnit.module("cleanTemperature");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedNumber",
+                temp: undefined,
+                offThreshold: undefined,
+                expected: "-"
+            },
+            {
+                title: "EmptyNumber",
+                temp: "",
+                offThreshold: undefined,
+                expected: "-"
+            },
+            {
+                title: "Text",
+                temp: "A",
+                offThreshold: undefined,
+                expected: "-"
+            },
+            {
+                title: "One",
+                temp: 1,
+                offThreshold: undefined,
+                expected: "1"
+            },
+            {
+                title: "Zero",
+                temp: 0,
+                offThreshold: undefined,
+                expected: "0"
+            },
+            {
+                title: "BelowThreshold",
+                temp: 0,
+                offThreshold: 1,
+                expected: "off"
+            },
+            {
+                title: "AboveThreshold",
+                temp: 1,
+                offThreshold: 0,
+                expected: "1"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("cleanTemperature", function (params, assert) {
+    var result = cleanTemperature(params.temp, params.offThreshold);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
+
+QUnit.module("formatFilament");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedFilament",
+                filament: undefined,
+                expected: "-"
+            },
+            {
+                title: "UndefinedLength",
+                filament: {length: undefined},
+                expected: "-"
+            },
+            {
+                title: "PositiveFilamentNoVolume",
+                filament: {length: 1},
+                expected: "0.00m"
+            },
+            {
+                title: "PositiveFilamentDecimal",
+                filament: {length: 10},
+                expected: "0.01m"
+            },
+            {
+                title: "OneMeterFilament",
+                filament: {length: 1000},
+                expected: "1.00m"
+            },
+            {
+                title: "PositiveFilamentUndefinedVolume",
+                filament: {length: 1, volume: undefined},
+                expected: "0.00m"
+            },
+            {
+                title: "PositiveFilamentWithVolume",
+                filament: {length: 1, volume: 1},
+                expected: "0.00m / 1.00cm\u00B3"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatFilament", function (params, assert) {
+    var result = formatFilament(params.filament);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
+
+QUnit.module("formatTimeAgo");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedTimestamp",
+                unixTimestamp: undefined,
+                expected: "-"
+            },
+            {
+                title: "ZeroTimestamp",
+                unixTimestamp: 0,
+                expected: "-"
+            },
+            {
+                title: "RecentTimestamp",
+                unixTimestamp: moment().unix() - 1,
+                expected: "a few seconds ago"
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatTimeAgo", function (params, assert) {
+    var result = formatTimeAgo(params.unixTimestamp);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
+});
+
+QUnit.module("splitTextToArray");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "EmptyText",
+                input: "",
+                sep: undefined,
+                stripEmpty: false,
+                filter: undefined,
+                expected: [""]
+            },
+            {
+                title: "EmptyTextStripEmpty",
+                input: "",
+                sep: undefined,
+                stripEmpty: true,
+                filter: undefined,
+                expected: []
+            },
+            {
+                title: "Text",
+                input: "text",
+                sep: undefined,
+                stripEmpty: false,
+                filter: undefined,
+                expected: ["text"]
+            },
+            {
+                title: "TextSeparator",
+                input: "te#xt",
+                sep: "#",
+                stripEmpty: false,
+                filter: undefined,
+                expected: ["te", "xt"]
+            },
+            {
+                title: "TrimmedText",
+                input: "te # xt",
+                sep: "#",
+                stripEmpty: false,
+                filter: undefined,
+                expected: ["te", "xt"]
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("splitTextToArray", function (params, assert) {
+    var result = splitTextToArray(
+        params.input,
+        params.sep,
+        params.stripEmpty,
+        params.filter
+    );
+    assert.equal(
+        JSON.stringify(result),
+        JSON.stringify(params.expected),
+        "As expected: " + String(params.expected)
+    );
+});
+
+QUnit.module("formatDate");
+QUnit.cases(
+    (function () {
+        var cases = [];
+
+        var params = [
+            {
+                title: "UndefinedTimestamp",
+                unixTimestamp: undefined,
+                options: undefined,
+                expected: "-"
+            },
+            {
+                title: "Millennium",
+                unixTimestamp: 946684800,
+                options: undefined,
+                expected: moment.unix(946684800).format("YYYY-MM-DD HH:mm")
+            },
+            {
+                title: "ExplicitNoSeconds",
+                unixTimestamp: 10,
+                options: {seconds: false},
+                expected: moment.unix(10).format("YYYY-MM-DD HH:mm")
+            },
+            {
+                title: "WithSeconds",
+                unixTimestamp: 10,
+                options: {seconds: true},
+                expected: moment.unix(10).format("YYYY-MM-DD HH:mm:ss")
+            }
+        ];
+
+        var param, i;
+        for (i = 0; i < params.length; i++) {
+            param = params[i];
+            cases.push(param);
+        }
+
+        return cases;
+    })()
+).test("formatDate", function (params, assert) {
+    var result = formatDate(params.unixTimestamp, params.options);
+    assert.equal(result, params.expected, "As expected: " + String(params.expected));
 });


### PR DESCRIPTION
<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR is adding tests for 9 methods in `helpers.js` with a total of 70 new unit tests (95 new asserts).

#### How was it tested? How can it be tested by the reviewer?
Validated by opening `test-helpers.html` locally in FireFox, Chrome, and Edge and verified all tests passed.

Also validated by running `node-qunit-puppeteer tests/static/js/test-helpers.html` locally and in the pipeline here: https://github.com/richardsondev/OctoPrint/runs/6747739463?check_suite_focus=true

The pipeline for this PR should also invoke the tests.

Output:
```
Test run result: success
Total tests: 129
  Assertions: 160
  Passed assertions: 160
  Failed assertions: 0
  Elapsed: 71ms
```

#### Any background context you want to provide?
Similar to this PR: #4529
These tests will run automatically in the build pipeline with this PR: #4534

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
https://github.com/richardsondev/OctoPrint/actions/runs/2444599075
![image](https://user-images.githubusercontent.com/48865951/172074243-149dc286-c066-4afe-848a-ab12dca98131.png)

#### Further notes
1. Switched the `assert.equals` usage to be `(actual, expected)` as per the documentation for QUnit: https://api.qunitjs.com/assert/equal/   -- before we were passing `(expected, actual)`
2. Added titles to each unit test due to the limitations of automatically generating the test names with complex input like arrays. Custom titles also allow us to be more descriptive about what is being tested.
3. Added a reference to `moment-with-locales.min.js` in `test-helpers.html` because one of the methods being tested invokes moment. I chose to not hard-code the expected result for these moment tests as the result could change depending on the timezone of the machine the tests are running on.