### PR TITLE
Fix/4525

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -166,6 +166,7 @@ date of first contribution):
   * [Nicu Surdu](https://github.com/surdu)
   * [Zack Lewis](https://github.com/lima3w)
   * [Billy Richardson](https://github.com/richardsondev)
+  * [Christian Bianchini](https://github.com/max246)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/static/js/lib/jquery/jquery.bootstrap.wizard.js
+++ b/src/octoprint/static/js/lib/jquery/jquery.bootstrap.wizard.js
@@ -270,7 +270,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 		// remove the existing handlers
 		$('a[data-toggle="tab"]', $navigation).off('click', innerTabClick);
-		$('a[data-toggle="tab"]', $navigation).off('show show.bs.tab', innerTabShown);
+		$('a[data-toggle="tab"]', $navigation).off('show', innerTabShown);
 
 		// reset elements based on current state of the DOM
 		$navigation = element.find('ul:first', element);
@@ -278,7 +278,7 @@ var bootstrapWizardCreate = function(element, options) {
 
 		// re-add handlers
 		$('a[data-toggle="tab"]', $navigation).on('click', innerTabClick);
-		$('a[data-toggle="tab"]', $navigation).on('show show.bs.tab', innerTabShown);
+		$('a[data-toggle="tab"]', $navigation).on('show', innerTabShown);
 
 		obj.fixNavigationButtons();
 	};
@@ -303,7 +303,8 @@ var bootstrapWizardCreate = function(element, options) {
 	$('a[data-toggle="tab"]', $navigation).on('click', innerTabClick);
 
 	// attach to both show and show.bs.tab to support Bootstrap versions 2.3.2 and 3.0.0
-	$('a[data-toggle="tab"]', $navigation).on('show show.bs.tab', innerTabShown);
+	// Note: removing show.bs.tab in the listener stops to trigger twice the method innerTabShown
+	$('a[data-toggle="tab"]', $navigation).on('show', innerTabShown);
 };
 $.fn.bootstrapWizard = function(options) {
 	//expose methods


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [] ~If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket~
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the AUTHORS.md file :)

#### What does this PR do and why is it necessary?

Fix the double trigger of the innerTabShown by removing one listener action.
This is a fix for this ticket #4525

#### How was it tested? How can it be tested by the reviewer?

I have tested on the local enviroment and it can be tested by running the wizard

#### Any background context you want to provide?

#### What are the relevant tickets if any?

Ticket #4525

#### Screenshots (if appropriate)

#### Further notes

Might need to keep an eye regarding the previous note left about bootstrap and the reason why there were two actions