### PR TITLE
Added D3 to default list of autoUppercaseBlacklist

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -176,6 +176,7 @@ date of first contribution):
   * [Moiz Rasheed](https://github.com/msrasheed)
   * [Scott Martin](https://github.com/smartin015)
   * [Shyam Sunder](https://github.com/sgsunder)
+  * [Alex Iribarren](https://github.com/alexiri)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/schema/config/feature.py
+++ b/src/octoprint/schema/config/feature.py
@@ -35,7 +35,7 @@ class FeatureConfig(BaseModel):
 
     uploadOverwriteConfirmation: bool = True
 
-    autoUppercaseBlacklist: List[str] = ["M117", "M118"]
+    autoUppercaseBlacklist: List[str] = ["M117", "M118", "D3"]
     """Commands that should never be auto-uppercased when sent to the printer through the Terminal tab."""
 
     g90InfluencesExtruder: bool = False


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds the gcode command D3 to the default list of gcodes excluded from uppercasing. [D3](https://reprap.org/wiki/G-code#D3:_Read.2FWrite_EEPROM) is a Prusa firmware debugging gcode that allows you to read and write the EEPROM, and the data to be written is encoded as case-sensitive alphanumerics. Uppercasing the data would alter what is being written to the EEPROM, with potentially serious consequences.

This is a Prusa firmware specific gcode (for now), but this is a pretty low-risk change and it could save other Prusa users quite a bit of trouble in the future.

#### How was it tested? How can it be tested by the reviewer?

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
