### PR TITLE
Add APIKey details to user settings so QRCode can be viewed. Fixes #4894

### DIFF
--- a/src/octoprint/plugins/appkeys/templates/appkeys_usersettings.jinja2
+++ b/src/octoprint/plugins/appkeys/templates/appkeys_usersettings.jinja2
@@ -14,7 +14,7 @@
         <tbody data-bind="foreach: keys.paginatedItems">
         <tr>
             <td class="settings_plugin_appkeys_app"><span data-bind="text: app_id"></span><br /><small class="muted">{{ _('API Key') }}: <span data-bind="text: api_key"></span> <a href="javascript:void(0)" title="{{ _('Copy API Key to clipboard')|edq }}" data-bind="click: function() { copyToClipboard(api_key) }"><i class="fas fa-copy"></i></a></small></td>
-            <td class="settings_plugin_appkeys_actions"><a href="javascript:void(0)" title="{{ _('Revoke')|edq }}" class="far fa-trash-alt" data-bind="click: function() { $parent.revokeKey($data.api_key) }"></a></td>
+            <td class="settings_plugin_appkeys_actions"><a href="javascript:void(0)" title="{{ _('Revoke')|edq }}" class="far fa-trash-alt" data-bind="click: function() { $parent.revokeKey($data.api_key) }"></a>&nbsp;|&nbsp;<a href="javascript:void(0)" title="{{ _('Details')|edq }}" class="fas fa-search" data-bind="click: function() { $parent.dialog.showDialog(gettext('Details'), $data) }"></a></td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your changes follow the existing coding style
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Anyone with "Settings Admin" permissions are able to view QRCodes through the main octoprint settings. Any one without "Settings Admin" permissions are unable to see their Application specific QRCodes at all since the User Settings page lacks such a feature, atm. This PR adds that ability.

#### How was it tested? How can it be tested by the reviewer?
I modified my local OctoPi instance with this change and it worked. The below screenshots are from said instance.

#### Any background context you want to provide?
I don't think so.

#### What are the relevant tickets if any?
#4894 

#### Screenshots (if appropriate)
![image](https://github.com/OctoPrint/OctoPrint/assets/1283031/62722e8b-290c-4258-b591-8889c986f638)

![image](https://github.com/OctoPrint/OctoPrint/assets/1283031/9bd6a024-3fc5-48bb-a045-7248d3f5a49b)

#### Further notes
I forgot to add myself to the AUTHORS.md file and since this was such a small little change I don't feel it is necessary.