### PR TITLE
🚸 New thermal kill error message

### DIFF
--- a/src/octoprint/util/comm.py
+++ b/src/octoprint/util/comm.py
@@ -90,7 +90,7 @@ regex_minMaxError = re.compile(r"Error:[0-9]\n")
 """Regex matching first line of min/max errors from the firmware."""
 
 regex_marlinKillError = re.compile(
-    r"Heating failed|Thermal Runaway|MAXTEMP triggered|MINTEMP triggered|Invalid extruder number|Watchdog barked|KILL caused"
+    r"Heating failed|Thermal Runaway|Thermal Malfunction|MAXTEMP triggered|MINTEMP triggered|Invalid extruder number|Watchdog barked|KILL caused"
 )
 """Regex matching first line of kill causing errors from Marlin."""
 


### PR DESCRIPTION
Added in MarlinFirmware/Marlin#23373

This PR adds a new string "Thermal Malfunction" to `regex_marlinKillError`. This message is emitted as part of the KILL process when the temperature variance monitor sees a frozen temperature sensor.

Not tested, but it's an obvious change. Marlin can be forced to emit this string to test the host response by sending `M118 Thermal Malfunction`.
