### PR TITLE
⚡ Speed up file list by moving full_extension_tree call out of the hot path

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -180,19 +180,19 @@ def get_content_type_mapping_for_extension(extension, subtree=None):
     return None
 
 
-def valid_extension(extension, type=None):
+def valid_extension(extension, type=None, tree=None):
     if not type:
-        return extension in get_all_extensions()
+        return extension in get_all_extensions(subtree=tree)
     else:
-        extensions = get_extensions(type)
+        extensions = get_extensions(type, subtree=tree)
         if extensions:
             return extension in extensions
 
 
-def valid_file_type(filename, type=None):
+def valid_file_type(filename, type=None, tree=None):
     _, extension = os.path.splitext(filename)
     extension = extension[1:].lower()
-    return valid_extension(extension, type=type)
+    return valid_extension(extension, type=type, tree=tree)
 
 
 def get_file_type(filename):

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -335,10 +335,13 @@ def _getFileList(
                     file.update({"date": f["date"]})
                 files.append(file)
     else:
+        # PERF: Only retrieve the extension tree once
+        extension_tree = octoprint.filemanager.full_extension_tree()
+
         filter_func = None
         if filter:
             filter_func = lambda entry, entry_data: octoprint.filemanager.valid_file_type(
-                entry, type=filter
+                entry, type=filter, tree=extension_tree
             )
 
         with _file_cache_mutex:
@@ -396,7 +399,7 @@ def _getFileList(
                     if (
                         "analysis" in file_or_folder
                         and octoprint.filemanager.valid_file_type(
-                            file_or_folder["name"], type="gcode"
+                            file_or_folder["name"], type="gcode", tree=extension_tree
                         )
                     ):
                         file_or_folder["gcodeAnalysis"] = file_or_folder["analysis"]
@@ -405,7 +408,7 @@ def _getFileList(
                     if (
                         "history" in file_or_folder
                         and octoprint.filemanager.valid_file_type(
-                            file_or_folder["name"], type="gcode"
+                            file_or_folder["name"], type="gcode", tree=extension_tree
                         )
                     ):
                         # convert print log

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -108,6 +108,23 @@ class FilemanagerMethodTest(unittest.TestCase):
         self.assertTrue(octoprint.filemanager.valid_file_type("foo.mime_detect_yes"))
         self.assertFalse(octoprint.filemanager.valid_file_type("foo.unknown"))
 
+        extension_tree = {
+            "machinecode": {
+                "gcode": octoprint.filemanager.ContentTypeMapping(
+                    ["gcode", "gco", "g"], "text/plain"
+                ),
+                "foo": ["foo", "f"],
+            }
+        }
+
+        # With cached extension tree
+        self.assertTrue(
+            octoprint.filemanager.valid_file_type("foo.foo", tree=extension_tree)
+        )
+        self.assertFalse(
+            octoprint.filemanager.valid_file_type("foo.amf", tree=extension_tree)
+        )
+
     def test_get_file_type(self):
         self.assertEqual(
             ["machinecode", "gcode"], octoprint.filemanager.get_file_type("foo.gcode")


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Moves `full_extension_tree` call outside the file listing loop so the extension tree is not computed for each file.

#### How was it tested? How can it be tested by the reviewer?
I tested the changes by listing files (`/api/files/local`) on an instance with virtual printer and also on an instance I use for my printer.

#### Any background context you want to provide?
I was investigating why it takes so long to get a list of files, and this was one of the things I noticed that could be improved. I currently have ~500 files in my uploads folder and `full_extension_tree` would take almost 2 seconds on RPi Zero 2. (One of the extensions I use has extension tree hook, but doesn't do anything intensive there, just returns a value.)

While I could remove some of the gcode files (again), I figured I'd rather try to speed up the code.
