### PR TITLE
Fix improper use of sys.version - again

### DIFF
--- a/src/octoprint/plugins/softwareupdate/version_checks/git_commit.py
+++ b/src/octoprint/plugins/softwareupdate/version_checks/git_commit.py
@@ -38,9 +38,7 @@ def _git(args, cwd, hide_stderr=False):
     else:
         return None, None
 
-    stdout = p.communicate()[0].strip()
-    if sys.version >= "3":
-        stdout = stdout.decode()
+    stdout = p.communicate()[0].strip().decode()
 
     if p.returncode != 0:
         return p.returncode, None

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -6,7 +6,7 @@ import base64
 import logging
 import sys
 
-PY3 = sys.version_info[0] == 3  # should now always be true, kept for plugins
+PY3 = sys.version_info >= (3, 0)  # should now always be True, kept for plugins
 
 import flask as _flask
 import flask_login


### PR DESCRIPTION
Like #4571 but on the `maintenance` branch.

<!--
Thank you for your interest into contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well that contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's devel branch if it's a completely
    new feature, or maintenance if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against master or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of master, maintenance or devel please),
    e.g. dev/my_new_feature or fix/my_bugfix
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [ ] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    .less source files, not the .css files (those are generated with
    lessc)
  * [ ] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the AUTHORS.md file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

`sys.version >= "3"` would fail on Python 4 and higher. 

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
