### PR TITLE
improve pause gcode

### DIFF
--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -213,7 +213,7 @@ to the persisted pause position on resume, making sure to also reset the extrude
 .. code-block:: jinja
    :caption: ``afterPrintPaused`` script
 
-   ; (optional) disable stepper inactivity timeout - uncoment if you printer disables steppers during pause and supports this command
+   ; (optional) disable stepper inactivity timeout - uncomment if you printer disables steppers during pause and supports this command
    ;M18 S0
 
    {% if pause_position.x is not none %}

--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -213,8 +213,8 @@ to the persisted pause position on resume, making sure to also reset the extrude
 .. code-block:: jinja
    :caption: ``afterPrintPaused`` script
 
-   ; disable stepper inactivity timeout - otherwise axes can move
-   M18 S0
+   ; (optional) disable stepper inactivity timeout - uncoment if you printer disables steppers during pause and supports this command
+   ;M18 S0
 
    {% if pause_position.x is not none %}
    ; relative XYZE

--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -212,6 +212,9 @@ to the persisted pause position on resume, making sure to also reset the extrude
 
 .. code-block:: jinja
    :caption: ``afterPrintPaused`` script
+   
+   ; disable stepper inactivity timeout - otherwise axes can move
+   M18 S0
 
    {% if pause_position.x is not none %}
    ; relative XYZE

--- a/docs/features/gcode_scripts.rst
+++ b/docs/features/gcode_scripts.rst
@@ -212,7 +212,7 @@ to the persisted pause position on resume, making sure to also reset the extrude
 
 .. code-block:: jinja
    :caption: ``afterPrintPaused`` script
-   
+
    ; disable stepper inactivity timeout - otherwise axes can move
    M18 S0
 


### PR DESCRIPTION
Without this command, steppers get disabled after a while (at least in Marlin) and axes can move during maintenance operations ( filament change, magnets inserts, etc.)