### PR TITLE
Send history message when WS subscription is changed

### DIFF
--- a/src/octoprint/server/util/sockjs.py
+++ b/src/octoprint/server/util/sockjs.py
@@ -382,10 +382,12 @@ class PrinterStateConnection(
                 self._subscriptions["plugins"] = plugins
                 self._subscriptions["events"] = events
 
-                if state and not old_state:
-                    # trigger initial data
+                if state and state != old_state:
+                    # state is requested and was changed from previous state
+                    # we should send a history message to send the update data
                     self._printer.send_initial_callback(self)
                 elif old_state and not state:
+                    # we no longer should send state updates
                     self._initial_data_sent = False
 
     def on_printer_send_current_data(self, data):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
When a client makes use of the selective subscription system the subscription can be updated at any point in time. At the moment if the client moves the `state` from something to `false` we stop sending current messages and if we move it from `false` to something (e.g. `true` or some filter object) we start sending current messages and send a history message.

If the client changes the subscription, e.g. from filtering terminal logs to wanting to consume all terminal logs, no history message is emitted at the moment. If the client wants to receive all logs matching the `state` subscription, the connection needs to be terminated and reconnected or the `state` needs to be set to `false` first

As the history message is emitted when the subscription changes in certain ways (`false` -> something), it should also be emitted when the subscription changes from something to something else.

#### How was it tested? How can it be tested by the reviewer?
Tested by sending subscription messages

#### Any background context you want to provide?
~

#### What are the relevant tickets if any?
~

#### Screenshots (if appropriate)
~

#### Further notes
~