### PR TITLE
:bug: Fix werkzeug 2.1 compatibility and remove redundant code

### DIFF
--- a/src/octoprint/plugins/corewizard/subwizards.py
+++ b/src/octoprint/plugins/corewizard/subwizards.py
@@ -85,7 +85,7 @@ class AclSubwizard:
         ):
             abort(404)
 
-        data = request.get_json()
+        data = request.get_json(silent=True)
         if data is None:
             data = request.values
 

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -288,7 +288,7 @@ def serverStatus():
     error_message="You have made too many failed login attempts. Please try again later.",
 )
 def login():
-    data = request.get_json()
+    data = request.get_json(silent=True)
     if not data:
         data = request.values
 

--- a/src/octoprint/server/api/access.py
+++ b/src/octoprint/server/api/access.py
@@ -34,9 +34,6 @@ def get_groups():
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def add_group():
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     data = request.get_json()
 
     if "key" not in data:
@@ -82,9 +79,6 @@ def get_group(key):
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def update_group(key):
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     data = request.get_json()
 
     try:
@@ -138,12 +132,7 @@ def get_users():
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def add_user():
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     data = request.get_json()
-    if data is None:
-        abort(400, description="Malformed JSON body in request")
 
     if "name" not in data:
         abort(400, description="name is missing")
@@ -192,13 +181,7 @@ def get_user(username):
 def update_user(username):
     user = userManager.find_user(username)
     if user is not None:
-        if "application/json" not in request.headers["Content-Type"]:
-            abort(400, description="Expected content-type JSON")
-
         data = request.get_json()
-
-        if data is None:
-            abort(400, description="Malformed JSON body in request")
 
         # change groups
         if "groups" in data:
@@ -246,13 +229,7 @@ def change_password_for_user(username):
             or current_user.has_permission(Permissions.SETTINGS)
         )
     ):
-        if "application/json" not in request.headers["Content-Type"]:
-            abort(400, description="Expected content-type JSON")
-
         data = request.get_json()
-
-        if data is None:
-            abort(400, description="Malformed JSON body in request")
 
         if "password" not in data or not data["password"]:
             abort(400, description="new password is missing")
@@ -307,9 +284,6 @@ def change_settings_for_user(username):
         abort(403)
 
     data = request.get_json()
-
-    if data is None:
-        abort(400, description="Malformed JSON body in request")
 
     try:
         userManager.change_user_settings(username, data)

--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -396,13 +396,7 @@ def printerCommand():
     if not printer.is_operational():
         abort(409, description="Printer is not operational")
 
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content type JSON")
-
     data = request.get_json()
-
-    if data is None:
-        abort(400, description="Malformed JSON body in request")
 
     if "command" in data and "commands" in data:
         abort(400, description="'command' and 'commands' are mutually exclusive")

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -54,13 +54,7 @@ def printerProfilesList():
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def printerProfilesAdd():
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
-    json_data = request.get_json()
-
-    if json_data is None:
-        abort(400, description="Malformed JSON body in request")
+    json_data = request.get_json()  # Werkzeug should return 400 if invalid JSON
 
     if "profile" not in json_data:
         abort(400, description="profile is missing")
@@ -136,12 +130,7 @@ def printerProfilesDelete(identifier):
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def printerProfilesUpdate(identifier):
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     json_data = request.get_json()
-    if json_data is None:
-        abort(400, description="Malformed JSON body in request")
 
     if "profile" not in json_data:
         abort(400, description="profile missing")

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -389,11 +389,8 @@ def _get_plugin_settings():
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def setSettings():
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     data = request.get_json()
-    if data is None or not isinstance(data, dict):
+    if not isinstance(data, dict):
         abort(400, description="Malformed JSON body in request")
 
     response = _saveSettings(data)

--- a/src/octoprint/server/api/slicing.py
+++ b/src/octoprint/server/api/slicing.py
@@ -160,12 +160,7 @@ def slicingGetSlicerProfile(slicer, name):
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def slicingAddSlicerProfile(slicer, name):
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
-
     json_data = request.get_json()
-    if json_data is None:
-        abort(400, description="Malformed JSON body in request")
 
     data = {}
     display_name = None
@@ -199,8 +194,7 @@ def slicingAddSlicerProfile(slicer, name):
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def slicingPatchSlicerProfile(slicer, name):
-    if "application/json" not in request.headers["Content-Type"]:
-        abort(400, description="Expected content-type JSON")
+    json_data = request.get_json()
 
     try:
         profile = slicingManager.load_profile(slicer, name, require_configured=False)
@@ -208,10 +202,6 @@ def slicingPatchSlicerProfile(slicer, name):
         return abort(404)
     except UnknownProfile:
         return abort(404)
-
-    json_data = request.get_json()
-    if json_data is None:
-        abort(400, description="Malformed JSON body in request")
 
     data = {}
     display_name = None

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1592,15 +1592,8 @@ def get_remote_address(request):
 
 
 def get_json_command_from_request(request, valid_commands):
-    content_type = request.headers.get("Content-Type", None)
-    if content_type is None or "application/json" not in content_type:
-        flask.abort(400, description="Expected content-type JSON")
-
     data = request.get_json()
-    if data is None:
-        flask.abort(
-            400, description="Malformed JSON body or wrong content-type in request"
-        )
+
     if "command" not in data or data["command"] not in valid_commands:
         flask.abort(400, description="command is invalid")
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
* Sort out werkzeug compatibility. It no longer returns None unless the `silent` parameter is specified.
* Removed redundant code seeing as werkzeug returns a 400 itself if you try and get json when json is not available.

#### How was it tested? How can it be tested by the reviewer?
Make requests to the server with dodgy content type or bad json data and verify that a 400 is returned.

#### Any background context you want to provide?
#4629

#### What are the relevant tickets if any?
#4629 