### PR TITLE
Fix redirect after sign in during authorization flow

### DIFF
--- a/src/octoprint/static/js/login/login.js
+++ b/src/octoprint/static/js/login/login.js
@@ -36,7 +36,15 @@ $(function () {
             .login(username, password, remember)
             .done(() => {
                 ignoreDisconnect = true;
-                window.location.href = REDIRECT_URL;
+
+                // If the current URL has a `redirect` param we redirect to this location (e.g. authorization flow),
+                // otherwise we redirect to the default REDIRECT_URL
+                const urlParams = new URLSearchParams(window.location.search);
+                if (urlParams.has("redirect")) {
+                    window.location.href = urlParams.get("redirect");
+                } else {
+                    window.location.href = REDIRECT_URL;
+                }
             })
             .fail((xhr) => {
                 usernameElement.val(USER_ID);


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR fixes #4712. I'm not sure if this is the "proper" way, but for me it seems like there is simply a small bit of logic in the `login.js` missing. The redirection after login always goes to `REDIRECT_URL` (aka `/` if not running on a sub-path) and the URL query params are never considered. This PR adds the required check

#### How was it tested? How can it be tested by the reviewer?
Follow the instructions in #4712

#### Any background context you want to provide?
/

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)
Before: 
https://user-images.githubusercontent.com/5859228/213904524-6273ef63-4c14-48c0-91fb-954e08ffad2e.mov

After:
https://user-images.githubusercontent.com/5859228/213905358-1be60517-aace-4da1-a7cb-ceb5238d8da1.mov

#### Further notes
