### PR TITLE
M20 T support (timestamps for files on sd card)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -170,6 +170,7 @@ date of first contribution):
   * [Kestin Goforth](https://github.com/kforth)
   * [Dawid Pieper](https://github.com/dawidpieper)
   * ["arrdem"](https://github.com/arrdem)
+  * [Arkadiusz Miśkiewicz](https://github.com/arekm)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/development/virtual_printer.rst
+++ b/docs/development/virtual_printer.rst
@@ -118,6 +118,12 @@ There many configuration options via ``config.yaml`` for the virtual printer tha
          # False: <filename>
          size: true
 
+         # Whether M20 responses will include timestamp or not (only if size = true as well)
+         #
+         # True: <filename> <filesize in bytes> <timestamp as hex>
+         # False: <filename> <filesize in bytes>
+         timestamp: false
+
          # Whether M20 responses will include longname or not (only if size = true as well)
          #
          # True:  <filename> <filesize in bytes> <longname>

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1417,7 +1417,7 @@ class VirtualPrinter:
                 "path": entry.path,
                 "dosname": dosname,
                 "size": entry.stat().st_size,
-                "timestamp": hex(unix_timestamp_to_m20_timestamp(entry.stat().st_mtime)),
+                "timestamp": unix_timestamp_to_m20_timestamp(entry.stat().st_mtime),
             }
         return result
 

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -592,7 +592,7 @@ class VirtualPrinter:
     # noinspection PyUnusedLocal
     def _gcode_M20(self, data: str) -> None:
         if self._sdCardReady:
-            self._listSd(incl_long="L" in data)
+            self._listSd(incl_long="L" in data, incl_timestamp="T" in data)
 
     # noinspection PyUnusedLocal
     def _gcode_M21(self, data: str) -> None:
@@ -1379,10 +1379,12 @@ class VirtualPrinter:
             except Exception:
                 self._logger.exception("While handling %r", data)
 
-    def _listSd(self, incl_long=False):
+    def _listSd(self, incl_long=False, incl_timestamp=False):
         line = "{dosname}"
         if self._settings.get_boolean(["sdFiles", "size"]):
             line += " {size}"
+            if self._settings.get_boolean(["sdFiles", "timestamp"]) or incl_timestamp:
+                line += " {timestamp}"
             if self._settings.get_boolean(["sdFiles", "longname"]) or incl_long:
                 if self._settings.get_boolean(["sdFiles", "longname_quoted"]):
                     line += ' "{name}"'
@@ -1412,6 +1414,8 @@ class VirtualPrinter:
                 "path": entry.path,
                 "dosname": dosname,
                 "size": entry.stat().st_size,
+                # 0 for now
+                "timestamp": hex(0),
             }
         return result
 

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1380,16 +1380,14 @@ class VirtualPrinter:
                 self._logger.exception("While handling %r", data)
 
     def _listSd(self, incl_long=False):
+        line = "{dosname}"
         if self._settings.get_boolean(["sdFiles", "size"]):
+            line += " {size}"
             if self._settings.get_boolean(["sdFiles", "longname"]) or incl_long:
                 if self._settings.get_boolean(["sdFiles", "longname_quoted"]):
-                    line = '{dosname} {size} "{name}"'
+                    line += ' "{name}"'
                 else:
-                    line = "{dosname} {size} {name}"
-            else:
-                line = "{dosname} {size}"
-        else:
-            line = "{dosname}"
+                    line += " {name}"
 
         files = self._mappedSdList()
         items = map(lambda x: line.format(**x), files.values())

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -910,7 +910,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
         return list(
             map(
-                lambda x: {"name": x[0][1:], "size": x[1], "display": x[2]},
+                lambda x: {"name": x[0][1:], "size": x[1], "display": x[2], "date": x[3]},
                 self._comm.getSdFiles(),
             )
         )

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -331,6 +331,8 @@ def _getFileList(
                 }
                 if f["size"] is not None:
                     file.update({"size": f["size"]})
+                if f["date"] is not None:
+                    file.update({"date": f["date"]})
                 files.append(file)
     else:
         filter_func = None

--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -6253,15 +6253,11 @@ def canonicalize_temperatures(parsed, current):
 
 
 def _validate_m20_timestamp(timestamp):
-    # Only hex in 0xABC format is valid
-    if not timestamp.startswith("0x"):
-        return False
     try:
-        int(timestamp, 16)
-        return True
+        m20_timestamp_to_unix_timestamp(timestamp)
     except ValueError:
-        pass
-    return False
+        return False
+    return True
 
 
 def parse_file_list_line(line):
@@ -6304,7 +6300,7 @@ def parse_file_list_line(line):
             if timestamp is not None:
                 # size was valid and we have timestamp, so try to use it
                 try:
-                    timestamp = m20_timestamp_to_unix_timestamp(int(timestamp, 16))
+                    timestamp = m20_timestamp_to_unix_timestamp(timestamp)
                 except ValueError:
                     timestamp = None
 

--- a/src/octoprint/util/files.py
+++ b/src/octoprint/util/files.py
@@ -332,14 +332,14 @@ def unix_timestamp_to_m20_timestamp(unix_timestamp):
     Arguments:
         unix_timestamp (int): Unix timestamp in seconds
     Returns:
-        int: M20 T timestamp
+        string: M20 T timestamp as hex string
     """
 
     dt = datetime.datetime.fromtimestamp(unix_timestamp)
     m20_date = dt.year - 1980 << 9 | dt.month << 5 | dt.day
     m20_time = dt.hour << 11 | dt.minute << 5
     m20_time |= (dt.second - (dt.second % 2)) // 2
-    return m20_date << 16 | m20_time
+    return hex(m20_date << 16 | m20_time)
 
 
 def m20_timestamp_to_unix_timestamp(timestamp):
@@ -353,11 +353,17 @@ def m20_timestamp_to_unix_timestamp(timestamp):
     https://wiki.osdev.org/FAT
 
     Arguments:
-        timestamp (int): M20 T timestamp
+        timestamp (string): M20 T timestamp as hex string
     Returns:
         int: Unix timestamp in seconds
     """
 
+    # Only hex in 0xABC format is valid while int() accepts
+    # hex without 0x prefix, too.
+    if not timestamp.startswith("0x"):
+        raise ValueError("Invalid M20 T timestamp format")
+
+    timestamp = int(timestamp, 16)
     dt = timestamp >> 16
     day = dt & (1 << 5) - 1
     month = (dt >> 5) & ((1 << 4) - 1)

--- a/tests/util/test_comm.py
+++ b/tests/util/test_comm.py
@@ -295,9 +295,9 @@ class TestCommErrorHandling(unittest.TestCase):
     [
         ("aaa", False),
         ("1234", False),
-        ("0x0", True),
-        ("0x34234", True),
+        ("0x21bf7d", True),
         ("0xghijk", False),
+        ("0x28210800", True),
     ],
 )
 def test__validate_m20_timestamp(val, expected):
@@ -326,7 +326,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "name.gco",
                 3424324,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 None,
             ),
         ),
@@ -339,7 +339,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "longname.gcode",
                 3424324,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 None,
             ),
         ),
@@ -352,7 +352,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "name.gco",
                 32424,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 "long name without quoting",
             ),
         ),
@@ -361,7 +361,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "name.gco",
                 32424,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 "long   name   without   quoting",
             ),
         ),
@@ -370,7 +370,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "name.gco",
                 32424,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 "long name with quoting",
             ),
         ),
@@ -379,7 +379,7 @@ def test__validate_m20_timestamp(val, expected):
             (
                 "name.gco",
                 32424,
-                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                m20_timestamp_to_unix_timestamp("0x21bf7d"),
                 "long   name   with   quoting",
             ),
         ),

--- a/tests/util/test_comm.py
+++ b/tests/util/test_comm.py
@@ -2,8 +2,10 @@ import unittest
 from unittest import mock
 
 import ddt
+import pytest
 
 import octoprint.util.comm
+from octoprint.util.files import m20_timestamp_to_unix_timestamp
 
 
 @ddt.ddt
@@ -286,3 +288,102 @@ class TestCommErrorHandling(unittest.TestCase):
         self.assert_not_disconnected()
         self.assert_not_print_cancelled()
         self.assert_not_cleared_to_send()
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        ("aaa", False),
+        ("1234", False),
+        ("0x0", True),
+        ("0x34234", True),
+        ("0xghijk", False),
+    ],
+)
+def test__validate_m20_timestamp(val, expected):
+    assert octoprint.util.comm._validate_m20_timestamp(val) == expected
+
+
+@pytest.mark.parametrize(
+    "val,expected",
+    [
+        (
+            "line that makes little sense",
+            ("line that makes little sense", None, None, None),
+        ),
+        ("name.gco", ("name.gco", None, None, None)),
+        ("name.gco invalid-size", ("name.gco invalid-size", None, None, None)),
+        (
+            "name.gco 3424324",
+            ("name.gco", 3424324, None, None),
+        ),
+        (
+            "name.gco 3424324 longname.gcode",
+            ("name.gco", 3424324, None, "longname.gcode"),
+        ),
+        (
+            "name.gco 3424324 0x21bf7d",
+            (
+                "name.gco",
+                3424324,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                None,
+            ),
+        ),
+        (
+            "name.gco 3424324 0xinvalid_timestamp_as_longname",
+            ("name.gco", 3424324, None, "0xinvalid_timestamp_as_longname"),
+        ),
+        (
+            "longname.gcode 3424324 0x21bf7d",
+            (
+                "longname.gcode",
+                3424324,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                None,
+            ),
+        ),
+        (
+            "longname.gcode 3424324 longname.gcode",
+            ("longname.gcode", 3424324, None, "longname.gcode"),
+        ),
+        (
+            "name.gco 32424 0x21bf7d long name without quoting",
+            (
+                "name.gco",
+                32424,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                "long name without quoting",
+            ),
+        ),
+        (
+            "name.gco 32424 0x21bf7d long   name   without   quoting",
+            (
+                "name.gco",
+                32424,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                "long   name   without   quoting",
+            ),
+        ),
+        (
+            'name.gco 32424 0x21bf7d "long name with quoting"',
+            (
+                "name.gco",
+                32424,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                "long name with quoting",
+            ),
+        ),
+        (
+            'name.gco 32424 0x21bf7d "long   name   with   quoting"',
+            (
+                "name.gco",
+                32424,
+                m20_timestamp_to_unix_timestamp(int("0x21bf7d", 16)),
+                "long   name   with   quoting",
+            ),
+        ),
+    ],
+)
+def test_parse_file_list_line(val, expected):
+    assert octoprint.util.comm.parse_file_list_line(val) == expected

--- a/tests/util/test_files.py
+++ b/tests/util/test_files.py
@@ -74,11 +74,11 @@ class FilesUtilTest(unittest.TestCase):
 
 # based on https://github.com/nathanhi/pyfatfs/blob/master/tests/test_DosDateTime.py
 m20_timestamp_tests = [
-    (int("0x21", 16) << 16, datetime.datetime(1980, 1, 1).timestamp()),
-    (int("0xff9f", 16) << 16, datetime.datetime(2107, 12, 31).timestamp()),
-    (int("0x21bf7d", 16), datetime.datetime(1980, 1, 1, 23, 59, 58).timestamp()),
-    (int("0x549088aa", 16), datetime.datetime(2022, 4, 16, 17, 5, 20).timestamp()),
-    (int("0x28210800", 16), datetime.datetime(2000, 1, 1, 1, 0).timestamp()),
+    ("0x210000", datetime.datetime(1980, 1, 1).timestamp()),
+    ("0xff9f0000", datetime.datetime(2107, 12, 31).timestamp()),
+    ("0x21bf7d", datetime.datetime(1980, 1, 1, 23, 59, 58).timestamp()),
+    ("0x549088aa", datetime.datetime(2022, 4, 16, 17, 5, 20).timestamp()),
+    ("0x28210800", datetime.datetime(2000, 1, 1, 1, 0).timestamp()),
 ]
 
 


### PR DESCRIPTION
    M20 T support (timestamps for files on sd card).

    Use "M20 L T" (if CAPABILITY_EXTENDED_M20 is available) which gives
    us long file names but also file timestamps.

    Wire up that timestamp into "date" field which gives us "Uploaded: ...
    ago" for files on SD card. Sorting by upload date also works.

    Implementing this also fixes parsing of response to (for example
    manually sent) "M20 T" command. Octoprint assumed that third entry
    in response is always long file name while with M20 T it is timestamp.