### PR TITLE
Add screenreader info about links in tabs for enabling navigation with keyboard shortcuts

### DIFF
--- a/src/octoprint/templates/index.jinja2
+++ b/src/octoprint/templates/index.jinja2
@@ -139,7 +139,7 @@
                                     {% if "data_bind" in data %}data-bind="{{ data.data_bind }}"{% endif %}
                                     {% if "styles_link" in data %} style="{{ data.styles_link|join(', ') }}" {% elif "styles" in data %} style="{{ data.styles|join(', ') }}" {% endif %}
                                         >
-                                        <a href="#{{ data._div }}" data-toggle="tab" role="tab" aria-label="{{ entry|edq }}">{{ entry|e }}</a>
+                                        <div role="tab"><a href="#{{ data._div }}" data-toggle="tab" aria-label="{{ entry|edq }}">{{ entry|e }}</a></div>
                                 </li>
                                 {% if "custom_bindings" not in data or data["custom_bindings"] %}<!-- /ko -->{% endif %}
                             {% endfor %}


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

In PR #4928 many screenreader related improvements were implemented.
One of them was, as proposed by WCAG, setting correct aria roles and labels.
Unfortunately, after final release of 1.10.0 I found out that this behavior, while with accordance with guidelines, makes it a lot harder to navigate between tabs as they are no longer seen as links by screenreaders. I used to navigate them using keyboard shortcuts or rotor on Mac, but now it is out of question.
This PR tries to make a workaround that allows for such navigation, while being compatible with WCAG and giving proper screenreader feedback.

#### How was it tested? How can it be tested by the reviewer?
Tested on Windows, Mac, iOS.

#### Any background context you want to provide?
N/A

#### What are the relevant tickets if any?
N/A

#### Screenshots (if appropriate)
N/A

#### Further notes
I'd like to thank you for your interest in making OctoPrint accessible software, recently many projects (also from the 3d printing world) ignore or assign low priority to a11y-related PRs.

I would be very grateful if that fix could be implemented in maintenance branch (version 1.10.1), as the issue (sorry for not noticing it previously) is quite problematic.