### PR TITLE
Marlin 2.1.x reports "No media" if no sd card. Handle that.

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -2899,6 +2899,7 @@ class MachineCom:
                     if (
                         "SD init fail" in line
                         or "volume.init failed" in line
+                        or "No media" in line
                         or "openRoot failed" in line
                         or "SD Card unmounted" in line
                         or "SD card released" in line


### PR DESCRIPTION
Commands like M20 return "No media" on Marlin 2.1.x with sd card
not initialized.

Send: M21
Recv: echo:SD card ok
Recv: ok P15 B3
Send: M22
Recv: ok P15 B3
Send: M20
Recv: echo:No media
Recv: ok P15 B3
Send: M115
Recv: FIRMWARE_NAME:Marlin bugfix-2.1.x (Aug 29 2022 12:04:58)
SOURCE_CODE_URL:github.com/MarlinFirmware/Marlin PROTOCOL_VERSION:1.0
...

https://github.com/MarlinFirmware/Marlin/blob/82d18517436c46b44826710d03654b48158b9a6b/Marlin/src/gcode/sd/M20.cpp#L51
