### PR TITLE
:bug: gcodeInterpreter: Avoid ZeroDivisionError with firmware retraction

### DIFF
--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -678,10 +678,17 @@ class gcode:
                 f = getCodeFloat(line, "F")
                 if s is not None and f is not None:
                     if gcode == "M207":
-                        fwretractTime = s / f
+                        # Ensure division is valid
+                        if f > 0:
+                            fwretractTime = s / f
+                        else:
+                            fwretractTime = 0
                         fwretractDist = s
                     else:
-                        fwrecoverTime = (fwretractDist + s) / f
+                        if f > 0:
+                            fwrecoverTime = (fwretractDist + s) / f
+                        else:
+                            fwrecoverTime = 0
             elif gcode == "M605":  # Duplication/Mirroring mode
                 s = getCodeInt(line, "S")
                 if s in [2, 4, 5, 6]:


### PR DESCRIPTION

#### What does this PR do and why is it necessary?

Avoid crashing if the F parameter is 0, through a ZeroDivisionError

#### How was it tested? How can it be tested by the reviewer?

See file in issue #4554 for reproduction and now confirm it is fixed

#### What are the relevant tickets if any?

Closes #4554