### PR TITLE
log extruder and file position on pause

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -519,6 +519,10 @@ PrintCancelled
      * ``position.f``: last feedrate for move commands **sent through OctoPrint** (note that if you modified the
        feedrate outside of OctoPrint, e.g. through the printer controller, or if you are printing from SD, this will
        NOT be accurate)
+     * ``fileposition``: record of the processed file and current position inside in the moment of cancel
+     * ``fileposition.origin``: origin of the file (local or SD card)
+     * ``fileposition.filename``: full path to the filename on octoprint filesystem
+     * ``fileposition.pos``: position in the file in bytes
 
    .. deprecated:: 1.3.0
 
@@ -550,6 +554,10 @@ PrintPaused
      * ``position.f``: last feedrate for move commands **sent through OctoPrint** (note that if you modified the
        feedrate outside of OctoPrint, e.g. through the printer controller, or if you are printing from SD, this will
        NOT be accurate)
+     * ``fileposition``: record of the processed file and current position inside in the moment of pause
+     * ``fileposition.origin``: origin of the file (local or SD card)
+     * ``fileposition.filename``: full path to the filename on octoprint filesystem
+     * ``fileposition.pos``: position in the file in bytes
 
    .. deprecated:: 1.3.0
 

--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -519,10 +519,7 @@ PrintCancelled
      * ``position.f``: last feedrate for move commands **sent through OctoPrint** (note that if you modified the
        feedrate outside of OctoPrint, e.g. through the printer controller, or if you are printing from SD, this will
        NOT be accurate)
-     * ``fileposition``: record of the processed file and current position inside in the moment of cancel
-     * ``fileposition.origin``: origin of the file (local or SD card)
-     * ``fileposition.filename``: full path to the filename on octoprint filesystem
-     * ``fileposition.pos``: position in the file in bytes
+     * ``fileposition``: position in the file in bytes at the time of cancellation
 
    .. deprecated:: 1.3.0
 
@@ -554,10 +551,7 @@ PrintPaused
      * ``position.f``: last feedrate for move commands **sent through OctoPrint** (note that if you modified the
        feedrate outside of OctoPrint, e.g. through the printer controller, or if you are printing from SD, this will
        NOT be accurate)
-     * ``fileposition``: record of the processed file and current position inside in the moment of pause
-     * ``fileposition.origin``: origin of the file (local or SD card)
-     * ``fileposition.filename``: full path to the filename on octoprint filesystem
-     * ``fileposition.pos``: position in the file in bytes
+     * ``fileposition``: position in the file in bytes at the time of pausing
 
    .. deprecated:: 1.3.0
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1691,6 +1691,9 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             position=self._comm.cancel_position.as_dict()
             if self._comm and self._comm.cancel_position
             else None,
+            fileposition=self._comm.getFilePosition()
+            if self._comm
+            else None,
             action_user=user,
         )
         if payload:
@@ -1702,11 +1705,13 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
                 {"type": "cancel", "label": "Cancel"},
             )
             self._logger_job.info(
-                "Print job cancelled - origin: {}, path: {}, owner: {}, user: {}".format(
+                "Print job cancelled - origin: {}, path: {}, owner: {}, user: {}, fileposition: {}, position: {}".format(
                     payload.get("origin"),
                     payload.get("path"),
                     payload.get("owner"),
                     payload.get("user"),
+                    payload.get("fileposition"),
+                    payload.get("position"),
                 )
             )
 
@@ -1740,23 +1745,21 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             position=self._comm.pause_position.as_dict()
             if self._comm and self._comm.pause_position and not suppress_script
             else None,
+            fileposition=self._comm.getFilePosition()
+            if self._comm
+            else None,
             action_user=user,
         )
         if payload:
             eventManager().fire(Events.PRINT_PAUSED, payload)
-            if "position" in payload:
-                position = str(payload["position"])
-            else:
-                position = "unknown"
-            fileposition = str(self._comm.getFilePosition())
             self._logger_job.info(
                 "Print job paused - origin: {}, path: {}, owner: {}, user: {}, fileposition: {}, position: {}".format(
                     payload.get("origin"),
                     payload.get("path"),
                     payload.get("owner"),
                     payload.get("user"),
-                    fileposition,
-                    position,
+                    payload.get("fileposition"),
+                    payload.get("position"),
                 )
             )
             eventManager().fire(
@@ -1872,6 +1875,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         print_job_size=None,
         print_job_user=None,
         position=None,
+        fileposition=None,
         action_user=None,
     ):
         if print_job_file is None:
@@ -1913,6 +1917,9 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
         if position is not None:
             result["position"] = position
+
+        if fileposition is not None:
+            result["fileposition"] = fileposition
 
         if print_job_user is not None:
             result["owner"] = print_job_user

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1748,9 +1748,9 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
                 position = str(payload["position"])
             else:
                 position = "unknown"
-            fileposition = str(self._comm.getFilePosition());
+            fileposition = str(self._comm.getFilePosition())
             self._logger_job.info(
-                    "Print job paused - origin: {}, path: {}, owner: {}, user: {}, fileposition: {}, position: {}".format(
+                "Print job paused - origin: {}, path: {}, owner: {}, user: {}, fileposition: {}, position: {}".format(
                     payload.get("origin"),
                     payload.get("path"),
                     payload.get("owner"),

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1691,9 +1691,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             position=self._comm.cancel_position.as_dict()
             if self._comm and self._comm.cancel_position
             else None,
-            fileposition=self._comm.getFilePosition()
-            if self._comm
-            else None,
+            fileposition=self._comm.getFilePosition() if self._comm else None,
             action_user=user,
         )
         if payload:
@@ -1745,9 +1743,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             position=self._comm.pause_position.as_dict()
             if self._comm and self._comm.pause_position and not suppress_script
             else None,
-            fileposition=self._comm.getFilePosition()
-            if self._comm
-            else None,
+            fileposition=self._comm.getFilePosition() if self._comm else None,
             action_user=user,
         )
         if payload:

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1744,12 +1744,19 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         )
         if payload:
             eventManager().fire(Events.PRINT_PAUSED, payload)
+            if "position" in payload:
+                position = str(payload["position"])
+            else:
+                position = "unknown"
+            fileposition = str(self._comm.getFilePosition());
             self._logger_job.info(
-                "Print job paused - origin: {}, path: {}, owner: {}, user: {}".format(
+                    "Print job paused - origin: {}, path: {}, owner: {}, user: {}, fileposition: {}, position: {}".format(
                     payload.get("origin"),
                     payload.get("path"),
                     payload.get("owner"),
                     payload.get("user"),
+                    fileposition,
+                    position,
                 )
             )
             eventManager().fire(

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1687,11 +1687,12 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         self._setCurrentZ(None)
         self._updateProgressData()
 
+        fileposition = self._comm.getFilePosition() if self._comm else None
         payload = self._payload_for_print_job_event(
             position=self._comm.cancel_position.as_dict()
             if self._comm and self._comm.cancel_position
             else None,
-            fileposition=self._comm.getFilePosition() if self._comm else None,
+            fileposition=fileposition["pos"] if fileposition else None,
             action_user=user,
         )
         if payload:
@@ -1739,11 +1740,12 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             thread.start()
 
     def on_comm_print_job_paused(self, suppress_script=False, user=None):
+        fileposition = self._comm.getFilePosition() if self._comm else None
         payload = self._payload_for_print_job_event(
             position=self._comm.pause_position.as_dict()
             if self._comm and self._comm.pause_position and not suppress_script
             else None,
-            fileposition=self._comm.getFilePosition() if self._comm else None,
+            fileposition=fileposition["pos"] if fileposition else None,
             action_user=user,
         )
         if payload:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
It logs extruder and file position to log in case of failure during pause state.

#### How was it tested? How can it be tested by the reviewer?
I run it during printing and the log showed added values

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
