### PR TITLE
Add 'operation' field to FILE_ADDED events

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -173,6 +173,7 @@ date of first contribution):
   * [Arkadiusz Miśkiewicz](https://github.com/arekm)
   * ["tempodat"](https://github.com/tempodat)
   * [Frederik Kemner](https://github.com/040medien)
+  * [Scott Martin](https://github.com/smartin015)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -750,6 +750,7 @@ class FileManager:
                 "path": path_in_storage,
                 "name": name,
                 "type": get_file_type(name),
+                "operation": "add",
             },
         )
         eventManager().fire(Events.UPDATED_FILES, {"type": "printables"})
@@ -787,6 +788,7 @@ class FileManager:
                 "path": path_in_storage,
                 "name": name,
                 "type": get_file_type(name),
+                "operation": "copy",
             },
         )
         eventManager().fire(Events.UPDATED_FILES, {"type": "printables"})
@@ -821,6 +823,7 @@ class FileManager:
                 "path": dst_path_in_storage,
                 "name": dst_name,
                 "type": get_file_type(dst_name),
+                "operation": "move",
             },
         )
         eventManager().fire(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Adds a new "operation" field to firing of FILE_ADDED events in order to indicate the context in which the file is being added ("true" file additions, moving files, or copying them). This is necessary For reasons discussed in #4667.

#### How was it tested? How can it be tested by the reviewer?

1. Pull the PR and start octoprint
2. `octoprint serve`
3. Set logging of `octoprint.events.fire` to `DEBUG`
4. Drag-drop a file, move a file, copy a file, and observe the fired events.

#### Any background context you want to provide?

See ticket

#### What are the relevant tickets if any?

#4667

#### Screenshots (if appropriate)

#### Further notes
