### PR TITLE
✨ Enable multiple file uploads

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1603,6 +1603,83 @@ $(function () {
             }
         };
 
+        self._uploadExistsQueue = []; // Files will be in this queue if their test fails and something needs to be done
+        self._uploadExistsOpen = false;
+
+        self._processUploadQueue = function () {
+            if (!self._uploadExistsQueue.length > 0 || self._uploadExistsOpen) return;
+
+            const hideAndSubmit = function (data) {
+                self.uploadExistsDialog.modal("hide");
+                self._uploadExistsOpen = false;
+                data.submit();
+                // Recursively move on to process the queue every time a dialog is closed
+                if (self._uploadExistsQueue.length > 0) {
+                    self._processUploadQueue();
+                }
+            };
+
+            // Collect an item from the queue that needs an overwrite dialog
+            const {data, response, path, fileSizeTooBig} =
+                self._uploadExistsQueue.shift();
+            const file = data.files[0];
+
+            const formData = {};
+            if (path !== "") {
+                formData.path = path;
+            }
+
+            // Build and show a dialog
+            self._uploadExistsOpen = true;
+
+            $("h3", self.uploadExistsDialog).text(
+                _.sprintf(gettext("File already exists: %(name)s"), {
+                    name: file.name
+                })
+            );
+            $("p, form", self.uploadExistsDialog).toggle(!fileSizeTooBig);
+            $("span", self.uploadExistsDialog).toggle(fileSizeTooBig);
+            $("input", self.uploadExistsDialog)
+                .val("")
+                .prop("placeholder", response.suggestion);
+            $("a.upload-rename", self.uploadExistsDialog)
+                .toggle(!fileSizeTooBig)
+                .prop("disabled", false)
+                .off("click")
+                .on("click", function () {
+                    var newName = $("input", self.uploadExistsDialog).val();
+                    if (newName === "") newName = response.suggestion;
+
+                    OctoPrint.files.exists("local", path, newName).done(function (r) {
+                        if (r.exists) {
+                            $(".control-group", self.uploadExistsDialog).addClass(
+                                "error"
+                            );
+                            $(".help-block", self.uploadExistsDialog).show();
+                        } else {
+                            $(".control-group", self.uploadExistsDialog).removeClass(
+                                "error"
+                            );
+                            $(".help-block", self.uploadExistsDialog).hide();
+
+                            formData.filename = newName;
+                            formData.noOverwrite = true;
+                            data.formData = formData;
+
+                            hideAndSubmit(data);
+                        }
+                    });
+                });
+            $("a.upload-overwrite", self.uploadExistsDialog)
+                .off("click")
+                .on("click", function () {
+                    data.formData = formData;
+                    hideAndSubmit(data);
+                });
+
+            self.uploadExistsDialog.modal("show");
+        };
+
         self._handleUploadAdd = function (e, data) {
             var file = data.files[0];
             var path = self.currentPath();
@@ -1618,67 +1695,15 @@ $(function () {
                     .exists("local", path, file.name)
                     .done(function (response) {
                         if (response.exists) {
-                            $("h3", self.uploadExistsDialog).text(
-                                _.sprintf(gettext("File already exists: %(name)s"), {
-                                    name: file.name
-                                })
-                            );
-                            $("p, form", self.uploadExistsDialog).toggle(!fileSizeTooBig);
-                            $("span", self.uploadExistsDialog).toggle(fileSizeTooBig);
-                            $("input", self.uploadExistsDialog)
-                                .val("")
-                                .prop("placeholder", response.suggestion);
-                            $("a.upload-rename", self.uploadExistsDialog)
-                                .toggle(!fileSizeTooBig)
-                                .prop("disabled", false)
-                                .off("click")
-                                .on("click", function () {
-                                    var newName = $(
-                                        "input",
-                                        self.uploadExistsDialog
-                                    ).val();
-                                    if (newName === "") newName = response.suggestion;
-
-                                    OctoPrint.files
-                                        .exists("local", path, newName)
-                                        .done(function (r) {
-                                            if (r.exists) {
-                                                $(
-                                                    ".control-group",
-                                                    self.uploadExistsDialog
-                                                ).addClass("error");
-                                                $(
-                                                    ".help-block",
-                                                    self.uploadExistsDialog
-                                                ).show();
-                                            } else {
-                                                $(
-                                                    ".control-group",
-                                                    self.uploadExistsDialog
-                                                ).removeClass("error");
-                                                $(
-                                                    ".help-block",
-                                                    self.uploadExistsDialog
-                                                ).hide();
-
-                                                self.uploadExistsDialog.modal("hide");
-
-                                                formData.filename = newName;
-                                                formData.noOverwrite = true;
-                                                data.formData = formData;
-
-                                                data.submit();
-                                            }
-                                        });
-                                });
-                            $("a.upload-overwrite", self.uploadExistsDialog)
-                                .off("click")
-                                .on("click", function () {
-                                    self.uploadExistsDialog.modal("hide");
-                                    data.formData = formData;
-                                    data.submit();
-                                });
-                            self.uploadExistsDialog.modal("show");
+                            const queueEntry = {
+                                data,
+                                response,
+                                path,
+                                fileSizeTooBig
+                            };
+                            self._uploadExistsQueue.push(queueEntry);
+                            // Start processing queue - if already processing, this will do nothing
+                            self._processUploadQueue();
                         } else {
                             data.formData = formData;
                             data.submit();
@@ -1740,8 +1765,6 @@ $(function () {
         };
 
         self._handleUploadStop = function (e, data) {
-            console.log("Upload stopped (complete)");
-
             var reset = function () {
                 self.ignoreUpdatedFilesEvent = false;
                 self._setProgressBar(0, "", false);

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -539,7 +539,10 @@ $(function () {
                     });
                     if (entryElement) {
                         // scroll to uploaded element
-                        self.listElement.scrollTop(entryElement.offsetTop); // TODO - maybe scroll to just one file? Top in list? First selected?
+                        // TODO scroll to item is really not working right now, scrolls to completely wrong file
+                        if (index === focus.length) {
+                            self.listElement.scrollTop(entryElement.offsetTop);
+                        }
 
                         // highlight uploaded element
                         var element = $(entryElement);

--- a/src/octoprint/templates/sidebar/files.jinja2
+++ b/src/octoprint/templates/sidebar/files.jinja2
@@ -67,7 +67,7 @@
             <span class="btn btn-primary fileinput-button span6" style="margin-bottom: 10px">
                                 <i class="fas fa-upload"></i>
                                 <span>{{ _('Upload') }}</span>
-                                <input id="gcode_upload" data-test-id="upload-local" accept="{{ ",".join(supportedExtensions) }}" type="file" name="file" class="fileinput-button">
+                                <input id="gcode_upload" data-test-id="upload-local" accept="{{ ",".join(supportedExtensions) }}" type="file" name="file" class="fileinput-button" multiple>
                             </span>
             <span class="btn btn-primary fileinput-button span6" data-bind="enable: $root.isSdReady() && !$root.isPrinting(), css: {disabled: !$root.isSdReady() || $root.isPrinting()}" style="margin-bottom: 10px">
                                 <i class="fas fa-upload"></i>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR has the necessary code changes to allow multiple file uploads to work in the UI with no strange side effects, and making sure that the 'file exists' dialogs work correctly. It fixes issue #4300 and aims to address the comments in #1868 as well.

Some of the stuff it does:

* Allows to select multiple files to upload
* Only refreshes the file list at the end of batch uploading 
* Queues the 'File already exists' dialogs
* Displays the filename in any errors that are shown, so if 1 file out of 5 fails for example, you can see what failed.
* All the files are highlighted yellow, but only scrolling to the position of the last file to be uploaded on stop.
  * This is the only outstanding TODO - I can't get it to scroll to the correct position currently. It will scroll but to completely the wrong place 🙈

#### How was it tested? How can it be tested by the reviewer?

I have a small folder of 8 files of varying file sizes that I have been using to test this. Some things that can be done:

* Upload one file (gcode, STL and name collision) (check everything still works as before 🙂)
* Select multiple files from the 'Upload' button
* Drag and drop multiple files
* Uploading multiple STL files (Probably requires a slicer plugin - I used the Slic3r with my PrusaSlicer install)
* Uploading a mix of gcode/STLs
* Uploading a mix of files that collide and files that can just be uploaded
* To demo the error handling, I simulated an error in the API by adding this to the code:
  ```python
  def uploadGcodeFile(target):
      from random import randint
      if randint(1, 5) % 2 == 0:
          abort(500, "simulated error")
  ```

#### Any background context you want to provide?

See issues

I have dug quite deep into how the jquery file upload works, the documentation wiki is good
https://github.com/blueimp/jQuery-File-Upload/wiki/Options

#### What are the relevant tickets if any?

#4300 and #1868

#### Screenshots & Videos

Coming soon.... 👀 

#### Further notes

I am not completely sure that the recursive way that file collision dialogs are handled is necessarily the 'best', but it seems to work well. When the dialog closes, the next one is called.

When writing new code, I used modern JavaScript features to make it less verbose. I will have to check on the browser compatibility, but it's passed the ESLint checks.

I'll carry on testing, I would like to test this on my Pi or with a simulated slow network connection to actually watch the progress bar works well. I think it does but it does move quite quickly when just uploading to `localhost` on my SSD!