### PR TITLE
Drop Python 3.7 (EOL)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,10 +14,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: 🏗 Set up Python 3.7
+      - name: 🏗 Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: 🏗 Install build dependencies
         run: |
           python -m pip install wheel --user
@@ -35,10 +35,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: 🏗 Set up Python 3.7
+      - name: 🏗 Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
       - name: 🏗 Set up dev dependencies
         run: |
           pip install -e .[develop]
@@ -50,7 +50,7 @@ jobs:
     name: 🧪 Unit tests
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -84,7 +84,7 @@ jobs:
     needs: build
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         installable: ["wheel", "sdist"]
     runs-on: ubuntu-latest
     steps:
@@ -120,10 +120,10 @@ jobs:
           name: dist
           path: dist
 
-      - name: 🏗 Set up Python 3.7
+      - name: 🏗 Set up Python 3.8
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.8
 
       - name: 🏗 Install OctoPrint build
         run: |

--- a/.github/workflows/test_install.yml
+++ b/.github/workflows/test_install.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
         branch: ["master"]
     runs-on: ${{ matrix.os }}
     steps:
@@ -51,7 +51,7 @@ jobs:
     strategy:
       matrix:
         os: ["ubuntu-latest"]
-        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
+        python: ["3.8", "3.9", "3.10", "3.11"]
     runs-on: ${{ matrix.os }}
     steps:
       - name: 👀 Determine latest release

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -181,6 +181,7 @@ date of first contribution):
   * [Christopher Perrin](https://github.com/cperrin88)
   * [Martin Bartsch](https://github.com/kaenguruhs)
   * [Matthias Weis](https://github.com/mad73923)
+  * [Anna Bocharova](https://github.com/RobinTail)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ which is a custom SD card image that includes OctoPrint plus dependencies.
 The generic steps that should basically be done regardless of operating system
 and runtime environment are the following (as *regular
 user*, please keep your hands *off* of the `sudo` command here!) - this assumes
-you already have Python 3.7+, pip and virtualenv and their dependencies set up on your system:
+you already have Python 3.8+, pip and virtualenv and their dependencies set up on your system:
 
 1. Create a user-owned virtual environment therein: `virtualenv venv`. If you want to specify a specific python
    to use instead of whatever version your system defaults to, you can also explicitly require that via the `--python`
@@ -86,7 +86,7 @@ access control as necessary.
 OctoPrint depends on a few python modules to do its job. Those are automatically installed when installing
 OctoPrint via `pip`.
 
-OctoPrint currently supports Python 3.7, 3.8, 3.9, 3.10 and 3.11.
+OctoPrint currently supports Python 3.8, 3.9, 3.10 and 3.11.
 
 ## Usage
 

--- a/docs/plugins/controlproperties.rst
+++ b/docs/plugins/controlproperties.rst
@@ -66,7 +66,7 @@ The following properties are recognized:
   that are still out there, as OctoPrint will not even attempt to load plugins whose Python compatibility
   information doesn't match its current environment.
 
-  If your plugin is compatible to Python 3 only, you should set this to ``>=3.7,<4``.
+  If your plugin is compatible to Python 3 only, you should set this to ``>=3.8,<4``.
 
   If your plugin is compatible to Python 2 and Python 3, you should set this to ``>=2.7,<4``.
 

--- a/docs/plugins/gettingstarted.rst
+++ b/docs/plugins/gettingstarted.rst
@@ -59,7 +59,7 @@ We'll start at the most basic form a plugin can take - just a few simple lines o
    __plugin_name__ = "Hello World"
    __plugin_version__ = "1.0.0"
    __plugin_description__ = "A quick \"Hello World\" example plugin for OctoPrint"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
 
 Saving this as ``helloworld.py`` in ``~/.octoprint/plugins`` yields you something resembling these log entries upon server startup::
 
@@ -77,7 +77,7 @@ OctoPrint found that plugin in the folder and took a look into it. The name and 
 entry it got from the ``__plugin_name__`` and ``__plugin_version__`` lines. It also read the description from
 ``__plugin_description__`` and stored it in an internal data structure, but we'll just ignore this for now. Additionally
 there is ``__plugin_pythoncompat__`` which tells OctoPrint here that your plugin can be run under any Python versions
-between 3.7 and 4. That is necessary so that your plugin will be loadable in OctoPrint instances running under Python 3
+between 3.8 and 4. That is necessary so that your plugin will be loadable in OctoPrint instances running under Python 3
 but not Python 2 (so you can use modern language features), and going forward you really should no longer have to care about
 the end-of-life Python 2.
 
@@ -101,7 +101,7 @@ Apart from being discovered by OctoPrint, our plugin does nothing yet. We want t
    __plugin_name__ = "Hello World"
    __plugin_version__ = "1.0.0"
    __plugin_description__ = "A quick \"Hello World\" example plugin for OctoPrint"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 and restart OctoPrint. You now get this output in the log::
@@ -298,7 +298,7 @@ and ``__plugin_description__`` from ``__init__.py``, but leave ``__plugin_implem
        def on_after_startup(self):
            self._logger.info("Hello World!")
 
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 and restart OctoPrint::
@@ -321,7 +321,7 @@ Our "Hello World" Plugin still gets detected fine, but it's now listed under the
            self._logger.info("Hello World!")
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 
@@ -367,7 +367,7 @@ add the :class:`TemplatePlugin` to our ``HelloWorldPlugin`` class:
            self._logger.info("Hello World!")
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 Next, we'll create a sub folder ``templates`` underneath our ``octoprint_helloworld`` folder, and within that a file
@@ -434,7 +434,7 @@ Let's take a look at how all that would look in our plugin's ``__init__.py``:
            return dict(url="https://en.wikipedia.org/wiki/Hello_world")
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 Restart OctoPrint. You should see something like this::
@@ -468,7 +468,7 @@ Adjust your plugin's ``__init__.py`` like this:
            return dict(url=self._settings.get(["url"]))
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 Also adjust your plugin's ``templates/helloworld_navbar.jinja2`` like this:
@@ -572,7 +572,7 @@ again since we don't use that anymore:
        ]
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 Restart OctoPrint and shift-reload your browser. Your link in the navigation bar should still point to the URL we
@@ -672,7 +672,7 @@ like so:
         )
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 Note how we did not add another entry to the return value of :func:`~octoprint.plugin.TemplatePlugin.get_template_configs`.
@@ -847,7 +847,7 @@ a reference to our CSS file:
         )
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 OctoPrint by default bundles all CSS, JavaScript and LESS files to reduce the amount of requests necessary to fully
@@ -930,7 +930,7 @@ Then adjust our returned assets to include our LESS file as well:
        )
 
    __plugin_name__ = "Hello World"
-   __plugin_pythoncompat__ = ">=3.7,<4"
+   __plugin_pythoncompat__ = ">=3.8,<4"
    __plugin_implementation__ = HelloWorldPlugin()
 
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ import versioneer  # noqa: F401
 # ----------------------------------------------------------------------------------------
 
 # Supported python versions
-PYTHON_REQUIRES = ">=3.7, <3.12"
+PYTHON_REQUIRES = ">=3.8, <3.12"
 
 # Requirements for setup.py
 SETUP_REQUIRES = []
@@ -345,7 +345,6 @@ def params():
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",

--- a/src/octoprint/plugins/action_command_notification/__init__.py
+++ b/src/octoprint/plugins/action_command_notification/__init__.py
@@ -141,7 +141,7 @@ __plugin_disabling_discouraged__ = gettext(
     " notifications in OctoPrint"
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = ActionCommandNotificationPlugin()
 __plugin_hooks__ = {
     "octoprint.comm.protocol.action": __plugin_implementation__.action_command_handler,

--- a/src/octoprint/plugins/action_command_prompt/__init__.py
+++ b/src/octoprint/plugins/action_command_prompt/__init__.py
@@ -289,7 +289,7 @@ __plugin_disabling_discouraged__ = gettext(
     " confirmation or selection prompts in OctoPrint"
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = ActionCommandPromptPlugin()
 __plugin_hooks__ = {
     "octoprint.comm.protocol.action": __plugin_implementation__.action_command_handler,

--- a/src/octoprint/plugins/announcements/__init__.py
+++ b/src/octoprint/plugins/announcements/__init__.py
@@ -662,7 +662,7 @@ __plugin_disabling_discouraged__ = gettext(
     "regarding security or other critical issues concerning OctoPrint."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = AnnouncementPlugin()
 
 __plugin_hooks__ = {

--- a/src/octoprint/plugins/appkeys/__init__.py
+++ b/src/octoprint/plugins/appkeys/__init__.py
@@ -547,7 +547,7 @@ __plugin_disabling_discouraged__ = gettext(
     "obtain an API key without you manually copy-pasting it."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = AppKeysPlugin()
 __plugin_hooks__ = {
     "octoprint.accesscontrol.keyvalidator": __plugin_implementation__.validate_api_key,

--- a/src/octoprint/plugins/backup/__init__.py
+++ b/src/octoprint/plugins/backup/__init__.py
@@ -1507,7 +1507,7 @@ __plugin_disabling_discouraged__ = gettext(
     "& restore your OctoPrint settings and data."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = BackupPlugin()
 __plugin_hooks__ = {
     "octoprint.server.http.routes": __plugin_implementation__.route_hook,

--- a/src/octoprint/plugins/classicwebcam/__init__.py
+++ b/src/octoprint/plugins/classicwebcam/__init__.py
@@ -244,5 +244,5 @@ __plugin_disabling_discouraged__ = gettext(
     "This plugin provides the standard webcam in OctoPrint. If you do not have any other plugin providing a webcam set up, the webcam section in the control tab will no longer be visible."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = ClassicWebcamPlugin()

--- a/src/octoprint/plugins/corewizard/__init__.py
+++ b/src/octoprint/plugins/corewizard/__init__.py
@@ -137,5 +137,5 @@ __plugin_disabling_discouraged__ = gettext(
     "setup steps that might be required after an update."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = CoreWizardPlugin()

--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -804,4 +804,4 @@ __plugin_disabling_discouraged__ = gettext(
     "discoverable on the network via Bonjour and uPnP."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"

--- a/src/octoprint/plugins/errortracking/__init__.py
+++ b/src/octoprint/plugins/errortracking/__init__.py
@@ -252,5 +252,5 @@ def __plugin_enable__():
 __plugin_name__ = "Error Tracking"
 __plugin_author__ = "Gina Häußge"
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = ErrorTrackingPlugin()

--- a/src/octoprint/plugins/eventmanager/__init__.py
+++ b/src/octoprint/plugins/eventmanager/__init__.py
@@ -60,7 +60,7 @@ class EventManagerPlugin(
 
 
 __plugin_name__ = gettext("Event Manager")
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_author__ = "jneilliii"
 __plugin_license__ = "AGPLv3"
 __plugin_description__ = gettext(

--- a/src/octoprint/plugins/gcodeviewer/__init__.py
+++ b/src/octoprint/plugins/gcodeviewer/__init__.py
@@ -108,7 +108,7 @@ __plugin_disabling_discouraged__ = gettext(
     "Without this plugin the GCode Viewer in OctoPrint will no longer be " "available."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = GcodeviewerPlugin()
 # __plugin_hooks__ = {
 # 	"octoprint.access.permissions": __plugin_implementation__.get_additional_permissions

--- a/src/octoprint/plugins/logging/__init__.py
+++ b/src/octoprint/plugins/logging/__init__.py
@@ -274,7 +274,7 @@ __plugin_disabling_discouraged__ = gettext(
     "the web interface."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_implementation__ = LoggingPlugin()
 __plugin_hooks__ = {
     "octoprint.access.permissions": __plugin_implementation__.get_additional_permissions

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -2371,7 +2371,7 @@ __plugin_author__ = "Gina Häußge"
 __plugin_url__ = "https://docs.octoprint.org/en/master/bundledplugins/pluginmanager.html"
 __plugin_description__ = "Allows installing and managing OctoPrint plugins"
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 __plugin_hidden__ = True
 
 

--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -2572,7 +2572,7 @@ __plugin_disabling_discouraged__ = gettext(
     "your system at risk."
 )
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 
 
 def __plugin_load__():

--- a/src/octoprint/plugins/tracking/__init__.py
+++ b/src/octoprint/plugins/tracking/__init__.py
@@ -568,6 +568,6 @@ __plugin_description__ = (
 __plugin_url__ = "https://tracking.octoprint.org"
 __plugin_author__ = "Gina Häußge"
 __plugin_license__ = "AGPLv3"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 
 __plugin_implementation__ = TrackingPlugin()

--- a/src/octoprint/plugins/virtual_printer/__init__.py
+++ b/src/octoprint/plugins/virtual_printer/__init__.py
@@ -137,7 +137,7 @@ __plugin_homepage__ = (
 )
 __plugin_license__ = "AGPLv3"
 __plugin_description__ = "Provides a virtual printer via a virtual serial port for development and testing purposes"
-__plugin_pythoncompat__ = ">=3.7,<4"
+__plugin_pythoncompat__ = ">=3.8,<4"
 
 
 def __plugin_load__():

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1405,17 +1405,9 @@ def check_lastmodified(lastmodified: Union[int, float, datetime]) -> bool:
         return False
 
     if isinstance(lastmodified, (int, float)):
-        # max(86400, lastmodified) is workaround for https://bugs.python.org/issue29097,
-        # present in CPython 3.6.x up to 3.7.1.
-        #
-        # I think it's fair to say that we'll never encounter lastmodified values older than
-        # 1970-01-02 so this is a safe workaround.
-        #
         # Timestamps are defined as seconds since epoch aka 1970/01/01 00:00:00Z, so we
         # use UTC as timezone here.
-        lastmodified = datetime.fromtimestamp(
-            max(86400, lastmodified), tz=UTC_TZ
-        ).replace(microsecond=0)
+        lastmodified = datetime.fromtimestamp(lastmodified, tz=UTC_TZ).replace(microsecond=0)
 
     if not isinstance(lastmodified, datetime):
         raise ValueError(

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1407,7 +1407,9 @@ def check_lastmodified(lastmodified: Union[int, float, datetime]) -> bool:
     if isinstance(lastmodified, (int, float)):
         # Timestamps are defined as seconds since epoch aka 1970/01/01 00:00:00Z, so we
         # use UTC as timezone here.
-        lastmodified = datetime.fromtimestamp(lastmodified, tz=UTC_TZ).replace(microsecond=0)
+        lastmodified = datetime.fromtimestamp(lastmodified, tz=UTC_TZ).replace(
+            microsecond=0
+        )
 
     if not isinstance(lastmodified, datetime):
         raise ValueError(

--- a/src/octoprint/util/json/encoding.py
+++ b/src/octoprint/util/json/encoding.py
@@ -3,7 +3,8 @@ __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms
 
 import json
 from collections import OrderedDict
-from typing import Any, Callable, OrderedDict as OrderedDictType
+from typing import Any, Callable
+from typing import OrderedDict as OrderedDictType
 
 from frozendict import frozendict
 

--- a/src/octoprint/util/json/encoding.py
+++ b/src/octoprint/util/json/encoding.py
@@ -3,12 +3,7 @@ __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms
 
 import json
 from collections import OrderedDict
-from typing import Any, Callable, Dict
-
-try:
-    from typing import OrderedDict as OrderedDictType
-except ImportError:
-    OrderedDictType = Dict  # py3.7.{0,1}
+from typing import Any, Callable, OrderedDict as OrderedDictType
 
 from frozendict import frozendict
 

--- a/src/octoprint/util/json/serializing.py
+++ b/src/octoprint/util/json/serializing.py
@@ -6,12 +6,7 @@ import datetime
 import json
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List
-
-try:
-    from typing import OrderedDict as OrderedDictType
-except ImportError:
-    OrderedDictType = Dict  # py3.7.{0,1}
+from typing import Any, Callable, Dict, List, OrderedDict as OrderedDictType
 
 from frozendict import frozendict
 

--- a/src/octoprint/util/json/serializing.py
+++ b/src/octoprint/util/json/serializing.py
@@ -6,7 +6,8 @@ import datetime
 import json
 import time
 from collections import OrderedDict
-from typing import Any, Callable, Dict, List, OrderedDict as OrderedDictType
+from typing import Any, Callable, Dict, List
+from typing import OrderedDict as OrderedDictType
 
 from frozendict import frozendict
 

--- a/tests/test_python_bugs.py
+++ b/tests/test_python_bugs.py
@@ -1,0 +1,18 @@
+"""
+Unit tests for Python bugs.
+"""
+
+import unittest
+from datetime import datetime
+
+class PythonBugsTest(unittest.TestCase):
+    """Tests for Python bugs"""
+
+    def test_datetime_fromtimestamp_accepts_arguments_below_86400(self):
+        """
+        Python bug 29097 affecting versions 3.6 and 3.7
+        See https://bugs.python.org/issue29097
+        Testing that it's safe to supply arguments below 86400 to datetime.fromtimestamp() starting v3.8
+        """
+        for subject in [0, 1, 100, 1000, 86000, 86399, 86400]:
+            self.assertIsInstance(datetime.fromtimestamp(subject), datetime)

--- a/tests/test_python_bugs.py
+++ b/tests/test_python_bugs.py
@@ -5,6 +5,7 @@ Unit tests for Python bugs.
 import unittest
 from datetime import datetime
 
+
 class PythonBugsTest(unittest.TestCase):
     """Tests for Python bugs"""
 


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

Python 3.7 has reached its End of Life state.
It's no longer maintained.
Newer versions provide bug fixes and improvements that can make the code easier to maintain.
More information on Python versions lifecycle here:

https://devguide.python.org/versions/

#### How was it tested? How can it be tested by the reviewer?

- I ran the tests locally;
- I ran all the CI workflows in my fork;
- I made a new test for removed workaround needed for 3.7;
- I checked that the bug needed the workaround is fixed in version 3.8 using Python online compiler;

#### Any background context you want to provide?

What's new in Python 3.8:
https://docs.python.org/3/whatsnew/3.8.html

#### What are the relevant tickets if any?

None

#### Screenshots (if appropriate)

![image](https://github.com/OctoPrint/OctoPrint/assets/13189514/5a34c09f-52cc-4932-8a8a-6947d86d985d)

The workaround for `datetime.fromtimestamp` is no longer needed.

#### Further notes

Since the PR reduces the range of supported Python versions by OctoPrint, I'd consider this as breaking changes targeting next major version of the product (OctoPrint 2.0)