### PR TITLE
event manager plugin tweaks

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -32,12 +32,15 @@ Example
        command: python ~/growl.py -t mygrowlserver -d "Lost connection to printer" -a OctoPrint -i http://raspi/Octoprint_logo.png
        type: system
        enabled: false
+       name: Disconnected
      - event: PrintStarted
        command: python ~/growl.py -t mygrowlserver -d "Starting {file}" -a OctoPrint -i http://raspi/Octoprint_logo.png
        type: system
+       name: Print Started
      - event: PrintDone
        command: python ~/growl.py -t mygrowlserver -d "Completed {file}" -a OctoPrint -i http://raspi/Octoprint_logo.png
        type: system
+       name: Print Done
      - event:
        - PrintStarted
        - PrintFailed
@@ -45,12 +48,14 @@ Example
        - PrintCancelled
        command: python ~/growl.py -t mygrowlserver -d "Event {__eventname} ({name})" -a OctoPrint -i http://raspi/Octoprint_logo.png
        type: system
+       name: Multiple Events
      - event: Connected
        command:
        - M115
        - M117 printer connected!
        - G28
        type: gcode
+       name: Connected
 
 .. _sec-events-placeholders:
 

--- a/src/octoprint/plugins/eventmanager/__init__.py
+++ b/src/octoprint/plugins/eventmanager/__init__.py
@@ -19,7 +19,7 @@ class EventManagerPlugin(
         for event in events.get("subscriptions", []):
             if "name" not in event:
                 event["name"] = event["command"]
-            if not type(event["event"]) == list:
+            if not isinstance(event["event"], list):
                 event["event"] = [event["event"]]
         if events:
             my_settings["subscriptions"] = sorted(

--- a/src/octoprint/plugins/eventmanager/__init__.py
+++ b/src/octoprint/plugins/eventmanager/__init__.py
@@ -19,9 +19,11 @@ class EventManagerPlugin(
         for event in events.get("subscriptions", []):
             if "name" not in event:
                 event["name"] = event["command"]
+            if not type(event["event"]) == list:
+                event["event"] = [event["event"]]
         if events:
             my_settings["subscriptions"] = sorted(
-                events.get("subscriptions", []), key=(lambda x: x["event"])
+                events.get("subscriptions", []), key=(lambda x: x["name"])
             )
         return my_settings
 

--- a/src/octoprint/plugins/eventmanager/templates/eventmanager_settings.jinja2
+++ b/src/octoprint/plugins/eventmanager/templates/eventmanager_settings.jinja2
@@ -3,16 +3,16 @@
     <p><strong>{{ _('Warning:') }}</strong> {{ _('For changes to take effect you must restart OctoPrint after saving.') }}</p>
 </div>
 <div class="row-fluid">
-    <div class="span4">{{ _('Event') }}</div>
-    <div class="span6">{{ _('Name') }}</div>
+    <div class="span4">{{ _('Name') }}</div>
+    <div class="span6">{{ _('Event(s)') }}</div>
     <div class="span2 btn-group">
         <button class="btn btn-mini" data-bind="click: addEvent"><i class="fa fa-plus"></i> {{ _('Add') }}</button>
     </div>
 </div>
 <div data-bind="foreach: settingsViewModel.settings.plugins.eventmanager.subscriptions" class="row-fluid">
     <div class="row-fluid">
-        <div class="span4" data-bind="text: event"></div>
-        <div class="span6" data-bind="attr: {title: command}, text: name() ? name() : command()"></div>
+        <div class="span4" data-bind="attr: {title: command}, text: name() ? name() : command()"></div>
+        <div class="span6" data-bind="text: event"></div>
         <div class="span2 btn-group">
             <button class="btn btn-mini" data-bind="click: $root.editEvent"><i class="fa fa-pencil"></i></button>
             <button class="btn btn-mini btn-danger" data-bind="click: $root.removeEvent"><i class="fa fa-trash-alt"></i></button>
@@ -27,16 +27,15 @@
     </div>
     <div class="modal-body">
         <div class="control-group">
-            <label class="control-label">{{ _('Event') }}</label>
-            <div class="controls">
-                <select class="input-block-level" data-bind="value: event, options: $root.settingsViewModel.settings.plugins.eventmanager.availableEvents().sort(), optionsCaption: 'Select Event', valueAllowUnset: true"></select>
-            </div>
-        </div>
-
-        <div class="control-group">
             <label class="control-label">{{ _('Name') }}</label>
             <div class="controls">
                 <input type="text" class="input-block-level" data-bind="value: name" />
+            </div>
+        </div>
+        <div class="control-group">
+            <label class="control-label">{{ _('Event(s)') }}</label>
+            <div class="controls">
+                <select class="input-block-level" data-bind="selectedOptions: event, options: $root.settingsViewModel.settings.plugins.eventmanager.availableEvents().sort(), valueAllowUnset: true" multiple="multiple" size="5"></select>
             </div>
         </div>
         <div class="control-group">


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?
- fixes issues related to a list element defined to event property of subscription that would break the UI
- update docs event examples to include name
- rearrange main event subscriptions list flipping name and event
#### How was it tested? How can it be tested by the reviewer?
running locally in dev environment, with both single string event in config.yaml and list event assigned to different subscriptions
#### Any background context you want to provide?
https://discord.com/channels/704958479194128507/708230241285439518/1129926871207907398
#### What are the relevant tickets if any?

#### Screenshots (if appropriate)
![image](https://github.com/OctoPrint/OctoPrint/assets/5249455/11eab61a-80bf-4256-b9a3-dd1a314307a8)
![image](https://github.com/OctoPrint/OctoPrint/assets/5249455/021efd7a-2e5d-4eb7-8b1c-60beffc662c1)

#### Further notes
if you have a better UI for multiple selection list, please share. not entirely happy with the standard multiple select list and couldn't remember if there was a special checkbox single line fly-out type option bundled in OctoPrint already or not. May poke around and see if I can find one in current UI. 