### PR TITLE
:bug: Reduce intersection observer threshold

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -122,7 +122,7 @@ $(function () {
                     var options = {
                         root: document.querySelector("#webcam_plugins_container"),
                         rootMargin: "0px",
-                        threshold: 1.0
+                        threshold: 0.9
                     };
                     var callback = function (entries) {
                         var visible = entries[0].isIntersecting;

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -57,19 +57,20 @@ $(function () {
         self._visibleWebcam = undefined;
 
         self._dispatchWebcamVisibilityChange = function (target, visible) {
+            log.debug(`Webcam visibility of #${target.id} changed to ${visible}`);
             var vm = ko.dataFor(target.children[0]);
             if (vm === self) {
-                console.debug(
+                log.debug(
                     `VM for webcam #${target.id} is not bound, skipping visibility update`
                 );
             } else if (vm === undefined) {
-                console.debug(
+                log.debug(
                     `VM for webcam #${target.id} not found, skipping visibility update`
                 );
             } else if (typeof vm.onWebcamVisibilityChange === "function") {
                 vm.onWebcamVisibilityChange(visible);
             } else {
-                console.debug(
+                log.debug(
                     `VM for webcam #${target.id} does not declare 'onWebcamVisibilityChange(visible)', skipping visibility update (vm=${vm.constructor.name})`
                 );
             }

--- a/src/octoprint/static/js/app/viewmodels/control.js
+++ b/src/octoprint/static/js/app/viewmodels/control.js
@@ -122,7 +122,7 @@ $(function () {
                     var options = {
                         root: document.querySelector("#webcam_plugins_container"),
                         rootMargin: "0px",
-                        threshold: 0.9
+                        threshold: 0.01
                     };
                     var callback = function (entries) {
                         var visible = entries[0].isIntersecting;


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
When this value is 1, scrolling down the page triggers the value to change - probably something changes invisibly. Setting it to anything less than 1 seems to cure the issue, and there are no longer unwanted triggers of changes.

#### How was it tested? How can it be tested by the reviewer?
Added logging to the 'Classic Webcam' plugin, and my own for when the visibility changed.

I haven't tested it with *just* the classic webcam plugin installed, to see whether it is only triggered by something I have done.

Once this was changed, the plugins stopped logging visibility changes on scrolling and the stream was stablez

#### Any background context you want to provide?
Working on CameraStreamerControl

#### What are the relevant tickets if any?
None

#### Screenshots (if appropriate)
The video I captured is a large file, too much for here, but it is posted to discord alright

https://discord.com/channels/704958479194128507/708230829050036236/1115668233874321549

#### Further notes

This may be my fault, I'm not sure.