### PR TITLE
Fix - Counterclockwise arc length calculation

### DIFF
--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -546,13 +546,17 @@ class gcode:
                 centerArc = Vector3D(oldPos.x + i, oldPos.y + j, oldPos.z)
                 startAngle = math.atan2(oldPos.y - centerArc.y, oldPos.x - centerArc.x)
                 endAngle = math.atan2(pos.y - centerArc.y, pos.x - centerArc.x)
+                arcAngle = endAngle - startAngle
 
                 if gcode in ("G2", "G02"):
                     startAngle, endAngle = endAngle, startAngle
+                    arcAngle = -arcAngle
                 if startAngle < 0:
                     startAngle += math.pi * 2
                 if endAngle < 0:
                     endAngle += math.pi * 2
+                if arcAngle < 0:
+                    arcAngle += math.pi * 2
 
                 # from now on we only think in counter-clockwise direction
 
@@ -588,9 +592,7 @@ class gcode:
                     e = 0
 
                 # calculate 3d arc length
-                arcLengthXYZ = math.sqrt(
-                    (oldPos.z - pos.z) ** 2 + ((endAngle - startAngle) * r) ** 2
-                )
+                arcLengthXYZ = math.sqrt((oldPos.z - pos.z) ** 2 + (arcAngle * r) ** 2)
 
                 # move time in x, y, z, will be 0 if no movement happened
                 moveTimeXYZ = abs(arcLengthXYZ / feedrate)


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR fixes a bug in my recent PR (#4581) where G3 arc lengths were calculated wrong - all arcs were calculated as clockwise.

#### How was it tested? How can it be tested by the reviewer?

- Download the test file:
  - [TestArc.gcode.txt](https://github.com/OctoPrint/OctoPrint/files/9253899/TestArc.gcode.txt)
- In file `gcodeinterpreter.py`:
  - Add this line below `arcLengthXYZ = ...`
    ```python
      print(gcode, arcLengthXYZ)
    ```
  - Add this code section to the end (be sure to set the filepath):
    ```python
      if __name__ == "__main__":
          gc = gcode()
          gc.load(r"path\to\TestArc.gcode")
    ```
- Run `python src\octoprint\util\gcodeInterpreter.py`
- Observe results :

    | GCode | Before | After |
    |:--|--:|--:|
    | G2 | 15.708 | 15.708 |
    | G3 | 47.124 | 15.708 |
    | G2 | 47.124 | 47.124 |
    | G3 | 15.708 | 47.124 |

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

Test File:
![G3ArcLengths](https://user-images.githubusercontent.com/7365747/182671283-68f247e1-d1e9-4511-b36b-da37918c8e57.png)

#### Further notes
