### PR TITLE
Show multiple whitespace in filename.

### DIFF
--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -880,6 +880,7 @@ ul.dropdown-menu li a {
         text-overflow: ellipsis;
         word-break: break-all;
         margin-right: 30px;
+        white-space: pre-wrap;
       }
 
       .toggleAdditionalData {


### PR DESCRIPTION
Long filename like <pre>more   than   one   space.gcode</pre> was shown in UI as
<pre>more than one space.gcode</pre> Fix that.