### PR TITLE
feat: add MMU commands to autoUppercaseBlacklist

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -183,6 +183,7 @@ date of first contribution):
   * [Matthias Weis](https://github.com/mad73923)
   * [Rob Emery](https://github.com/mintsoft)
   * [Jacopo Tediosi](https://github.com/jacopotediosi)
+  * [Jeff Mixon](https://github.com/zaventh)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/schema/config/feature.py
+++ b/src/octoprint/schema/config/feature.py
@@ -35,7 +35,7 @@ class FeatureConfig(BaseModel):
 
     uploadOverwriteConfirmation: bool = True
 
-    autoUppercaseBlacklist: List[str] = ["M117", "M118"]
+    autoUppercaseBlacklist: List[str] = ["M707", "M708", "M117", "M118"]
     """Commands that should never be auto-uppercased when sent to the printer through the Terminal tab."""
 
     g90InfluencesExtruder: bool = False

--- a/src/octoprint/schema/config/feature.py
+++ b/src/octoprint/schema/config/feature.py
@@ -35,7 +35,7 @@ class FeatureConfig(BaseModel):
 
     uploadOverwriteConfirmation: bool = True
 
-    autoUppercaseBlacklist: List[str] = ["M707", "M708", "M117", "M118"]
+    autoUppercaseBlacklist: List[str] = ["M117", "M118", "M707", "M708"]
     """Commands that should never be auto-uppercased when sent to the printer through the Terminal tab."""
 
     g90InfluencesExtruder: bool = False


### PR DESCRIPTION
M707, M708 are related to Prusa MMU devices and require passing a hexadecimal argument with a lower-cased address.

More information: https://reprap.org/wiki/G-code#M707:_Read_from_MMU_register

Resolves #4864

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)


#### What does this PR do and why is it necessary?

Allows sending relevant MMU gcode commands without having to manually blacklist them