### PR TITLE
Timelapse render option

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.11
+  python: python3.10
 exclude: ^(src/octoprint/vendor/|src/octoprint/static/js/lib|src/octoprint/static/vendor|src/octoprint_setuptools|tests/static/js/lib|tests/util/_files|scripts/|translations/|.*\.css|.*\.svg)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,5 @@
 default_language_version:
-  python: python3.10
+  python: python3.11
 exclude: ^(src/octoprint/vendor/|src/octoprint/static/js/lib|src/octoprint/static/vendor|src/octoprint_setuptools|tests/static/js/lib|tests/util/_files|scripts/|translations/|.*\.css|.*\.svg)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/docs/api/timelapse.rst
+++ b/docs/api/timelapse.rst
@@ -258,7 +258,7 @@ For timelapse type ``zchange``.
    * - ``renderAfterPrint``
      - 1
      - string
-     - Determines whether the timelapse should be rendered automatically after the print finishes. 
+     - Determines whether the timelapse should be rendered automatically after the print finishes.
 
 .. _sec-api-timelapse-datamodel-config-timed:
 

--- a/docs/api/timelapse.rst
+++ b/docs/api/timelapse.rst
@@ -255,6 +255,10 @@ For timelapse type ``zchange``.
      - 1
      - int
      - Snapshots will be rate limited against this interval, to prevent performance issues with vase mode/continuous z prints
+   * - ``renderAfterPrint``
+     - 1
+     - string
+     - Determines whether the timelapse should be rendered automatically after the print finishes. 
 
 .. _sec-api-timelapse-datamodel-config-timed:
 
@@ -283,3 +287,7 @@ For timelapse type ``timed``.
      - 1
      - int
      - Seconds between individual shots
+   * - ``renderAfterPrint``
+     - 1
+     - string
+     - Determines whether the timelapse should be rendered automatically after the print finishes.

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1227,6 +1227,11 @@ Use the following settings to configure webcam support:
        # fps * postRoll * interval seconds. Zchange timelapses will take one final picture and add it fps * postRoll
        postRoll: 0
 
+       # Determines whether rendering the timelapse should be done automatically after the print is finished. 
+       # Can be "always", "never", and "successful". 
+       # "successful" means that only successful prints are rendered after the print finished.
+       renderAfterPrint: always
+
        # Additional options depending on the timelapse type. All timelapses take a postRoll and an fps setting.
        options:
 

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1227,8 +1227,8 @@ Use the following settings to configure webcam support:
        # fps * postRoll * interval seconds. Zchange timelapses will take one final picture and add it fps * postRoll
        postRoll: 0
 
-       # Determines whether rendering the timelapse should be done automatically after the print is finished. 
-       # Can be "always", "never", and "successful". 
+       # Determines whether rendering the timelapse should be done automatically after the print is finished.
+       # Can be "always", "never", and "successful".
        # "successful" means that only successful prints are rendered after the print finished.
        renderAfterPrint: always
 

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1228,8 +1228,7 @@ Use the following settings to configure webcam support:
        postRoll: 0
 
        # Determines whether rendering the timelapse should be done automatically after the print is finished.
-       # Can be "always", "never", "successful" and "fail".
-       # "successful" means that only successful prints are rendered after the print finished, while "fail" means the opposite.
+       # This can be done always, only after successful prints, only after failed prints, or never.
        renderAfterPrint: always
 
        # Additional options depending on the timelapse type. All timelapses take a postRoll and an fps setting.

--- a/docs/configuration/config_yaml.rst
+++ b/docs/configuration/config_yaml.rst
@@ -1228,8 +1228,8 @@ Use the following settings to configure webcam support:
        postRoll: 0
 
        # Determines whether rendering the timelapse should be done automatically after the print is finished.
-       # Can be "always", "never", and "successful".
-       # "successful" means that only successful prints are rendered after the print finished.
+       # Can be "always", "never", "successful" and "fail".
+       # "successful" means that only successful prints are rendered after the print finished, while "fail" means the opposite.
        renderAfterPrint: always
 
        # Additional options depending on the timelapse type. All timelapses take a postRoll and an fps setting.

--- a/src/octoprint/schema/config/webcam.py
+++ b/src/octoprint/schema/config/webcam.py
@@ -14,6 +14,13 @@ class TimelapseTypeEnum(str, Enum):
     timed = "timed"
 
 
+class RenderAfterPrintEnum(str, Enum):
+    off = "off"
+    always = "always"
+    success = "success"
+    failure = "failure"
+
+
 @with_attrs_docs
 class TimelapseOptions(BaseModel):
     interval: Optional[int] = None
@@ -36,6 +43,9 @@ class TimelapseConfig(BaseModel):
 
     postRoll: int = 0
     """The number of seconds in the rendered video to add after a finished print. The exact way how the additional images will be recorded depends on timelapse type. `zchange` timelapses will take one final picture and add it `fps * postRoll` times. `timed` timelapses continue to record just like at the beginning, so the recording will continue another `fps * postRoll * interval` seconds. This behaviour can be overridden by setting the `capturePostRoll` option to `false`, in which case the post roll will be created identically to `zchange` mode."""
+
+    renderAfterPrint: RenderAfterPrintEnum = RenderAfterPrintEnum.always
+    """Determines whether rendering the timelapse should be done automatically after the print is finished. This can be done always, only after successful prints, only after failed prints, or never."""
 
     options: TimelapseOptions = TimelapseOptions()
     """Additional options depending on the timelapse type."""

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -320,7 +320,7 @@ def setTimelapseConfig():
             except ValueError:
                 abort(400, description="renderAfterPrint is invalid")
             else:
-                if renderAfterPrint in ["always", "successful", "fail", "never"]:
+                if renderAfterPrint in ["always", "success", "failure", "never"]:
                     config["renderAfterPrint"] = renderAfterPrint
                 else:
                     abort(400, description="renderAfterPrint is invalid")

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -42,7 +42,6 @@ def _config_for_timelapse(timelapse):
             "retractionZHop": timelapse.retraction_zhop,
             "minDelay": timelapse.min_delay,
             "renderAfterPrint": timelapse.render_after_print,
-            "renderFailedPrint": timelapse.render_failed_print,
         }
     elif timelapse is not None and isinstance(
         timelapse, octoprint.timelapse.TimedTimelapse
@@ -53,7 +52,6 @@ def _config_for_timelapse(timelapse):
             "fps": timelapse.fps,
             "interval": timelapse.interval,
             "renderAfterPrint": timelapse.render_after_print,
-            "renderFailedPrint": timelapse.render_failed_print,
         }
     else:
         return {"type": "off"}
@@ -253,7 +251,7 @@ def setTimelapseConfig():
         data = request.values
 
     if "type" in data:
-        config = {"type": data["type"], "postRoll": 0, "fps": 25, "renderAfterPrint": True, "renderFailedPrint": True, "options": {}}
+        config = {"type": data["type"], "postRoll": 0, "fps": 25, "renderAfterPrint": "always", "options": {}}
 
         if "postRoll" in data:
             try:
@@ -312,19 +310,14 @@ def setTimelapseConfig():
 
         if "renderAfterPrint" in data:
             try:
-                renderAfterPrint = bool(data["renderAfterPrint"])
+                renderAfterPrint = str(data["renderAfterPrint"])
             except ValueError:
                 abort(400, description="renderAfterPrint is invalid")
             else:
-                config["renderAfterPrint"] = renderAfterPrint
-
-        if "renderFailedPrint" in data:
-            try:
-                renderFailedPrint = bool(data["renderFailedPrint"])
-            except ValueError:
-                abort(400, description="renderFailedPrint is invalid")
-            else:
-                config["renderFailedPrint"] = renderFailedPrint
+                if renderAfterPrint in ["always", "successful", "never"]:
+                    config["renderAfterPrint"] = renderAfterPrint
+                else:
+                    abort(400, description="renderAfterPrint is invalid")
 
         if (
             admin_permission.can()

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -251,7 +251,13 @@ def setTimelapseConfig():
         data = request.values
 
     if "type" in data:
-        config = {"type": data["type"], "postRoll": 0, "fps": 25, "renderAfterPrint": "always", "options": {}}
+        config = {
+            "type": data["type"],
+            "postRoll": 0,
+            "fps": 25,
+            "renderAfterPrint": "always",
+            "options": {},
+        }
 
         if "postRoll" in data:
             try:

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -41,6 +41,8 @@ def _config_for_timelapse(timelapse):
             "fps": timelapse.fps,
             "retractionZHop": timelapse.retraction_zhop,
             "minDelay": timelapse.min_delay,
+            "renderAfterPrint": timelapse.render_after_print,
+            "renderFailedPrint": timelapse.render_failed_print,
         }
     elif timelapse is not None and isinstance(
         timelapse, octoprint.timelapse.TimedTimelapse
@@ -50,6 +52,8 @@ def _config_for_timelapse(timelapse):
             "postRoll": timelapse.post_roll,
             "fps": timelapse.fps,
             "interval": timelapse.interval,
+            "renderAfterPrint": timelapse.render_after_print,
+            "renderFailedPrint": timelapse.render_failed_print,
         }
     else:
         return {"type": "off"}
@@ -249,7 +253,7 @@ def setTimelapseConfig():
         data = request.values
 
     if "type" in data:
-        config = {"type": data["type"], "postRoll": 0, "fps": 25, "options": {}}
+        config = {"type": data["type"], "postRoll": 0, "fps": 25, "renderAfterPrint": True, "renderFailedPrint": True, "options": {}}
 
         if "postRoll" in data:
             try:
@@ -305,6 +309,22 @@ def setTimelapseConfig():
                     config["options"]["minDelay"] = minDelay
                 else:
                     abort(400, description="minDelay is invalid")
+
+        if "renderAfterPrint" in data:
+            try:
+                renderAfterPrint = bool(data["renderAfterPrint"])
+            except ValueError:
+                abort(400, description="renderAfterPrint is invalid")
+            else:
+                config["renderAfterPrint"] = renderAfterPrint
+
+        if "renderFailedPrint" in data:
+            try:
+                renderFailedPrint = bool(data["renderFailedPrint"])
+            except ValueError:
+                abort(400, description="renderFailedPrint is invalid")
+            else:
+                config["renderFailedPrint"] = renderFailedPrint
 
         if (
             admin_permission.can()

--- a/src/octoprint/server/api/timelapse.py
+++ b/src/octoprint/server/api/timelapse.py
@@ -320,7 +320,7 @@ def setTimelapseConfig():
             except ValueError:
                 abort(400, description="renderAfterPrint is invalid")
             else:
-                if renderAfterPrint in ["always", "successful", "never"]:
+                if renderAfterPrint in ["always", "successful", "fail", "never"]:
                     config["renderAfterPrint"] = renderAfterPrint
                 else:
                     abort(400, description="renderAfterPrint is invalid")

--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -630,7 +630,7 @@ $(function () {
             self.fromConfig(self.serverConfig());
         };
 
-        self.displayTimelapsePopup = function (options) {
+        self.displayTimelapsePopup = function (options, tag) {
             if (self.timelapsePopup !== undefined) {
                 self.timelapsePopup.remove();
             }
@@ -646,6 +646,17 @@ $(function () {
             });
 
             self.timelapsePopup = new PNotify(options);
+            self.timelapsePopup._tag = tag;
+        };
+
+        self.hideTimelapsePopup = function (tag) {
+            if (
+                self.timelapsePopup !== undefined &&
+                (!tag || self.timelapsePopup._tag === tag)
+            ) {
+                self.timelapsePopup.remove();
+                self.timelapsePopup = undefined;
+            }
         };
 
         self.onDataUpdaterReconnect = function () {
@@ -690,11 +701,18 @@ $(function () {
                 }
             }
 
-            self.displayTimelapsePopup({
-                title: title,
-                text: text,
-                hide: false
-            });
+            self.displayTimelapsePopup(
+                {
+                    title: title,
+                    text: text,
+                    hide: false
+                },
+                "postroll"
+            );
+        };
+
+        self.onEventPostRollEnd = function (payload) {
+            self.hideTimelapsePopup("postroll");
         };
 
         // 3 consecutive capture fails trigger error popup
@@ -755,16 +773,19 @@ $(function () {
         };
 
         self.onEventMovieRendering = function (payload) {
-            self.displayTimelapsePopup({
-                title: gettext("Rendering timelapse"),
-                text: _.sprintf(
-                    gettext(
-                        "Now rendering timelapse %(movie_prefix)s. Due to performance reasons it is not recommended to start a print job while a movie is still rendering."
+            self.displayTimelapsePopup(
+                {
+                    title: gettext("Rendering timelapse"),
+                    text: _.sprintf(
+                        gettext(
+                            "Now rendering timelapse %(movie_prefix)s. Due to performance reasons it is not recommended to start a print job while a movie is still rendering."
+                        ),
+                        {movie_prefix: _.escape(payload.movie_prefix)}
                     ),
-                    {movie_prefix: _.escape(payload.movie_prefix)}
-                ),
-                hide: false
-            });
+                    hide: false
+                },
+                "rendering"
+            );
 
             self.renderProgress(0);
             self.renderTarget(payload.movie_prefix);
@@ -820,12 +841,15 @@ $(function () {
                     "</p>";
             }
 
-            self.displayTimelapsePopup({
-                title: title,
-                text: html,
-                type: "error",
-                hide: false
-            });
+            self.displayTimelapsePopup(
+                {
+                    title: title,
+                    text: html,
+                    type: "error",
+                    hide: false
+                },
+                "error"
+            );
 
             self.renderProgress(0);
             self.renderTarget(undefined);
@@ -833,21 +857,24 @@ $(function () {
         };
 
         self.onEventMovieDone = function (payload) {
-            self.displayTimelapsePopup({
-                title: gettext("Timelapse ready"),
-                text: _.sprintf(
-                    gettext("New timelapse %(movie_prefix)s is done rendering."),
-                    {movie_prefix: _.escape(payload.movie_prefix)}
-                ),
-                type: "success",
-                callbacks: {
-                    before_close: function (notice) {
-                        if (self.timelapsePopup === notice) {
-                            self.timelapsePopup = undefined;
+            self.displayTimelapsePopup(
+                {
+                    title: gettext("Timelapse ready"),
+                    text: _.sprintf(
+                        gettext("New timelapse %(movie_prefix)s is done rendering."),
+                        {movie_prefix: _.escape(payload.movie_prefix)}
+                    ),
+                    type: "success",
+                    callbacks: {
+                        before_close: function (notice) {
+                            if (self.timelapsePopup === notice) {
+                                self.timelapsePopup = undefined;
+                            }
                         }
                     }
-                }
-            });
+                },
+                "ready"
+            );
             self.requestData();
 
             self.renderProgress(0);

--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -14,8 +14,7 @@ $(function () {
         self.defaultInterval = 10;
         self.defaultRetractionZHop = 0;
         self.defaultMinDelay = 5.0;
-        self.defaultRenderAfterPrint = true;
-        self.defaultRenderFailedPrint = true;
+        self.defaultRenderAfterPrint = "always";
 
         self.timelapseType = ko.observable(undefined);
         self.timelapseTimedInterval = ko.observable(self.defaultInterval);
@@ -24,7 +23,6 @@ $(function () {
         self.timelapseRetractionZHop = ko.observable(self.defaultRetractionZHop);
         self.timelapseMinDelay = ko.observable(self.defaultMinDelay);
         self.timelapseRenderAfterPrint = ko.observable(self.defaultRenderAfterPrint);
-        self.timelapseRenderFailedPrint = ko.observable(self.defaultRenderFailedPrint);
         self.snapshotWebcam = ko.pureComputed(function () {
             var snapshotWebcamName = self.settings.webcam_snapshotWebcam();
             return self.settings.webcam_webcams().find(function (w) {
@@ -145,9 +143,6 @@ $(function () {
             self.isDirty(true);
         });
         self.timelapseRenderAfterPrint.subscribe(function () {
-            self.isDirty(true);
-        });
-        self.timelapseRenderFailedPrint.subscribe(function () {
             self.isDirty(true);
         });
         self.persist.subscribe(function () {
@@ -291,12 +286,6 @@ $(function () {
                 self.timelapseRenderAfterPrint(config.renderAfterPrint);
             } else {
                 self.timelapseRenderAfterPrint(self.defaultRenderAfterPrint);
-            }
-
-            if (config.renderFailedPrint !== undefined) {
-                self.timelapseRenderFailedPrint(config.renderFailedPrint);
-            } else {
-                self.timelapseRenderFailedPrint(self.defaultRenderFailedPrint);
             }
 
             self.persist(false);
@@ -621,7 +610,6 @@ $(function () {
                 postRoll: self.timelapsePostRoll(),
                 fps: self.timelapseFps(),
                 renderAfterPrint: self.timelapseRenderAfterPrint(),
-                renderFailedPrint: self.timelapseRenderFailedPrint(),
                 save: self.persist()
             };
 

--- a/src/octoprint/static/js/app/viewmodels/timelapse.js
+++ b/src/octoprint/static/js/app/viewmodels/timelapse.js
@@ -14,6 +14,8 @@ $(function () {
         self.defaultInterval = 10;
         self.defaultRetractionZHop = 0;
         self.defaultMinDelay = 5.0;
+        self.defaultRenderAfterPrint = true;
+        self.defaultRenderFailedPrint = true;
 
         self.timelapseType = ko.observable(undefined);
         self.timelapseTimedInterval = ko.observable(self.defaultInterval);
@@ -21,6 +23,8 @@ $(function () {
         self.timelapseFps = ko.observable(self.defaultFps);
         self.timelapseRetractionZHop = ko.observable(self.defaultRetractionZHop);
         self.timelapseMinDelay = ko.observable(self.defaultMinDelay);
+        self.timelapseRenderAfterPrint = ko.observable(self.defaultRenderAfterPrint);
+        self.timelapseRenderFailedPrint = ko.observable(self.defaultRenderFailedPrint);
         self.snapshotWebcam = ko.pureComputed(function () {
             var snapshotWebcamName = self.settings.webcam_snapshotWebcam();
             return self.settings.webcam_webcams().find(function (w) {
@@ -138,6 +142,12 @@ $(function () {
             self.isDirty(true);
         });
         self.timelapseMinDelay.subscribe(function () {
+            self.isDirty(true);
+        });
+        self.timelapseRenderAfterPrint.subscribe(function () {
+            self.isDirty(true);
+        });
+        self.timelapseRenderFailedPrint.subscribe(function () {
             self.isDirty(true);
         });
         self.persist.subscribe(function () {
@@ -275,6 +285,18 @@ $(function () {
                 self.timelapseFps(config.fps);
             } else {
                 self.timelapseFps(self.defaultFps);
+            }
+
+            if (config.renderAfterPrint !== undefined) {
+                self.timelapseRenderAfterPrint(config.renderAfterPrint);
+            } else {
+                self.timelapseRenderAfterPrint(self.defaultRenderAfterPrint);
+            }
+
+            if (config.renderFailedPrint !== undefined) {
+                self.timelapseRenderFailedPrint(config.renderFailedPrint);
+            } else {
+                self.timelapseRenderFailedPrint(self.defaultRenderFailedPrint);
             }
 
             self.persist(false);
@@ -598,6 +620,8 @@ $(function () {
                 type: self.timelapseType(),
                 postRoll: self.timelapsePostRoll(),
                 fps: self.timelapseFps(),
+                renderAfterPrint: self.timelapseRenderAfterPrint(),
+                renderFailedPrint: self.timelapseRenderFailedPrint(),
                 save: self.persist()
             };
 

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -75,6 +75,24 @@
             <div class="control-group">
                 <div class="controls">
                     <label class="checkbox">
+                        <input type="checkbox" data-bind="checked: timelapseRenderAfterPrint, valueUpdate: 'afterkeydown'"> {{ _('Render Timelapse automatically') }}
+                        <span class="help-block">{{ _('Start the rendering of the timelapse automatically after finishing the print.') }}</span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="control-group">
+                <div class="controls">
+                    <label class="checkbox">
+                        <input type="checkbox" data-bind="checked: timelapseRenderFailedPrint, valueUpdate: 'afterkeydown', enable: timelapseRenderAfterPrint"> {{ _('Render Timelapse for failed prints automatically') }}
+                        <span class="help-block">{{ _('Start the rendering of the timelapse automatically for failed prints.') }}</span>
+                    </label>
+                </div>
+            </div>
+
+            <div class="control-group">
+                <div class="controls">
+                    <label class="checkbox">
                         <input type="checkbox" data-bind="checked: persist"> {{ _('Save as default') }}
                         <span class="help-block">{{ _('Check this to make your selected timelapse mode and options persist across restarts.') }}</span>
                     </label>

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -73,20 +73,13 @@
             </div>
 
             <div class="control-group">
+                <label class="control-label" for="webcam_timelapse_mode">{{ _('Render timelapse after print') }}</label>
                 <div class="controls">
-                    <label class="checkbox">
-                        <input type="checkbox" data-bind="checked: timelapseRenderAfterPrint, valueUpdate: 'afterkeydown'"> {{ _('Render Timelapse automatically') }}
-                        <span class="help-block">{{ _('Start the rendering of the timelapse automatically after finishing the print.') }}</span>
-                    </label>
-                </div>
-            </div>
-
-            <div class="control-group">
-                <div class="controls">
-                    <label class="checkbox">
-                        <input type="checkbox" data-bind="checked: timelapseRenderFailedPrint, valueUpdate: 'afterkeydown', enable: timelapseRenderAfterPrint"> {{ _('Render Timelapse for failed prints automatically') }}
-                        <span class="help-block">{{ _('Start the rendering of the timelapse automatically for failed prints.') }}</span>
-                    </label>
+                    <select id="webcam_timelapse_mode" data-bind="value: timelapseRenderAfterPrint, enable: !isPrinting()">
+                        <option value="always">{{ _('Always') }}</option>
+                        <option value="successful">{{ _('If Successful') }}</option>
+                        <option value="never">{{ _('Never') }}</option>
+                    </select>
                 </div>
             </div>
 

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -78,6 +78,7 @@
                     <select id="webcam_timelapse_mode" data-bind="value: timelapseRenderAfterPrint, enable: !isPrinting()">
                         <option value="always">{{ _('Always') }}</option>
                         <option value="successful">{{ _('If Successful') }}</option>
+                        <option value="fail">{{ _('If Failed') }}</option>
                         <option value="never">{{ _('Never') }}</option>
                     </select>
                 </div>

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -77,8 +77,8 @@
                 <div class="controls">
                     <select id="webcam_timelapse_mode" data-bind="value: timelapseRenderAfterPrint, enable: !isPrinting()">
                         <option value="always">{{ _('Always') }}</option>
-                        <option value="successful">{{ _('If Successful') }}</option>
-                        <option value="fail">{{ _('If Failed') }}</option>
+                        <option value="success">{{ _('On success') }}</option>
+                        <option value="failure">{{ _('On failure') }}</option>
                         <option value="never">{{ _('Never') }}</option>
                     </select>
                 </div>

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -662,7 +662,11 @@ class Timelapse:
             file_prefix = self._file_prefix
             gcode_file = self._gcode_file
             self._reset_metadata()
-            if self.render_after_print=="always" or (self.render_after_print=="successful" and success) or (self.render_after_print=="fail" and not success):
+            if (
+                self.render_after_print == "always"
+                or (self.render_after_print == "successful" and success)
+                or (self.render_after_print == "fail" and not success)
+            ):
                 create_movie(file_prefix, gcode_file)
             else:
                 self._logger.debug("Not rendering timelapse of failed prints")

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -20,6 +20,7 @@ import octoprint.plugin
 import octoprint.util as util
 from octoprint.events import Events, eventManager
 from octoprint.plugin import plugin_manager
+from octoprint.schema.config.webcam import RenderAfterPrintEnum, TimelapseTypeEnum
 from octoprint.settings import settings
 from octoprint.util import get_fully_qualified_classname as fqcn
 from octoprint.util import sv
@@ -432,7 +433,7 @@ def configure_timelapse(config=None, persist=False):
         not timelapse_enabled
         or not timelapse_precondition
         or type is None
-        or "off" == type
+        or type == TimelapseTypeEnum.off
     ):
         current = None
 
@@ -445,11 +446,11 @@ def configure_timelapse(config=None, persist=False):
         if "fps" in config and config["fps"] > 0:
             fps = config["fps"]
 
-        renderAfterPrint = "always"
+        renderAfterPrint = RenderAfterPrintEnum.always
         if "renderAfterPrint" in config:
             renderAfterPrint = config["renderAfterPrint"]
 
-        if "zchange" == type:
+        if type == TimelapseTypeEnum.zchange:
             retractionZHop = 0
             if (
                 "options" in config
@@ -474,7 +475,7 @@ def configure_timelapse(config=None, persist=False):
                 render_after_print=renderAfterPrint,
             )
 
-        elif "timed" == type:
+        elif type == TimelapseTypeEnum.timed:
             interval = 10
             if (
                 "options" in config
@@ -501,7 +502,9 @@ class Timelapse:
     QUEUE_ENTRY_TYPE_CAPTURE = "capture"
     QUEUE_ENTRY_TYPE_CALLBACK = "callback"
 
-    def __init__(self, post_roll=0, fps=25, render_after_print="always"):
+    def __init__(
+        self, post_roll=0, fps=25, render_after_print=RenderAfterPrintEnum.always
+    ):
         self._logger = logging.getLogger(__name__)
         self._image_number = None
         self._in_timelapse = False
@@ -593,9 +596,12 @@ class Timelapse:
         self.stop_timelapse(
             success=success,
             do_create_movie=(
-                self.render_after_print == "always"
-                or (self.render_after_print == "successful" and success)
-                or (self.render_after_print == "fail" and not success)
+                self.render_after_print == RenderAfterPrintEnum.always
+                or (self.render_after_print == RenderAfterPrintEnum.success and success)
+                or (
+                    self.render_after_print == RenderAfterPrintEnum.failure
+                    and not success
+                )
             ),
         )
 

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -589,9 +589,14 @@ class Timelapse:
         """
         Override this to perform additional actions upon the stop of a print job.
         """
+        success = event == Events.PRINT_DONE
         self.stop_timelapse(
-            success=(event == Events.PRINT_DONE),
-            do_create_movie=(self.render_after_print != "never"),
+            success=success,
+            do_create_movie=(
+                self.render_after_print == "always"
+                or (self.render_after_print == "successful" and success)
+                or (self.render_after_print == "fail" and not success)
+            ),
         )
 
     def on_print_resumed(self, event, payload):
@@ -662,14 +667,7 @@ class Timelapse:
             file_prefix = self._file_prefix
             gcode_file = self._gcode_file
             self._reset_metadata()
-            if (
-                self.render_after_print == "always"
-                or (self.render_after_print == "successful" and success)
-                or (self.render_after_print == "fail" and not success)
-            ):
-                create_movie(file_prefix, gcode_file)
-            else:
-                self._logger.debug("Not rendering timelapse of failed prints")
+            create_movie(file_prefix, gcode_file)
 
         def wait_for_captures(callback):
             self._capture_queue.put(

--- a/src/octoprint/timelapse.py
+++ b/src/octoprint/timelapse.py
@@ -483,7 +483,12 @@ def configure_timelapse(config=None, persist=False):
             ):
                 interval = config["options"]["interval"]
 
-            current = TimedTimelapse(post_roll=postRoll, interval=interval, fps=fps, render_after_print=renderAfterPrint)
+            current = TimedTimelapse(
+                post_roll=postRoll,
+                interval=interval,
+                fps=fps,
+                render_after_print=renderAfterPrint,
+            )
 
     notify_callbacks(current)
 
@@ -584,7 +589,10 @@ class Timelapse:
         """
         Override this to perform additional actions upon the stop of a print job.
         """
-        self.stop_timelapse(success=(event == Events.PRINT_DONE), do_create_movie=(self.render_after_print != "never"))
+        self.stop_timelapse(
+            success=(event == Events.PRINT_DONE),
+            do_create_movie=(self.render_after_print != "never"),
+        )
 
     def on_print_resumed(self, event, payload):
         """
@@ -646,7 +654,7 @@ class Timelapse:
 
         def reset_and_create():
             reset_image_number()
-            if self.render_failed_print!="successful" or success:
+            if self.render_failed_print != "successful" or success:
                 create_movie()
             else:
                 self._logger.debug("Not rendering timelapse of failed prints")
@@ -858,8 +866,17 @@ class Timelapse:
 
 
 class ZTimelapse(Timelapse):
-    def __init__(self, retraction_zhop=0, min_delay=5.0, post_roll=0, fps=25, render_after_print="always"):
-        Timelapse.__init__(self, post_roll=post_roll, fps=fps, render_after_print=render_after_print)
+    def __init__(
+        self,
+        retraction_zhop=0,
+        min_delay=5.0,
+        post_roll=0,
+        fps=25,
+        render_after_print="always",
+    ):
+        Timelapse.__init__(
+            self, post_roll=post_roll, fps=fps, render_after_print=render_after_print
+        )
 
         if min_delay < 0:
             min_delay = 0
@@ -917,7 +934,9 @@ class ZTimelapse(Timelapse):
 
 class TimedTimelapse(Timelapse):
     def __init__(self, interval=1, post_roll=0, fps=25, render_after_print="always"):
-        Timelapse.__init__(self, post_roll=post_roll, fps=fps, render_after_print=render_after_print)
+        Timelapse.__init__(
+            self, post_roll=post_roll, fps=fps, render_after_print=render_after_print
+        )
         self._interval = interval
         if self._interval < 1:
             self._interval = 1  # force minimum interval of 1s


### PR DESCRIPTION
This Request wants to take care of the suprisingly old #1313
It offers a combo box for setting what is to be done with the timelapse after a print is finished. To not break previous setups, the default is to render always after a print. However, it is now also possible to render only successful prints after the print is finished, or to never render a print after finishing printing. 

However, I am still not done with this request, because there is a bug I cannot really get my head around. Maybe someone a bit more acquainted can help me out here?

Currently, the render is successfully skipped, however the according print files are still kept as currently active, as if the recording did not stop. This must be due to the timelapse being saved as "current" (the variable in src/octoprint/timelapse.py), but I cannot find where this is happening and how to stop it. A restart of the server fixes it, as the "current" variable gets reinitialized then. 
I am also not really sure how to test it without printing, which is just a bit painful for debugging this efficiently. 
I would appreciate any help. Thank you for this great project @foosel !