### PR TITLE
Recognize sd card initialization on Repetier fw

### DIFF
--- a/src/octoprint/templates/dialogs/settings/serialconnection.jinja2
+++ b/src/octoprint/templates/dialogs/settings/serialconnection.jinja2
@@ -303,13 +303,6 @@
                     <div class="control-group">
                         <div class="controls">
                             <label class="checkbox">
-                                <input type="checkbox" data-bind="checked: serial_sdAlwaysAvailable" id="settings-serialSdAlwaysAvailable"> {{ _('Always assume SD card is present') }} <span class="label">{{ _('Repetier') }}</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <div class="controls">
-                            <label class="checkbox">
                                 <input type="checkbox" data-bind="checked: serial_disableSdPrintingDetection" id="settings-disableSdPrintingDetection"> {{ _('Disable SD printing detection') }} <span class="label">{{ _('Ultimaker 2/2+') }}</span>
                             </label>
                         </div>
@@ -372,7 +365,7 @@
                             </label>
                         </div>
                     </div>
-            </div>
+                </div>
                 <div>
                     <div><small><a href="#" class="muted" data-bind="toggleContent: { class: 'fa-caret-right fa-caret-down', container: '#settings_serial_protocol_firmware .hide' }"><i class="fas fa-caret-right"></i> {{ _('Advanced options') }}</a></small></div>
                     <div class="hide">
@@ -423,6 +416,13 @@
                                 <label class="checkbox">
                                     <input type="checkbox" data-bind="checked: serial_triggerOkForM29" id="settings-serialTriggerOkForM29"> {{ _('Simulate <code>ok</code> for <code>M29</code>') }}
                                     <span class="help-block">{{ _('Most Marlin forks that were derived from Marlin versions &lt; v1.1.0 do not send an acknowledging <code>ok</code> for a <code>M29</code>. Check this if you run into communication stalls following streaming of a file to your printer\'s SD.') }}</span>
+                                </label>
+                            </div>
+                        </div>
+                        <div class="control-group">
+                            <div class="controls">
+                                <label class="checkbox">
+                                    <input type="checkbox" data-bind="checked: serial_sdAlwaysAvailable" id="settings-serialSdAlwaysAvailable"> {{ _('Always assume SD card is present') }}
                                 </label>
                             </div>
                         </div>

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2798,11 +2798,6 @@ class MachineCom:
                                 supportRepetierTargetTemp = True
                                 disable_external_heatup_detection = True
 
-                                sd_always_available = self._sdAlwaysAvailable
-                                self._sdAlwaysAvailable = True
-                                if not sd_always_available and not self._sdAvailable:
-                                    self.initSdCard()
-
                             elif "reprapfirmware" in firmware_name.lower():
                                 self._logger.info(
                                     "Detected RepRapFirmware, enabling relevant features for issue free communication"
@@ -2928,11 +2923,15 @@ class MachineCom:
                         "SD init fail" in line
                         or "volume.init failed" in line
                         or "openRoot failed" in line
+                        or "SD Card unmounted" in line
+                        or "SD card released" in line
                     ):
                         self._sdAvailable = False
                         self._sdFiles = []
                         self._callback.on_comm_sd_state_change(self._sdAvailable)
-                    elif "SD card ok" in line and not self._sdAvailable:
+                    elif (
+                        "SD card ok" in line or "Card successfully initialized" in line
+                    ) and not self._sdAvailable:
                         self._sdAvailable = True
                         self.refreshSdFiles()
                         self._callback.on_comm_sd_state_change(self._sdAvailable)


### PR DESCRIPTION
Repetier firmware uses different text for sd card initialization:

Send: N10 M21*33
Recv: ok 10
Recv: Card successfully initialized.

Recognize that in octoprint, so sd card operations become available in
UI.

Tested with Repetier firmware 1.0.4.

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

