### PR TITLE
Add a display indication when the Github access token is set

### DIFF
--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -704,7 +704,6 @@ class SoftwareUpdatePlugin(
             "updatelog_cutoff": 30 * 24 * 60,  # 30 days
             "credentials": {
                 "github": None,
-                "github_set": False,
                 "bitbucket_user": None,
                 "bitbucket_password": None,
             },
@@ -714,14 +713,11 @@ class SoftwareUpdatePlugin(
         # ensure we don't persist check configs we receive on the API
         data = dict(octoprint.plugin.SettingsPlugin.on_settings_load(self))
 
-        # set credentials data flags and remove credentials fields
-        if "credentials" in data:
-            if "github" in data["credentials"]:
-                data["credentials"]["github_set"] = bool(data["credentials"]["github"])
-            for key in data["credentials"]:
-                if key == "github_set":
-                    continue
-                data["credentials"][key] = None
+        # set credentials flag
+        credentials = self._settings.get(["credentials"])
+        data["credentials"] = {}
+        for key, value in credentials.items():
+            data["credentials"][f"{key}_set"] = bool(value)
 
         if "checks" in data:
             del data["checks"]
@@ -779,7 +775,7 @@ class SoftwareUpdatePlugin(
         return data
 
     def get_settings_restricted_paths(self):
-        return {}
+        return {"never": [["credentials"]]}
 
     def on_settings_save(self, data):
         # ~~ plugin settings

--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -704,6 +704,7 @@ class SoftwareUpdatePlugin(
             "updatelog_cutoff": 30 * 24 * 60,  # 30 days
             "credentials": {
                 "github": None,
+                "github_set": False,
                 "bitbucket_user": None,
                 "bitbucket_password": None,
             },
@@ -712,6 +713,19 @@ class SoftwareUpdatePlugin(
     def on_settings_load(self):
         # ensure we don't persist check configs we receive on the API
         data = dict(octoprint.plugin.SettingsPlugin.on_settings_load(self))
+
+        # set credentials data flags and remove credentials fields
+        if "credentials" in data:
+            if "github" in data["credentials"]:
+                data["credentials"]["github_set"] = (
+                    data["credentials"]["github"] is not None
+                    and data["credentials"]["github"] != ""
+                )
+            for key in data["credentials"]:
+                if key == "github_set":
+                    continue
+                data["credentials"][key] = None
+
         if "checks" in data:
             del data["checks"]
 
@@ -768,7 +782,7 @@ class SoftwareUpdatePlugin(
         return data
 
     def get_settings_restricted_paths(self):
-        return {"never": [["credentials"]]}
+        return {}
 
     def on_settings_save(self, data):
         # ~~ plugin settings

--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -717,10 +717,7 @@ class SoftwareUpdatePlugin(
         # set credentials data flags and remove credentials fields
         if "credentials" in data:
             if "github" in data["credentials"]:
-                data["credentials"]["github_set"] = (
-                    data["credentials"]["github"] is not None
-                    and data["credentials"]["github"] != ""
-                )
+                data["credentials"]["github_set"] = bool(data["credentials"]["github"])
             for key in data["credentials"]:
                 if key == "github_set":
                     continue

--- a/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
+++ b/src/octoprint/plugins/softwareupdate/static/js/softwareupdate.js
@@ -65,6 +65,7 @@ $(function () {
         self.config_pipEnableCheck = ko.observable();
         self.config_minimumFreeStorage = ko.observable();
         self.config_githubToken = ko.observable();
+        self.config_githubTokenSet = ko.observable(false);
 
         self.error_checkoutFolder = ko.pureComputed(function () {
             return (
@@ -333,6 +334,10 @@ $(function () {
 
             self.config_minimumFreeStorage(
                 self.settings.settings.plugins.softwareupdate.minimum_free_storage()
+            );
+
+            self.config_githubTokenSet(
+                self.settings.settings.plugins.softwareupdate.credentials.github_set()
             );
         };
 

--- a/src/octoprint/plugins/softwareupdate/templates/snippets/githubToken.jinja2
+++ b/src/octoprint/plugins/softwareupdate/templates/snippets/githubToken.jinja2
@@ -1,7 +1,12 @@
 <div class="control-group">
     <label class="control-label">{{ _('GitHub Access Token') }}</label>
     <div class="controls">
+        <!-- ko if : config_githubTokenSet -->
+        <input type="text" class="input-block-level" data-bind="value: config_githubToken" placeholder="{{ _('Token entered but hidden for privacy reasons')|edq }}">
+        <!-- /ko -->
+        <!-- ko ifnot : config_githubTokenSet -->
         <input type="text" class="input-block-level" data-bind="value: config_githubToken" placeholder="{{ _('Enter a new token...')|edq }}">
+        <!-- /ko -->
         <span class="help-block">{{ _('Set this if you keep running into rate limiting issues. <a href="%(url)s" target="_blank" rel="noopener noreferer">See here for how to obtain a token</a>.', url="https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token") }}</span>
     </div>
 </div>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
Implementation of #4520 
This PR adds a computed flag to indicate to the view whether or not to show the input of the Github authentication token with a specific placeholder (if not present/if already present but hidden)

#### How was it tested? How can it be tested by the reviewer?
Start OctoPrint, display token placeholder when not present. Add the token to view the updated placeholder.

#### Any background context you want to provide?

#### What are the relevant tickets if any?
#4520 

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/25205086/173207041-d51fda36-ab8c-43ab-8ada-0ce94f23a829.png)
![image](https://user-images.githubusercontent.com/25205086/173207040-3bb71e5b-b392-42f4-b9ef-4dd0f9c6199c.png)

#### Further notes
I am not entirely sure if this implementation is the most correct one. Please let me know if you have any suggestions.

Also, as mentioned in #4520 , it is currently not possible to remove the token entered via the interface. If I can in the next few days I will create a request and start working on it.