### PR TITLE
Further accessibility improvements: label regions, hide temperature graph, add necessary headings

### DIFF
--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -97,7 +97,7 @@
                                     >
                                 <div class="accordion-heading">
 
-                                    <a class="accordion-toggle" data-toggle="collapse" data-test-id="sidebar-{{ data._div }}-toggle" data-target="#{{ data._div }}">
+                                    <a role="heading" aria-level="2" class="accordion-toggle" data-toggle="collapse" data-test-id="sidebar-{{ data._div }}-toggle" data-target="#{{ data._div }}">
                                         {% if "icon" in data %}
                                             {% if data.icon.startswith("fa") %}
                                                 {# Fontawesome 5 allows using fas, far, fab etc. (FA6 also has fa-solid, fa-regular) so plugins should use the prefix they want #}
@@ -127,6 +127,7 @@
                     </div>
                     {% endif %}
 
+<h1 class="sr-only">Tabs</h1>
                     <!-- Tabs -->
                     {% if templates.tab.order %}
                     <div class="tabbable {% if templates.sidebar.order %}span8{% else %}span12{% endif %}">

--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -84,6 +84,7 @@
             </div>
             <div class="container octoprint-container">
                 <div class="row">
+                    <h1 class="sr-only">Sidebar</h1>
                     <!-- Sidebar -->
                     {% if templates.sidebar.order %}
                     <div id="sidebar" class="accordion {% if templates.tab.order %}span4{% else %}span12{% endif %}">
@@ -127,7 +128,7 @@
                     </div>
                     {% endif %}
 
-<h1 class="sr-only">Tabs</h1>
+                    <h1 class="sr-only">Tabs</h1>
                     <!-- Tabs -->
                     {% if templates.tab.order %}
                     <div class="tabbable {% if templates.sidebar.order %}span8{% else %}span12{% endif %}">

--- a/src/octoprint/templates/recovery.jinja2
+++ b/src/octoprint/templates/recovery.jinja2
@@ -165,7 +165,7 @@
             <pre class="pre-scrollable pre-output" style="height: 170px" data-bind="foreach: workLoglines"><span data-bind="text: line, css: {stdout: stream == 'stdout', stderr: stream == 'stderr', call: stream == 'call', message: stream == 'message', error: stream == 'error'}"></span></pre>
         </div>
         <div class="modal-footer">
-            <button class="btn" data-dismiss="modal" data-bind="enable: !workInProgress()" aria-hidden="true">{{ _('Close') }}</button>
+            <button class="btn" data-dismiss="modal" data-bind="enable: !workInProgress()">{{ _('Close') }}</button>
         </div>
     </div>
 

--- a/src/octoprint/templates/sidebar/files.jinja2
+++ b/src/octoprint/templates/sidebar/files.jinja2
@@ -17,7 +17,7 @@
     <script type="text/html" id="files_template_machinecode">
         <div class="btn btn-mini toggleAdditionalData pull-right" data-bind="visible: origin != 'sdcard',click: function() { if ($root.enableAdditionalData($data)) { $root.toggleAdditionalData($data); } else { return; } }, css: { disabled: !$root.enableAdditionalData($data) }" title="{{ _('Additional data')|edq }}"><i class="fas fa-chevron-down"></i></div>
         <div class="btn btn-mini pull-right disabled" data-bind="visible: origin == 'sdcard'" title="{{ _('On SD Card')|edq }}"><i class="fas fa-sd-card"></i></div>
-        <div class="title clickable" data-bind="click: function() { if ($root.enableSelect($data)) { $root.loadFile($data, false); } else { return; } }, css: $root.getSuccessClass($data), style: { 'font-weight': $root.listHelper.isSelected($data) ? 'bold' : 'normal' }, text: display"></div>
+        <div role="heading" aria-level="3" class="title clickable" data-bind="click: function() { if ($root.enableSelect($data)) { $root.loadFile($data, false); } else { return; } }, css: $root.getSuccessClass($data), style: { 'font-weight': $root.listHelper.isSelected($data) ? 'bold' : 'normal' }, text: display"></div>
         <div class="internal" data-bind="visible: display && name != display && $root.showInternalFilename">{{ _('Internal') }}: <span data-bind="text: name"></span></div>
         <div class="uploaded">{{ _('Uploaded') }}: <span data-bind="text: formatTimeAgo(date, '?'), attr: {title: formatDate(date, {placeholder:'{{ _('unknown') | esq }}'})}"></span></div>
         <div class="size">{{ _('Size') }}: <span data-bind="text: formatSize(size)"></span></div>

--- a/src/octoprint/templates/tabs/control.jinja2
+++ b/src/octoprint/templates/tabs/control.jinja2
@@ -1,3 +1,4 @@
+<h2 class="sr-only">Control</h2>
 {% if enableWebcam %}
     <div id="webcam_plugins_container" tabindex="0" data-bind="visible: loginState.hasPermissionKo(access.permissions.WEBCAM), event: { keydown: onKeyDown, mouseover: onMouseOver, mouseout: onMouseOut, focus: onFocus }">
         <div class="tabbable row-fluid">

--- a/src/octoprint/templates/tabs/temperature.jinja2
+++ b/src/octoprint/templates/tabs/temperature.jinja2
@@ -1,6 +1,7 @@
+<h2 class="sr-only">Temperature</h2>
 {% if enableTemperatureGraph %}
     <div class="row-fluid">
-        <div class="dropdown pull-right">
+        <div class="dropdown pull-right" aria-hidden="true">
             <div class="btn-group">
                 <button class="btn btn-small dropdown-toggle" data-toggle="dropdown" href="javascript:void(0)">
                     <i class="fas fa-wrench"></i>
@@ -12,7 +13,7 @@
         </div>
     </div>
     <div class="row-fluid">
-        <div id="temperature-graph" style="width: 100%"></div>
+        <div id="temperature-graph" style="width: 100%" aria-hidden="true"></div>
     </div>
 {% endif %}
 <div class="row-fluid">

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -1,3 +1,4 @@
+<h2 class="sr-only">Terminal</h2>
 <div class="terminal">
     <pre id="terminal-output" class="pre-scrollable pre-output" data-bind="foreach: displayedLines, visible: fancyFunctionality(), click: function(){ gotoTerminalCommand(); }, event: { scroll: terminalScrollEvent }"><span data-bind="text: line + '\n', css: {muted: display == 'filtered' || display == 'cut', 'text-error': type == 'warn'}"></span></pre>
     <pre id="terminal-output-lowfi" style="display: none" class="pre-scrollable" data-bind="text: plainLogOutput, visible: !fancyFunctionality()"></pre>


### PR DESCRIPTION
#### What does this PR do and why is it necessary?
With PR #4597 accessibility labels were added to links and buttons, thus making OctoPrint basically accessible.
This PR adds some improvements to the accessibility:

* Temperature graph is hidden from screenreader's view
* Important sections have hidden headers, enabling for easier navigation
* Files have hidden headers, making it far more comfortable to navigate

#### How was it tested? How can it be tested by the reviewer?
Tested using NVDA screenreader on Windows, Voice Over on Mac and iOS.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
N/A

#### Further notes
N/A