### PR TITLE
Wrapped gcode filepath in analysis.py with quotes.

### DIFF
--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -480,7 +480,7 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
                 command += ["--offset", str(offset[0]), str(offset[1])]
             if g90_extruder:
                 command += ["--g90-extruder"]
-            command.append(f"\"{self._current.absolute_path}\"")
+            command.append(f'"{self._current.absolute_path}"')
 
             self._logger.info("Invoking analysis command: {}".format(" ".join(command)))
 

--- a/src/octoprint/filemanager/analysis.py
+++ b/src/octoprint/filemanager/analysis.py
@@ -480,7 +480,7 @@ class GcodeAnalysisQueue(AbstractAnalysisQueue):
                 command += ["--offset", str(offset[0]), str(offset[1])]
             if g90_extruder:
                 command += ["--g90-extruder"]
-            command.append(self._current.absolute_path)
+            command.append(f"\"{self._current.absolute_path}\"")
 
             self._logger.info("Invoking analysis command: {}".format(" ".join(command)))
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket - Not applicable
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`) - Not applicable
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Fixing issue #5008.

#### How was it tested? How can it be tested by the reviewer?
I monkeypatched my installation of octoprint.
The file `/octoprint/octoprint/uploads/.metadata.json` is now correctly modified.

<details>
  <summary>Before fix</summary>

```
cat /octoprint/octoprint/uploads/.metadata.json
{
  "CFFFP_medium paint palette.gcode": {
    "hash": "5e0c70c86eb7229ac74592d3ae8bb6fd355bad41",
    "thumbnail": "plugin/prusaslicerthumbnails/thumbnail/CFFFP_medium%20paint%20palette.png?20240505092824",
    "thumbnail_src": "prusaslicerthumbnails",
    "dashboard": {
      "layer_move_array": "[8, 1908, 1891, 4546, 4805, 5189, 5160, 6064, 6137, 3157, 3002, 3094]",
      "filament_change_array": "[]"
    }
  },
  "CFFFP_Art Palette.gcode": {
    "hash": "5dc1acc6868494dc97853b3d4c236412fdedac4a",
    "thumbnail": "plugin/prusaslicerthumbnails/thumbnail/CFFFP_Art%20Palette.png?20240505110712",
    "thumbnail_src": "prusaslicerthumbnails"
  }
}
```
</details>

<details>
  <summary>After fix</summary>

```
# cat /octoprint/octoprint/uploads/.metadata.json
{
  "CFFFP_medium paint palette.gcode": {
    "hash": "5e0c70c86eb7229ac74592d3ae8bb6fd355bad41",
    "thumbnail": "plugin/prusaslicerthumbnails/thumbnail/CFFFP_medium%20paint%20palette.png?20240505092824",
    "thumbnail_src": "prusaslicerthumbnails",
    "dashboard": {
      "layer_move_array": "[8, 1908, 1891, 4546, 4805, 5189, 5160, 6064, 6137, 3157, 3002, 3094]",
      "filament_change_array": "[]"
    },
    "history": [
      {
        "timestamp": 1714908785.426236,
        "printTime": 7481.191400446987,
        "success": true,
        "printerProfile": "_default"
      }
    ],
    "statistics": {
      "averagePrintTime": {
        "_default": 7481.191400446987
      },
      "lastPrintTime": {
        "_default": 7481.191400446987
      }
    },
    "analysis": {
      "printingArea": {
        "maxX": 183.256,
        "maxY": 163.88,
        "maxZ": 2.2,
        "minX": 0.0,
        "minY": -5.0,
        "minZ": 0.0
      },
      "dimensions": {
        "depth": 168.88,
        "height": 2.2,
        "width": 183.256
      },
      "travelArea": {
        "maxX": 200.0,
        "maxY": 220.0,
        "maxZ": 10.0,
        "minX": 0.0,
        "minY": -5.0,
        "minZ": 0.0
      },
      "travelDimensions": {
        "depth": 225.0,
        "height": 10.0,
        "width": 200.0
      },
      "estimatedPrintTime": 7072.297209649928,
      "filament": {
        "tool0": {
          "length": 5866.855039999981,
          "volume": 0.0
        }
      }
    }
  },
  "CFFFP_Art Palette.gcode": {
    "hash": "5dc1acc6868494dc97853b3d4c236412fdedac4a",
    "thumbnail": "plugin/prusaslicerthumbnails/thumbnail/CFFFP_Art%20Palette.png?20240505110712",
    "thumbnail_src": "prusaslicerthumbnails",
    "analysis": {
      "printingArea": {
        "maxX": 212.836,
        "maxY": 187.46,
        "maxZ": 4.8,
        "minX": 0.0,
        "minY": -5.0,
        "minZ": 0.0
      },
      "dimensions": {
        "depth": 192.46,
        "height": 4.8,
        "width": 212.836
      },
      "travelArea": {
        "maxX": 212.836,
        "maxY": 220.0,
        "maxZ": 10.0,
        "minX": 0.0,
        "minY": -5.0,
        "minZ": 0.0
      },
      "travelDimensions": {
        "depth": 225.0,
        "height": 10.0,
        "width": 212.836
      },
      "estimatedPrintTime": 27858.101268077822,
      "filament": {
        "tool0": {
          "length": 24140.12336000039,
          "volume": 0.0
        }
      }
    },
    "dashboard": {
      "layer_move_array": "[8, 2348, 2371, 2339, 2374, 2343, 2376, 4700, 8224, 7691, 7883, 8144, 8295, 5878, 5869, 5879, 5008, 6029, 6061, 6790, 6832, 6803, 6862, 7568, 7001]",
      "filament_change_array": "[]"
    },
    "history": [
      {
        "timestamp": 1714909651.5161788,
        "success": false,
        "printerProfile": "_default"
      }
    ],
    "statistics": {
      "averagePrintTime": {},
      "lastPrintTime": {}
    }
  }
}
```
</details>

#### Any background context you want to provide?
Plugins like dashboard are depending on the parsed metadata generated like "maxZ".
This lead me here.

#### Further notes
I failed to run the unit tests via pytest even without my changes. Any help in this department would be great.
What I did:
1. Created a new venv
2. Installed the dependencies from setup.py via `python setup.py install`
3. Ran `pytest .\tests\`

I know, python 3.12 breaks a lot of dependencies, but as it is allowed in setup.py (`PYTHON_REQUIRES = ">=3.7, <3.13"`) I went with it. The error i am getting is this one repeating:
```
ERROR tests/access/groups/test_groupmanager.py - AttributeError: 'FieldInfo' object has no attribute 'field_info'
ERROR tests/access/groups/test_groupmanager.py - AttributeError: 'FieldInfo' object has no attribute 'field_info'
...
```
Edit 1:
I uninstalled my python 3.12 installation and reinstalled python 3.10.11.
Afterwards my unit tests passed successfully. Seems my python 3.12 version has been corrupted.
