### PR TITLE
Fix - Use G2/G3 arc length for estimating print time

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -167,6 +167,7 @@ date of first contribution):
   * [Zack Lewis](https://github.com/lima3w)
   * [Billy Richardson](https://github.com/richardsondev)
   * [Christian Bianchini](https://github.com/max246)
+  * [Kestin Goforth](https://github.com/kforth)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -587,8 +587,13 @@ class gcode:
                 else:
                     e = 0
 
+                # calculate 3d arc length
+                arcLengthXYZ = math.sqrt(
+                    (oldPos.z - pos.z) ** 2 + ((endAngle - startAngle) * r) ** 2
+                )
+
                 # move time in x, y, z, will be 0 if no movement happened
-                moveTimeXYZ = abs((oldPos - pos).length / feedrate)
+                moveTimeXYZ = abs(arcLengthXYZ / feedrate)
 
                 # time needed for extruding, will be 0 if no extrusion happened
                 extrudeTime = abs(e / feedrate)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR uses the 3D arc length of `G2` and `G3` commands for estimating the print time.

Currently the analysis uses the linear distance between the start and end points, which causes the estimated print time to be wrong if there are considerably long `G2` or `G3` moves.

#### How was it tested? How can it be tested by the reviewer?

- Load one of the attached gcode files: [arc_len_test_files.zip](https://github.com/OctoPrint/OctoPrint/files/9114732/arc_len_test_files.zip)
- Observe the following estimated print times in .metadata.json:

| Filename                          | Print Time Before | Print Time After |
| :------------------------- | -----------------: | ---------------: |
| `arc_len_test.gcode`          |                    60.0 |            111.275 |
| `arc_len_test_z100.gcode` |              600.749 |            610.231 |
| `arc_welder_test.gcode`    |            6139.248 |        10964.207 |

#### Screenshots (if appropriate)

| How G2/G3 print time is currently analyzed | How G2/G3 print time should be analyzed |
| :--------------------: | :---------------------: |
| `G2 X3 Y4 R-20 E10` | `G2 X3 Y4 R-20 E10` |
| ![bad_arc](https://user-images.githubusercontent.com/7365747/179061365-c48d6427-1984-42bb-9a4e-889395462c7c.png) | ![good_arc](https://user-images.githubusercontent.com/7365747/179061394-566677b8-205c-42a6-8d6e-4e059db12a51.png) |

#### Further notes


