### PR TITLE
GCodeViewer: fix onTabChange bug

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -891,8 +891,11 @@ $(function () {
         self.onTabChange = function (current, previous) {
             self.tabActive = current === "#gcode";
             if (self.tabActive && self.needsLoad) {
-                self.loadFile(self.selectedFile.path(), self.selectedFile.date()),
-                    self.selectedFile.size();
+                self.loadFile(
+                    self.selectedFile.path(),
+                    self.selectedFile.date(),
+                    self.selectedFile.size()
+                );
             }
         };
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Fixes a bug in onTabChange() in the gcodeviewer.

#### How was it tested? How can it be tested by the reviewer?

1. go to gcodeviewre load print A
2. load print B
3. go to other tab, select print A
4. go to gcode viewer

With the bug, this resulted either in a double load or single load followed by a clear().

#### Any background context you want to provide?

Just a parenthesis in the wrong place.
