### PR TITLE
Lowercase only filename.

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1778,7 +1778,7 @@ class VirtualPrinter:
         filename = filename
         if filename.startswith("/"):
             filename = filename[1:]
-        file = os.path.join(self._virtualSd, filename).lower()
+        file = os.path.join(self._virtualSd, filename.lower())
         if os.path.exists(file):
             if os.path.isfile(file):
                 os.remove(file)


### PR DESCRIPTION
Lowercasing entire path causes wrong dir to be used in some cases like
.octoprint/virtualsd instead of .octoprint/virtualSd.