### PR TITLE
🐛  Fix `webcam.snapshotWebcam` not saving to config

### DIFF
--- a/src/octoprint/schema/config/webcam.py
+++ b/src/octoprint/schema/config/webcam.py
@@ -78,3 +78,6 @@ class WebcamConfig(BaseModel):
 
     defaultWebcam: str = "classic"
     """The name of the default webcam"""
+
+    snapshotWebcam: str = "classic"
+    """The name of the default webcam to use for snapshots"""


### PR DESCRIPTION
It had no default so OctoPrint didn't want to save it

Closes #4783
