### PR TITLE
gcode viewer missing name in warning

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_tab.jinja2
+++ b/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_tab.jinja2
@@ -125,7 +125,7 @@
 <div data-bind="visible: waitForApproval">
     <h1>{{ _('Warning') }}</h1>
     {% trans %}<p>
-        You've selected <strong data-bind="text: selectedFile.name"></strong> for printing which has a size of
+        You've selected <strong data-bind="text: selectedFile.path"></strong> for printing which has a size of
         <strong data-bind="text: formatSize(selectedFile.size())"></strong>. Depending on your machine this
         might be too large for rendering and cause your browser to become unresponsive or crash.
     </p>
@@ -136,7 +136,7 @@
 
     <p>
         <button class="btn btn-warning btn-block" data-bind="click: approveLargeFile">
-            {{ _('Yes, please visualize %(name)s regardless of its size', name='<span data-bind="text: selectedFile.name"></span>') }}
+            {{ _('Yes, please visualize %(name)s regardless of its size', name='<span data-bind="text: selectedFile.path"></span>') }}
         </button>
     <p>
 


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

changes ko binding to path instead of non-existant name attribute

#### How was it tested? How can it be tested by the reviewer?

updated in local dev env

#### Any background context you want to provide?

#### What are the relevant tickets if any?

resolves #4841

#### Screenshots (if appropriate)

before

![image](https://github.com/OctoPrint/OctoPrint/assets/5249455/aa9219ba-a2e1-4214-9b44-7dfca8c63477)

after

![image](https://github.com/OctoPrint/OctoPrint/assets/5249455/25f6e211-c9a6-4738-a2a8-90003f860b45)

#### Further notes
