### PR TITLE
add information regarding existing and new file

### DIFF
--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -192,6 +192,13 @@ def runFilesTest():
 
         exists = fileManager.file_exists(storage, sanitized)
         if exists:
+            exists_file = [gcode_file for gcode_file in _getFileList(storage) if
+                           gcode_file['name'] == filename]
+            if len(exists_file) > 0:
+                exists_size = exists_file[0]['size']
+                exists_date = exists_file[0]['date']
+            else:
+                abort(400, descrption='Not exists file found to retrive information')
             suggestion = filename
             name, ext = os.path.splitext(filename)
             counter = 0
@@ -205,7 +212,7 @@ def runFilesTest():
             ):
                 counter += 1
                 suggestion = f"{name}_{counter}{ext}"
-            return jsonify(exists=True, suggestion=suggestion)
+            return jsonify(exists=True, suggestion=suggestion, size=exists_size, date=exists_date)
         else:
             return jsonify(exists=False)
 

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1695,6 +1695,13 @@ $(function () {
             );
             $("p, form", self.uploadExistsDialog).toggle(!fileSizeTooBig);
             $("span", self.uploadExistsDialog).toggle(fileSizeTooBig);
+            $("span.existing_size", self.uploadExistsDialog).text(formatSize(response.size));
+            var date_exists = new Date(response.date * 1000);
+            $("span.existing_date", self.uploadExistsDialog).text(date_exists.toLocaleString());
+            var date = new Date(file.lastModified);
+
+            $("span.new_size", self.uploadExistsDialog).text(formatSize(file.size));
+            $("span.new_date", self.uploadExistsDialog).text(date.toLocaleString());
             $("input", self.uploadExistsDialog)
                 .val("")
                 .prop("placeholder", response.suggestion);

--- a/src/octoprint/templates/dialogs/files.jinja2
+++ b/src/octoprint/templates/dialogs/files.jinja2
@@ -70,10 +70,26 @@
                 </div>
             </div>
         </form>
+        <div>
+            <b>Existing file</b>
+            <ul>
+            <li>Size: <span class="existing_size"></span></li>
+            <li>Date: <span class="existing_date"></span></li>
+            </ul>
+
+            <b>New file</b>
+            <ul>
+            <li>Size: <span class="new_size"></span></li>
+            <li>Date: <span class="new_date"></span></li>
+            </ul>
+        </div>
         <span hidden>
             {{ _('There is not enough free disk space to keep the existing file and upload this one.') }}
         </span>
+
+
     </div>
+
     <div class="modal-footer">
         <a href="javascript:void(0)" class="btn" data-dismiss="modal" aria-hidden="true">{{ _('Cancel') }}</a>
         <a href="javascript:void(0)" class="btn btn-primary upload-rename">{{ _('Upload (rename)') }}</a>


### PR DESCRIPTION


  * [ x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [ x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [ x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x ] Your changes follow the existing coding style
  * [ x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [ x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ x] You have run the existing unit tests against your changes and
    nothing broke
  * [ x] You have added yourself to the `AUTHORS.md` file :)



#### What does this PR do and why is it necessary?

The change is made in the files.py which returns current information about the existing file and show the differences on the model before overrite the file.

#### How was it tested? How can it be tested by the reviewer?

Yes tested locally

#### Any background context you want to provide?


#### What are the relevant tickets if any?

 #4681

#### Scre
![Selection_011](https://user-images.githubusercontent.com/1809444/215602616-6ee16681-2752-48f5-a53a-3b7d8ec33907.jpg)
enshots (if appropriate)

#### Further notes
