### PR TITLE
Improve - Better error handling for uploading and removing files and folders

### DIFF
--- a/src/octoprint/filemanager/storage.py
+++ b/src/octoprint/filemanager/storage.py
@@ -740,7 +740,7 @@ class LocalFileStorage(StorageInterface):
         ):
             raise StorageError(
                 f"{destination_name} does already exist in {destination_path}",
-                code=StorageError.INVALID_DESTINATION,
+                code=StorageError.ALREADY_EXISTS,
             )
 
         source_meta = self._get_metadata_entry(source_path, source_name)

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1779,9 +1779,9 @@ $(function () {
             }
             error += "</p>";
 
-            if (data.jqXHR.responseText) {
+            if (data.jqXHR.responseJSON && data.jqXHR.responseJSON.error) {
                 error += pnotifyAdditionalInfo(
-                    "<pre>" + _.escape(data.jqXHR.responseText) + "</pre>"
+                    "<pre>" + _.escape(data.jqXHR.responseJSON.error) + "</pre>"
                 );
             }
             new PNotify({

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -888,8 +888,27 @@ $(function () {
                             deferred.reject();
                         });
                 })
-                .fail(function () {
+                .fail(function (data) {
                     deferred.reject();
+
+                    // Notify user
+                    var error =
+                        "<p>" +
+                        gettext(
+                            "Could not remove entry. Please check octoprint.log for possible reasons."
+                        ) +
+                        "</p>";
+                    if (data.responseJSON && data.responseJSON.error) {
+                        error += pnotifyAdditionalInfo(
+                            "<pre>" + _.escape(data.responseJSON.error) + "</pre>"
+                        );
+                    }
+                    new PNotify({
+                        title: gettext("Failed to remove entry"),
+                        text: error,
+                        type: "error",
+                        hide: false
+                    });
                 });
 
             return deferred.promise().always(function () {

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1603,6 +1603,7 @@ $(function () {
         self._handleUploadAdd = function (e, data) {
             var file = data.files[0];
             var path = self.currentPath();
+            var fileSizeTooBig = file.size > self.freeSpace();
 
             var formData = {};
             if (path !== "") {
@@ -1619,10 +1620,13 @@ $(function () {
                                     name: file.name
                                 })
                             );
+                            $("p, form", self.uploadExistsDialog).toggle(!fileSizeTooBig);
+                            $("span", self.uploadExistsDialog).toggle(fileSizeTooBig);
                             $("input", self.uploadExistsDialog)
                                 .val("")
                                 .prop("placeholder", response.suggestion);
                             $("a.upload-rename", self.uploadExistsDialog)
+                                .toggle(!fileSizeTooBig)
                                 .prop("disabled", false)
                                 .off("click")
                                 .on("click", function () {
@@ -1678,8 +1682,35 @@ $(function () {
                         }
                     });
             } else {
-                data.formData = formData;
-                data.submit();
+                if (fileSizeTooBig) {
+                    var error =
+                        "<p>" +
+                        gettext(
+                            "Could not upload the file. There is not enough disk space remaining."
+                        ) +
+                        "</p>";
+
+                    error +=
+                        "<pre>" +
+                        _.sprintf(gettext("Free Space: %(freespace)s"), {
+                            freespace: self.freeSpaceString()
+                        }) +
+                        "<br>" +
+                        _.sprintf(gettext("File Size: %(filesize)s"), {
+                            filesize: formatSize(file.size)
+                        }) +
+                        "</pre>";
+
+                    new PNotify({
+                        title: "Upload failed",
+                        text: error,
+                        type: "error",
+                        hide: false
+                    });
+                } else {
+                    data.formData = formData;
+                    data.submit();
+                }
             }
         };
 

--- a/src/octoprint/templates/dialogs/files.jinja2
+++ b/src/octoprint/templates/dialogs/files.jinja2
@@ -64,6 +64,9 @@
                 </div>
             </div>
         </form>
+        <span hidden>
+            {{ _('There is not enough free disk space to keep the existing file and upload this one.') }}
+        </span>
     </div>
     <div class="modal-footer">
         <a href="javascript:void(0)" class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</a>

--- a/tests/filemanager/test_localstorage.py
+++ b/tests/filemanager/test_localstorage.py
@@ -292,7 +292,7 @@ class LocalStorageTest(unittest.TestCase):
             getattr(self.storage, operation)("bp_case.stl", "test/crazyradio.stl")
             self.fail("Expected an exception")
         except StorageError as e:
-            self.assertEqual(e.code, StorageError.INVALID_DESTINATION)
+            self.assertEqual(e.code, StorageError.ALREADY_EXISTS)
 
     def test_add_folder(self):
         self._add_and_verify_folder("test", "test")
@@ -481,7 +481,7 @@ class LocalStorageTest(unittest.TestCase):
             getattr(self.storage, operation)("source", "destination/copied")
             self.fail("Expected an exception")
         except StorageError as e:
-            self.assertEqual(e.code, StorageError.INVALID_DESTINATION)
+            self.assertEqual(e.code, StorageError.ALREADY_EXISTS)
 
     def test_list(self):
         bp_case_stl = self._add_and_verify_file(


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR improves the error handling for file/folder upload and removal.
This PR also prevents uploading a file if there's not enough free disk space (can still overwrite).

This PR solves 2 main issues:
- If a file or folder is currently inaccessible and OctoPrint fails to remove it, it will do it silently.
- If a file or folder upload fails OctoPrint shows a notification telling the user to check the file type, regardless of the actual issue.

#### How was it tested? How can it be tested by the reviewer?

To test the file size limit:
 - Limit disk space
   - Set the uploads folder path to a small USB flash drive
  or
   - Run `octoprint serve` with `--basedir` set to a small USB flash drive.
 - Try to upload a file that's too large thru the web ui

To cause a failed file upload:
 - Set an already uploaded file to read-only
 - Try to overwrite the file thru the web ui

To cause a failed file removal:
 - Set an already uploaded file to read-only
 - Try to remove file thru the web ui

To reproduce the original issue that caused file removal to fail (only on windows apparently):
- Upload a gcode file to octoprint and quickly click 'Remove' as soon as it's uploaded.
  - It helps if the file is large so analyzing takes longer, here is a sample file: [TestFile.gcode.zip](https://github.com/OctoPrint/OctoPrint/files/9143696/TestFile.gcode.zip)
- Observe that nothing changes in the web ui
  - OctoPrint log/terminal should show errors

#### Any background context you want to provide?

My original issue was that file removal failed because the file was locked by the gcode interpreter process, but there are other reasons a file could be inaccessible to OctoPrint at any given moment.

#### What are the relevant tickets if any?

This PR resolves #655 and #3879.

#### Screenshots (if appropriate)

| Overwrite Confirmation | No Overwrite Confirmation |
|:-:|:-:|
| ![Screen Shot 2022-07-21 at 11 42 22 PM](https://user-images.githubusercontent.com/7365747/180361323-e2c85d84-7f06-4218-a4f1-f852a5b97fa2.png) | ![size-limit-no-overwrite-confirm](https://user-images.githubusercontent.com/7365747/180361294-bee1f0ad-8d57-4494-90d9-93a945175909.png) |

| Failed Upload | Failed Removal |
|:-:|:-:|
| ![upload-failed-notification](https://user-images.githubusercontent.com/7365747/180476477-088258f7-b8a3-4f13-be51-78b78d0a27d6.png) | ![removal-fail-notification](https://user-images.githubusercontent.com/7365747/179836105-c265f949-33a2-47bd-a7ae-1f45567d5272.png) |


#### Further notes

Thoughts are appreciated.

Please suggest improvements for the various error message texts.