### PR TITLE
✨ Add `removeMessage` to OctoPrint socket

### DIFF
--- a/docs/jsclientlib/socket.rst
+++ b/docs/jsclientlib/socket.rst
@@ -60,6 +60,23 @@
    :param string message: The type of message for which to register
    :param function handler: The handler function
 
+.. js:function:: OctoPrintClient.socker.removeMessage(message, handler)
+
+   Removes the ``handler`` for messages of type ``message``.
+
+   .. code-block:: javascript
+
+      const handler = (message) => {
+          // do something with the message object
+      };
+
+      OctoPrint.socket.onMessage("*", handler);
+      // Use the same reference to the handler function to remove it again
+      OctoPrint.socket.removeMessage("*", handler);
+
+   :param string message: The type of message for which to remove the handler
+   :param function handler: The handler function
+
 .. js:function:: OctoPrintClient.socket.sendMessage(type, payload)
 
    Sends a message of type ``type`` with the provided ``payload`` to the server.

--- a/src/octoprint/static/js/app/client/socket.js
+++ b/src/octoprint/static/js/app/client/socket.js
@@ -220,6 +220,18 @@
         return this;
     };
 
+    OctoPrintSocketClient.prototype.removeMessage = function (message, handler) {
+        if (!this.registeredHandlers.hasOwnProperty(message)) {
+            // No handlers registered, do nothing
+            return;
+        }
+
+        const index = OctoPrint.socket.registeredHandlers[message].indexOf(handler);
+        if (index > -1) {
+            OctoPrint.socket.registeredHandlers[message].splice(index, 1);
+        }
+    };
+
     OctoPrintSocketClient.prototype.onReconnectAttempt = function (trial) {};
     OctoPrintSocketClient.prototype.onReconnectFailed = function () {};
     OctoPrintSocketClient.prototype.onConnected = function () {};


### PR DESCRIPTION
Feel free to reject this - I had to add it to the socket client to make it work with React hooks in a plugin. This allows to unsubscribe components from socket messages, or I ended up with slowly increasing handler numbers.

Usage example: https://github.com/cp2004/OctoPrint-OneDriveFileSync/blob/7fb0eb5467335613ad3aa385252b3ee1194b71b7/octoprint_onedrive_files/static/src/hooks/useSocket.ts#L19-L24