### PR TITLE
:pencil2: virtual: Fix a log typo

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -52,7 +52,7 @@ class VirtualPrinter:
         self._plugin_data_folder = data_folder
 
         self._seriallog = logging.getLogger(
-            "octoprint.plugin.virtual_printer.VirtualPrinter.serial"
+            "octoprint.plugins.virtual_printer.VirtualPrinter.serial"
         )
         self._seriallog.setLevel(logging.CRITICAL)
         self._seriallog.propagate = False


### PR DESCRIPTION
:)

I'm going to assume there was no reason for this, so hopefully it is fine...

I just noticed the inconsistency in the logging plugin's settings