### PR TITLE
fix bug in files.js file

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1401,7 +1401,7 @@ $(function () {
             self.uploadProgress.addClass("progress-striped").addClass("active");
             self.uploadProgressBar.css("width", "100%");
             if (payload.progressAvailable) {
-                self.uploadProgressPercentage(percentage);
+                self.uploadProgressPercentage(0);
                 self.uploadProgressText(
                     _.sprintf(gettext("Slicing ... (%(percentage)d%%)"), {percentage: 0})
                 );


### PR DESCRIPTION
in the event handler onSlicingStarted the uploadProgressPercentage was given the parameter perecntage, but this was not know, so it will throw an error.
As this is the start of the slicing the correct value should be 0


#### What does this PR do and why is it necessary?
fix a bug in the slicing events
```
files.js:1347 Uncaught ReferenceError: percentage is not defined
    at FilesViewModel.self.onEventSlicingStarted (files.js:1347:47)
    at dataupdater.js:453:48
    at Pn (lodash.min.js:9:530)
    at Function.<anonymous> (lodash.min.js:30:66)
    at dataupdater.js:451:15
    at DataUpdater.self._ifInitialized (dataupdater.js:515:13)
    at DataUpdater.self._onEvent (dataupdater.js:323:14)
    at socket.js:56:17
    at Pn (lodash.min.js:9:530)
    at Function.<anonymous> (lodash.min.js:30:66)
```

#### How was it tested? How can it be tested by the reviewer?
tested with custom slicing plugin
should show up with any slicing plugin

#### Any background context you want to provide?
discoverd while using a custom slicing plugin

#### What are the relevant tickets if any?
N/A
#### Screenshots (if appropriate)
N/A
#### Further notes
N/A