### PR TITLE
✨ Track printer profile information

### DIFF
--- a/src/octoprint/plugins/tracking/__init__.py
+++ b/src/octoprint/plugins/tracking/__init__.py
@@ -273,6 +273,8 @@ class TrackingPlugin(
             )
         )
 
+        payload["printer_profile_count"] = len(self._printer_profile_manager.get_all())
+
         self._track("pong", body=True, **payload)
 
     def _track_startup(self):
@@ -473,6 +475,13 @@ class TrackingPlugin(
             if self._printer_connection_parameters:
                 args["printer_port"] = self._printer_connection_parameters["port"]
                 args["printer_baudrate"] = self._printer_connection_parameters["baudrate"]
+
+            profile = self._printer_profile_manager.get_current().copy()
+            for k in ["id", "name", "model"]:
+                # Scrub these out since they could be identifiable information
+                profile.pop(k)
+            args["printer_profile"] = profile
+
             self._track("printer_connected", **args)
 
     def _track_printer_safety_event(self, event, payload):


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
This PR adds printer profile information to anonymous tracking. This can be useful to determine what features/changes to focus on.

#### How was it tested? How can it be tested by the reviewer?
This was locally tested to ensure the data is compiled and shipped. Data ingestion rules may need to be adjusted to accept the traffic and the dashboard will need to be updated to make use of the data.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

Right now the primary reason to gather this info is to see how profiles are used. Initially I think it would be worthwhile to display a profile count as a pie chart in `data.octoprint.org`
