### PR TITLE
Use block scalars in YAML dumps

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -174,6 +174,7 @@ date of first contribution):
   * ["tempodat"](https://github.com/tempodat)
   * [Frederik Kemner](https://github.com/040medien)
   * [Scott Martin](https://github.com/smartin015)
+  * [Shyam Sunder](https://github.com/sgsunder)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/yaml.py
+++ b/src/octoprint/util/yaml.py
@@ -44,6 +44,14 @@ def _save_to_file_base(data, file=None, path=None, pretty=False, **kwargs):
     except ImportError:
         from yaml import SafeDumper
 
+    # make multiline strings look better by using block scalars
+    def _block_scalar_str_presenter(dumper, data):
+        return dumper.represent_scalar(
+            "tag:yaml.org,2002:str", data, style="|" if "\n" in data else None
+        )
+
+    SafeDumper.add_representer(str, _block_scalar_str_presenter)
+
     if pretty:
         # make each element go on a new line and indent by 2
         kwargs.update(default_flow_style=False, indent=2)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This is a minor tweak that improves the look of multiline string values that are dumped as YAML. Most often, it makes GCODE scripts stored inline in the `config.yaml` file look much easier to read and to hand parse.

Before:

```
  bedlevelvisualizer:
    _config_version: 1
    command: M420 T0 V
    commands:
    - command: 'M190 R%(bedtemp)s

        G34

        G29'
      confirmation: true
      enabled_while_graphing: false
      enabled_while_printing: false
```

After:

```
  bedlevelvisualizer:
    _config_version: 1
    command: M420 T0 V
    commands:
    - command: |-
        M190 R%(bedtemp)s
        G34
        G29
      confirmation: true
      enabled_while_graphing: false
      enabled_while_printing: false
```

Both statements parse equivalently so it should not have any effect on functionality. This change is only intended to make it easier for humans to read and modify.

#### How was it tested? How can it be tested by the reviewer?

* Ran pytest (Passed with no errors).
* Ran against a copy of my personal `config.yaml` file. (No errors found).

#### Any background context you want to provide?

N/A

#### What are the relevant tickets if any?

No open issues could be found regarding this.

#### Screenshots (if appropriate)

N/A

#### Further notes
