### PR TITLE
Remove custom port from CSRF cookie suffix

### DIFF
--- a/src/octoprint/static/js/app/client/base.js
+++ b/src/octoprint/static/js/app/client/base.js
@@ -119,7 +119,7 @@
             if (!path || path[0] !== "/") {
                 path = "/" + (path ? path : "");
             }
-            var url = new URL(parsed.protocol + "//" + parsed.host + path);
+            var url = new URL(parsed.protocol + "//" + parsed.hostname + path);
         }
 
         return url;


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Addresses: https://github.com/OctoPrint/OctoPrint/issues/4740 by utilizing 443 or 80 as the port for the CSRF cookie name even if a custom port is being used.

#### How was it tested? How can it be tested by the reviewer?
The best method is to set up an NGINX proxy outside of OctoPi running on `https://octoprint.domain.com:12345` and confirm that `https://octoprint.domain.com:12345/reverse_proxy_test/` is all green. You will see 443 as the port (to align to the server port from OctoPi). Without this fix, logins will fail with a 400, with it, they will succeed regardless of if you are running a standard port, non-standard port, going through `haproxy`, or direct.

#### Any background context you want to provide?
https://github.com/OctoPrint/OctoPrint/issues/4740 has a link to the forum post with a full description and debugging of this issue.

#### What are the relevant tickets if any?
https://github.com/OctoPrint/OctoPrint/issues/4740 

#### Screenshots (if appropriate)
N/A

#### Further notes
N/A