### PR TITLE
Remove upper pin from argon2-cffi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,7 @@ bundled_plugins = [
     "OctoPrint-PiSupport>=2023.5.24",
 ]
 core_deps = [
-    "argon2_cffi>=21.3.0,<22",
+    "argon2-cffi>=21.3.0",
     "Babel>=2.12.1,<2.13",  # breaking changes can happen on minor version increases
     "cachelib>=0.10.2,<0.11",
     "Click>=8.1.3,<9",


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

argon2-cffi uses [calendar versioning](https://calver.org), therefore the pin achieves no compatibility promises and only limits releases to from before 2022.

That's not great for security-relevant packages like a password hasher. 🤓

#### How was it tested? How can it be tested by the reviewer?

You've got CI, don't cha. ;)

#### Any background context you want to provide?

I am the maintainer of argon2-cffi. If you run into compat problems, please talk to me directly. I'm trying to keep argon2-cffi as stable as possible at all times.