### PR TITLE
double slash basedir breaks timelapse delete

### DIFF
--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -178,7 +178,7 @@ def deleteTimelapse(filename):
     thumb_path = octoprint.timelapse.create_thumbnail_path(full_path)
     if (
         octoprint.timelapse.valid_timelapse(full_path)
-        and full_path.startswith(timelapse_folder)
+        and full_path.startswith(os.path.realpath(timelapse_folder))
         and os.path.exists(full_path)
         and not util.is_hidden_path(full_path)
     ):
@@ -192,7 +192,7 @@ def deleteTimelapse(filename):
 
     if (
         octoprint.timelapse.valid_timelapse_thumbnail(thumb_path)
-        and thumb_path.startswith(timelapse_folder)
+        and thumb_path.startswith(os.path.realpath(timelapse_folder))
         and os.path.exists(thumb_path)
         and not util.is_hidden_path(thumb_path)
     ):


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

When running OctoPrint with a basedir specified with a double slash in the path deleting timelapses will not work because they no longer pass the check. 

#### What does this PR do and why is it necessary?
Wraps the timelapse_folder paramter with os.path.realpath in the startswith checks so that they pass as expected.

#### How was it tested? How can it be tested by the reviewer?
Ran OctoPrint manually specifying a basedir and config parameter to a path that included double slashes.

#### Any background context you want to provide?
Lengthy Discord discussion that went over a couple of days: https://discord.com/channels/704958479194128507/705046975669600298/1096470187420688434

#### What are the relevant tickets if any?
n/a

#### Screenshots (if appropriate)
n/a

#### Further notes
