### PR TITLE
Fix/4582 - Fix gcodeviewer rendering G02 and G03 commands as lines

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
@@ -480,8 +480,10 @@ var doParse = function () {
                         center_j = Number(args[j].slice(1));
                         break;
                     case "g":
-                        if (/^(?:G2|G02)(\.\d+)?\s/i.test(line)) direction = -1;
-                        else if (/^(?:G3|G03)(\.\d+)?\s/i.test(line)) direction = 1;
+                        if (args[j].charAt(1) === "2" || args[j].charAt(2) === "2")
+                            direction = -1;
+                        else if (args[j].charAt(1) === "3" || args[j].charAt(2) === "3")
+                            direction = 1;
                         break;
                 }
             }

--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
@@ -480,8 +480,8 @@ var doParse = function () {
                         center_j = Number(args[j].slice(1));
                         break;
                     case "g":
-                        if (args[j].charAt(1).toLowerCase() === "2") direction = -1;
-                        if (args[j].charAt(1).toLowerCase() === "3") direction = 1;
+                        if (/^(?:G2|G02)(\.\d+)?\s/i.test(line)) direction = -1;
+                        else if (/^(?:G3|G03)(\.\d+)?\s/i.test(line)) direction = 1;
                         break;
                 }
             }


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR is a proposed fix to issue #4582.

The gcodeviewer currently renders G02 and G03 commands as straight lines instead of arcs.

#### How was it tested? How can it be tested by the reviewer?

- Upload the test file: [arc_test_G02_G03.gcode.zip](https://github.com/OctoPrint/OctoPrint/files/9137000/arc_test_G02_G03.gcode.zip)
- Observe the gcodeviewer and verify the file renders correctly

#### What are the relevant tickets if any?

This is related to issue #4582.

#### Screenshots (if appropriate)

| How `G02` and `G03` are currently rendered | How `G02` and `G03` should be rendered |
|:-:|:-:|
| ![Rendered Before](https://user-images.githubusercontent.com/7365747/179652320-16463984-8036-4561-8e5d-796097035e9f.png) | ![Rendered After](https://user-images.githubusercontent.com/7365747/179652348-45242e52-1f97-4df6-9e8c-f4f05203c980.png) |

#### Further notes

You could probably use a simpler regex expression but I decided to keep the style from the test above so that it's more clear.
