### PR TITLE
Fire action hooks on ALL //action messages, not just unhandled ones

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2401,25 +2401,25 @@ class MachineCom:
                                 level=logging.INFO,
                             )
                             self.refreshSdFiles()
-                        else:
-                            for name, hook in self._printer_action_hooks.items():
-                                try:
-                                    hook(
-                                        self,
-                                        line,
-                                        action_command,
-                                        name=action_name,
-                                        params=action_params,
-                                    )
-                                except Exception:
-                                    self._logger.exception(
-                                        "Error while calling hook from plugin "
-                                        "{} with action command {}".format(
-                                            name, action_command
-                                        ),
-                                        extra={"plugin": name},
-                                    )
-                                    continue
+
+                        for name, hook in self._printer_action_hooks.items():
+                            try:
+                                hook(
+                                    self,
+                                    line,
+                                    action_command,
+                                    name=action_name,
+                                    params=action_params,
+                                )
+                            except Exception:
+                                self._logger.exception(
+                                    "Error while calling hook from plugin "
+                                    "{} with action command {}".format(
+                                        name, action_command
+                                    ),
+                                    extra={"plugin": name},
+                                )
+                                continue
 
                     if self._state not in (
                         self.STATE_CONNECTING,


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR reworks how user-defined handlers for slash actions are fired to enable userland hooks to spy on and extend the existing support for `//action:paused` and friends.

#### How was it tested? How can it be tested by the reviewer?

Installed and tested on my local OctoPrint instance. Since this patch will cause action handlers to be fired more often there are potential performance concerns here, but as action handlers are already expected to implement their own filtering and dispatch I suggest this is not a breaking API change.

#### Any background context you want to provide?

When built with runout support, MarlinFW will emit the following action over the serial console:

```
//action:paused filament_runout T0
```

the interpretation of this action as a pause was initiated by runout while using tool 0. At present, OctoPrint correctly interprets this action as a pause. But it does NOT interpret this action as a source for the `Events.FILAMENT_CHANGE` event. This means that it isn't possible to hang other automation or listeners off of `Events.FILAMENT_CHANGE` event correctly because this pause is not interpreted as a filament change.

As originally implemented user-defined handlers run in the terminal `else:` block of a long `if`/`elif` chain. This means they will be fired ONLY IF no handler ran, which precludes extending OctoPrint's behavior in this particular case without patching `comm.py` one way or another.

This patch simply makes executing user-defined handlers unconditional. All handlers will always be fired on any action. This is not a change of contract or semantics as handlers already expect to receive any action and must decide whether they care.

#### What are the relevant tickets if any?

It would appear that the capability I've built with this and a plugin was previously requested in #3341, but that was never actioned one way or another.

#### Screenshots (if appropriate)

#### Further notes

This patch enables me to use https://github.com/arrdem/octoprint-runout-event-plugin + the Matrix event handler plugin to treat runouts as an explicit event I can be notified of, rather than notifying on pauses.