### PR TITLE
Add extensible chart markings support

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -605,6 +605,17 @@ GcodeScript${ScriptName}Finished
 
    .. versionadded:: 1.6.0
 
+ChartMarked
+   A time-based marking has been made on the UI's temperature chart.
+
+   Payload:
+
+     * ``type``: the marking's ID. Built-in types are ``print``, ``done``, ``cancel``, ``pause``, and ``resume``. Plugins may set arbitrary types
+     * ``label``: the human-readable short label of the marking
+     * ``time``: the epoch time of marking
+
+   .. versionadded:: 1.9.0
+
 .. _sec-events-available_events-gcode_processing:
 
 GCODE processing

--- a/src/octoprint/events.py
+++ b/src/octoprint/events.py
@@ -81,6 +81,7 @@ class Events:
     PRINT_PAUSED = "PrintPaused"
     PRINT_RESUMED = "PrintResumed"
     ERROR = "Error"
+    CHART_MARKED = "ChartMarked"
 
     # print/gcode events
     POWER_ON = "PowerOn"

--- a/src/octoprint/static/js/app/viewmodels/temperature.js
+++ b/src/octoprint/static/js/app/viewmodels/temperature.js
@@ -203,29 +203,6 @@ $(function () {
 
         self.markings = [];
 
-        self.marking_props = {
-            print: {
-                label: gettext("Start"),
-                color: "#218656"
-            },
-            pause: {
-                label: gettext("Pause"),
-                color: "#FDC02F"
-            },
-            resume: {
-                label: gettext("Resume"),
-                color: "#27CAEE"
-            },
-            cancel: {
-                label: gettext("Cancel"),
-                color: "#DA3749"
-            },
-            done: {
-                label: gettext("Done"),
-                color: "#1B72F9"
-            }
-        };
-
         self.showStateMarks = ko.observable(
             loadFromLocalStorage("temperatureGraph.showStateMarks", true)
         );
@@ -485,15 +462,15 @@ $(function () {
                     y: self.plot.getAxes().yaxis.max
                 });
 
+                var markLabel = mark.type;
+                if (mark.label) {
+                    markLabel = gettext(mark.label);
+                }
                 if (o.left > yAxisLabelWidth) {
                     var label = $("<div></div>");
-                    label.html(self.marking_props[mark.type].label);
-                    var css = {
-                        backgroundColor: self.marking_props[mark.type].color
-                    };
-
-                    label.css(css);
+                    label.html(markLabel);
                     label.addClass("temperature-mark-label");
+                    label.addClass("temperature-mark-type-" + mark.type);
 
                     graph.append(label);
 
@@ -520,7 +497,7 @@ $(function () {
                 }
 
                 return {
-                    color: self.marking_props[mark.type].color,
+                    color: label.css("background-color"),
                     lineWidth: lineWidth,
                     xaxis: {from: time, to: time}
                 };
@@ -528,6 +505,17 @@ $(function () {
 
             return marks;
         };
+
+        // Dummy translation requests for dynamic strings supplied by the backend
+        // noinspection BadExpressionStatementJS
+        [
+            // mark labels
+            gettext("Start"),
+            gettext("Done"),
+            gettext("Cancel"),
+            gettext("Pause"),
+            gettext("Resume")
+        ];
 
         self._initializePlot = function (force, plotInfo) {
             var graph = $("#temperature-graph");

--- a/src/octoprint/static/less/octoprint.less
+++ b/src/octoprint/static/less/octoprint.less
@@ -575,10 +575,27 @@ table {
 .temperature-mark-label {
   position: absolute;
   color: white;
+  background-color: #aeb6bf;
   padding: 0 5px;
   font-size: 8px;
   transform-origin: 0 0;
   transform: rotate(-90deg);
+}
+
+.temperature-mark-type-print {
+  background-color: #218656;
+}
+.temperature-mark-type-pause {
+  background-color: #fdc02f;
+}
+.temperature-mark-type-resume {
+  background-color: #27caee;
+}
+.temperature-mark-type-cancel {
+  background-color: #da3749;
+}
+.temperature-mark-type-done {
+  background-color: #1b72f9;
 }
 
 /** Various */


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] (_Not a large audience, but relevant to plugin development_)Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] (_Already in there_)You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Add extensible chart markings support
    
- Replace add_marking with CHART_MARKED event
- Allow for arbitrary markings in the JS UI

Note that this removes `add_marking()`.  In #4657 I said it would be easiest to just extend it, but since plugin maintainers will need to have a check for backwards compatibility anyway, extending it would require them to catch `TypeError` for missing kwargs, which IMHO was too broad.  As it was impossible to use `add_marking()` for plugins in the past, nothing could have used it and it's safe to replace with an event.

~~The only thing I'm not totally happy with is moving style functionality (the colors) into functional code, but I think the additional functionality to plugin writers is worth it.~~

Edit: moved the colors to CSS, with a default color of grey, and removed all color mentions from the code path.  If plugin authors want, they can define custom CSS for `.temperature-mark-type-{type}`

#### How was it tested? How can it be tested by the reviewer?

- Verified identical visual functionality for all existing built-in markings (print, done, cancel, pause, resume).
- Simple plugin:

```python
from octoprint.events import Events
import octoprint.plugin
import octoprint.util


class TestMarkings(octoprint.plugin.StartupPlugin):
    def on_after_startup(self):
        if hasattr(Events, "CHART_MARKED"):
            timer = octoprint.util.RepeatedTimer(30, self.example_recurring)
            timer.start()

    def example_recurring(self):
        self._event_bus.fire(
            Events.CHART_MARKED,
            {
                "type": "testmarkings_example",
                "label": "Example",
            },
        )


__plugin_name__ = "TestMarkings"
__plugin_pythoncompat__ = ">=3,<4"


def __plugin_load__():
    global __plugin_implementation__
    __plugin_implementation__ = TestMarkings()
```

#### Any background context you want to provide?

Per original feature request:

> I maintain [a plugin](https://plugins.octoprint.org/plugins/bedcooldown/) which begins the bed cooldown shortly before the end of the print, and it would be a good addition to show on the chart when that cooldown begins.

#### What are the relevant tickets if any?

- #4657 (My feature request)
- #4382 (Original PR for chart markings)

#### Screenshots (if appropriate)

![image](https://user-images.githubusercontent.com/704589/193483708-5baca400-87ad-4d40-addf-436430bea88f.png)

#### Further notes

I'm not sure how "versionadded" is added for documentation updates; I just put "1.9.0" for the time being.