### PR TITLE
Add X-Original-Content-Length to avoid issues with chunked transfers

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
@@ -353,7 +353,7 @@ var gCodeLineGenerator = async function* (fileURL) {
     const reader = response.body.getReader();
 
     // we use these two variables to calculate the percentage.
-    var totalDownloadLength = response.headers.get("content-length");
+    var totalDownloadLength = response.headers.get("X-Original-Content-Length");
     var currentDownloadLength = 0;
 
     // lets read a first data chunk

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -1192,6 +1192,8 @@ class LargeResponseHandler(
             self.set_header("Cache-Control", "max-age=0, must-revalidate, private")
             self.set_header("Expires", "-1")
 
+        self.set_header("X-Original-Content-Length", str(self.get_content_size()))
+
     @property
     def original_absolute_path(self):
         """The path of the uncompressed file corresponding to the compressed file"""


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes issue #4772 

Because we enable compression in haproxy in OctoPi, the request is converted from normal to chunked. When using a chunked request, there is no Content-Length header the GCodeViewer worker depended on.

This PR adds a custom header X-Original-Content-Length that works around this issue. As this is a custom header, it is not touched by HAProxy. The actual length does not change because the compression is removed by the browser, restoring the original length (but not the Content-Length header).

#### How was it tested? How can it be tested by the reviewer?

This was tested by start a print and opening the GCodeViewer.

#### What are the relevant tickets if any?

Closes #4772 
