### PR TITLE
Fix - Invert start and end angles for G02 commands in gcode interpreter

### DIFF
--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -547,7 +547,7 @@ class gcode:
                 startAngle = math.atan2(oldPos.y - centerArc.y, oldPos.x - centerArc.x)
                 endAngle = math.atan2(pos.y - centerArc.y, pos.x - centerArc.x)
 
-                if gcode == "G2":
+                if gcode in ("G2", "G02"):
                     startAngle, endAngle = endAngle, startAngle
                 if startAngle < 0:
                     startAngle += math.pi * 2


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR fixes a bug in the gcode interpreter that incorrectly calculated the min/max of `G02` commands.
`G2` commands have their start and end angles swapped so they may be treated as `G3` arcs, the angles do not get swapped for `G02` commands.

#### How was it tested? How can it be tested by the reviewer?

- Load one of the attached gcode files: [arc_test_files.zip](https://github.com/OctoPrint/OctoPrint/files/9113517/arc_test_files.zip)
- Observe the following model sizes:

| Filename                   | MinX Before | MinX After |
|:----------------------|-------------:|------------:|
| `test_arc_G2.gcode`   |         9.014  |         9.014 |
| `test_arc_G02.gcode` |         -7.089 |         9.014 |
| `test_arc_G3.gcode`   |         -7.089 |       -7.089 |
| `test_arc_G03.gcode` |         -7.089 |       -7.089 |



#### What are the relevant tickets if any?

Not a ticket, but this is a bugfix for PR #4437.

#### Screenshots (if appropriate)

| How G02 arcs are currently analyzed | How G02 arcs should be analyzed |
|:--------------------------------------:|:-----------------------------------:|
| ![bad_g02_arc](https://user-images.githubusercontent.com/7365747/179030684-a3a4b2a2-446a-43ff-aa9d-c87ce0836b69.png) | ![good_g02_arc](https://user-images.githubusercontent.com/7365747/179030637-d15ba9d4-e7e5-4113-a086-8594e888ca55.png) |

#### Further notes
