### PR TITLE
Bugfix/ExcpHandling for BambuStudio and filament diameter

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -177,6 +177,7 @@ date of first contribution):
   * [Scott Martin](https://github.com/smartin015)
   * [Shyam Sunder](https://github.com/sgsunder)
   * [Christopher Perrin](https://github.com/cperrin88)
+  * [Nils Rottgardt](https://github.com/NilsRo)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/util/gcodeInterpreter.py
+++ b/src/octoprint/util/gcodeInterpreter.py
@@ -392,7 +392,13 @@ class gcode:
                 comment = line[line.find(";") + 1 :].strip()
                 if comment.startswith("filament_diameter"):
                     # Slic3r
-                    filamentValue = comment.split("=", 1)[1].strip()
+                    try:
+                        filamentValue = comment.split("=", 1)[1].strip()
+                    except IndexError:
+                        try:
+                            filamentValue = comment.split(":", 1)[1].strip()
+                        except IndexError:
+                            filamentValue = "0"
                     try:
                         self._filamentDiameter = float(filamentValue)
                     except ValueError:


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

BambuStudio Testfile
[BBS-Support_top_PLA_36m30s.zip](https://github.com/OctoPrint/OctoPrint/files/14655537/BBS-Support_top_PLA_36m30s.zip)

#### What does this PR do and why is it necessary?
Added exception handling and new separator for filament diameter parsing

#### How was it tested? How can it be tested by the reviewer?
Uploading and running estimator for file provided

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)
![image](https://github.com/OctoPrint/OctoPrint/assets/51311453/d79a7092-55d4-4efd-901f-d2eba6252f95)


#### Further notes
