### PR TITLE
fix netmask

### DIFF
--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -57,7 +57,7 @@ def get_lan_ranges(additional_private=None):
         additional_private = []
 
     def to_ipnetwork(address):
-        prefix = address["netmask"]
+        prefix = address["mask"]
         if "/" in prefix:
             # v6 notation in netifaces output, e.g. "ffff:ffff:ffff:ffff::/64"
             _, prefix = prefix.split("/")


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)


#### What does this PR do and why is it necessary?
in netifaces2 netmask was replaced with mask
#### How was it tested? How can it be tested by the reviewer?
manually modified in local deployment and ran OctoPrint
#### Any background context you want to provide?

#### What are the relevant tickets if any?
#5005
#### Screenshots (if appropriate)

#### Further notes
