### PR TITLE
Filename sanitization improvement in download_file function

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -182,6 +182,7 @@ date of first contribution):
   * [Martin Bartsch](https://github.com/kaenguruhs)
   * [Matthias Weis](https://github.com/mad73923)
   * [Rob Emery](https://github.com/mintsoft)
+  * [Jacopo Tediosi](https://github.com/jacopotediosi)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -10,6 +10,7 @@ import netaddr
 import netifaces
 import requests
 import werkzeug.http
+from werkzeug.utils import secure_filename
 
 _cached_check_v6 = None
 
@@ -270,6 +271,7 @@ def download_file(url, folder, max_length=None, connect_timeout=3.05, read_timeo
         if filename is None:
             filename = url.split("/")[-1]
 
+        filename = secure_filename(filename)
         assert len(filename) > 0
 
         # TODO check content-length against safety limit


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
The `download_file` function in `/octoprint/OctoPrint/src/octoprint/util/net.py` suffers from a *quasi* - Path Traversal vulnerability:

https://github.com/OctoPrint/OctoPrint/blob/65a5533c5d645f7033f01056c8ef735a938339f0/src/octoprint/util/net.py#L260-L283

As visible on line 277, the filename of the file to be downloaded, taken from the `Content-Disposition` header received from the remote server during file download, is not sanitized and is appended directly to the folder name.

The presence of the `assert path.startswith(folder)` instruction on line 278 prevents Path Traversal towards the parent of the folder, but not within subfolders. Taking for example a case in which the function was called with the intention of storing the file inside `/`, if the server responded with the header `Content-Disposition: attachment; filename=etc/passwd`, the downloaded file would overwrite `/etc/passwd`.

I'm sending a PR instead of using the GitHub Advisory tool because **in the current codebase** the `download_file` function is only called by specifying temporary folders as the folder, so **this vulnerability is not exploitable**. However, I believe that improving filename sanitization in this case is easy and prevents any vulnerabilities that might arise by reusing the `download_file` function differently in the future.

#### How was it tested? How can it be tested by the reviewer?
I have verified that the unit tests pass.

I don't seem to see any situations where this change would break anything.

The function I added, `secure_filename`, takes care of sanitizing file names and is specifically designed to pass the sanitized filename to `os.path.join()`, as documented in the [Flask documentation](https://tedboy.github.io/flask/generated/werkzeug.secure_filename.html).

However, I'm open to discussion if you notice any edge cases that I missed.