### PR TITLE
:bug: Support the R parameter in temperature offsets

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -6113,7 +6113,7 @@ class SendQueue(PrependableQueue):
 
 
 _temp_command_regex = re.compile(
-    r"^M(?P<command>104|109|140|190)(\s+T(?P<tool>\d+)|\s+S(?P<temperature>[-+]?\d*\.?\d*))+"
+    r"^M(?P<command>104|109|140|190)(\s+T(?P<tool>\d+)|\s+[SR](?P<temperature>[-+]?\d*\.?\d*))+"
 )
 
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Makes temperature offsets support the R parameter. This parameter waits for cooling as well as heating and so it makes sense to be supported. It's been in Marlin for as long as I know, but can't say about wide usage.

#### How was it tested? How can it be tested by the reviewer?

Using the gcode provided in #4695

#### What are the relevant tickets if any?

Closes #4695 
