### PR TITLE
Use webcam container for intersection instead of controls

### DIFF
--- a/src/octoprint/plugins/classicwebcam/static/js/classicwebcam.js
+++ b/src/octoprint/plugins/classicwebcam/static/js/classicwebcam.js
@@ -117,18 +117,11 @@ $(function () {
         };
 
         self._enableWebcam = function () {
-            if (
-                OctoPrint.coreui.selectedTab != "#control" ||
-                !OctoPrint.coreui.browserTabVisible
-            ) {
-                return;
-            }
-
             if (self.webcamDisableTimeout != undefined) {
                 clearTimeout(self.webcamDisableTimeout);
             }
 
-            // IF disabled then we dont need to do anything
+            // If disabled then we dont need to do anything
             if (self.settings.webcamEnabled() == false) {
                 console.log("Webcam not enabled");
                 return;
@@ -156,7 +149,7 @@ $(function () {
         };
 
         self.onWebcamErrored = function () {
-            log.debug("Webcam stream failed to load/disabled");
+            log.debug("Webcam stream failed to load/was unloaded");
             self.webcamLoaded(false);
             self.webcamError(true);
         };

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -85,7 +85,7 @@ $(function () {
                 .querySelectorAll("#webcam-group .tab-pane")
                 .forEach(function (target) {
                     var options = {
-                        root: document.querySelector("#control"),
+                        root: document.querySelector("#webcam_plugins_container"),
                         rootMargin: "0px",
                         threshold: 1.0
                     };

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -37,6 +37,7 @@ $(function () {
 
         self.controlsFromServer = [];
         self.additionalControls = [];
+        self.intersectionObservers = [];
 
         self.keycontrolActive = ko.observable(false);
         self.keycontrolHelpActive = ko.observable(false);
@@ -75,12 +76,21 @@ $(function () {
         };
 
         self.onAfterBinding = function () {
+            self.recreateIntersectionObservers();
+        };
+
+        self.recreateIntersectionObservers = function () {
             // We are using the IntersectionObserver API to determine whether a webcam is visible or not.
             // A webcam will not intersect with the control tab if the control tab is invisible because another tab
             // is selected or if the webcam isn't shown because another webcam is active.
             //
             // Whenever the webacam changes visibility we will call onWebcamVisbilityChange() which the webcam's
             //  VM can use to start or stop the stream.
+            self.intersectionObservers.forEach(function (observer) {
+                observer.disconnect();
+            });
+            self.intersectionObservers = [];
+
             document
                 .querySelectorAll("#webcam-group .tab-pane")
                 .forEach(function (target) {
@@ -103,6 +113,7 @@ $(function () {
 
                     var observer = new IntersectionObserver(callback, options);
                     observer.observe(target);
+                    self.intersectionObservers.push(observer);
                 });
         };
 

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -75,7 +75,7 @@ $(function () {
             }
         };
 
-        self.onAfterBinding = function () {
+        self.onStartupComplete = function () {
             self.recreateIntersectionObservers();
         };
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This is a minor change to allow @LazeMSS and others to move the webcam surface around. We used `#control` to determine if the webcam and if yes which webcam plugin is visible to the user. This causes issues if the webcam is not embedded in `#control`. This PR changes the intersection code to use `#webcam_plugins_container` which is the outer most div containing webcam code.

Functionally, this does not make any difference in vanilla OctoPrint

#### How was it tested? How can it be tested by the reviewer?

- Switch away from control tab -> Webcam unloaded after 5s
- Switch browser tab -> Webcam unloaded after 5s

#### Any background context you want to provide?

https://discord.com/channels/704958479194128507/708230829050036236/1083833450076848229

#### What are the relevant tickets if any?
https://github.com/LazeMSS/OctoPrint-UICustomizer/issues/281

#### Screenshots (if appropriate)
~

#### Further notes
~
