### PR TITLE
Add API method for editing temp of "Current Extruder" on a multiple Extruder printer.

### DIFF
--- a/docs/api/printer.rst
+++ b/docs/api/printer.rst
@@ -351,8 +351,8 @@ Issue a tool command
    target
      Sets the given target temperature on the printer's tools. Additional parameters:
 
-     * ``targets``: Target temperature(s) to set, properties must match the format ``tool{n}`` with ``n`` being the
-       tool's index starting with 0. A value of `0` will turn the heater off.
+     * ``targets``: Target temperature(s) to set, properties must match the format ``tool`` or ``tool{n}`` with ``n`` being the
+       tool's index starting with 0. ``tool`` signifies the currently active extruder. A target value of `0` will turn the heater off.
 
    offset
      Sets the given temperature offset on the printer's tools. Additional parameters:
@@ -400,6 +400,28 @@ Issue a tool command
         "targets": {
           "tool0": 220,
           "tool1": 205
+        }
+      }
+
+   .. sourcecode:: http
+
+      HTTP/1.1 204 No Content
+
+   **Example Target Temperature Request (Current Tool Only)**
+
+   Set the target temperature for the printer's currently active hotend to 220°C.
+
+   .. sourcecode:: http
+
+      POST /api/printer/tool HTTP/1.1
+      Host: example.com
+      Content-Type: application/json
+      X-Api-Key: abcdef...
+
+      {
+        "command": "target",
+        "targets": {
+          "tool": 220
         }
       }
 

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1686,7 +1686,7 @@ class VirtualPrinter:
         self, line: str, wait: bool = False, support_r: bool = False
     ) -> None:
         only_wait_if_higher = True
-        tool = 0
+        tool = self.currentExtruder
         toolMatch = re.search(r"T([0-9]+)", line)
         if toolMatch:
             tool = int(toolMatch.group(1))

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -46,8 +46,11 @@ class PrinterInterface:
     valid_tool_regex = re.compile(r"^(tool\d+)$")
     """Regex for valid tool identifiers."""
 
-    valid_heater_regex = re.compile(r"^(tool\d+|bed|chamber)$")
+    valid_heater_regex = re.compile(r"^(tool\d*|bed|chamber)$")
     """Regex for valid heater identifiers."""
+
+    valid_heater_regex_no_current = re.compile(r"^(tool\d+|bed|chamber)$")
+    """Regex for valid heater identifiers without the current heater."""
 
     @classmethod
     def get_connection_options(cls, *args, **kwargs):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -606,7 +606,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
     def set_temperature(self, heater, value, *args, **kwargs):
         if not PrinterInterface.valid_heater_regex.match(heater):
             raise ValueError(
-                'heater must match "tool([0-9]+|Current_Extruder)", "bed" or "chamber": {heater}'.format(
+                'heater must match "tool", "tool([0-9])", "bed" or "chamber": {heater}'.format(
                     heater=heater
                 )
             )
@@ -616,17 +616,18 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
 
         tags = kwargs.get("tags", set()) | {"trigger:printer.set_temperature"}
 
-        if heater.startswith("tool"):
+        if heater == "tool":
+            # set current tool, whatever that might be
+            self.commands(f"M104 S{value}", tags=tags)
+
+        elif heater.startswith("tool"):
+            # set specific tool
             printer_profile = self._printerProfileManager.get_current_or_default()
             extruder_count = printer_profile["extruder"]["count"]
             shared_nozzle = printer_profile["extruder"]["sharedNozzle"]
             if extruder_count > 1 and not shared_nozzle:
-                if heater[len("tool") :] == "Current_Extruder":
-                    toolNum = "current_extruder"
-                    self.commands(f"M104 T{toolNum} S{value}", tags=tags)
-                else:
-                    toolNum = int(heater[len("tool") :])
-                    self.commands(f"M104 T{toolNum} S{value}", tags=tags)
+                toolNum = int(heater[len("tool") :])
+                self.commands(f"M104 T{toolNum} S{value}", tags=tags)
             else:
                 self.commands(f"M104 S{value}", tags=tags)
 
@@ -644,7 +645,10 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             raise ValueError("offsets must be a dict")
 
         validated_keys = list(
-            filter(lambda x: PrinterInterface.valid_heater_regex.match(x), offsets.keys())
+            filter(
+                lambda x: PrinterInterface.valid_heater_regex_no_current.match(x),
+                offsets.keys(),
+            )
         )
         validated_values = list(
             filter(lambda x: isinstance(x, (int, float)), offsets.values())
@@ -1845,7 +1849,8 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
         self, local_filename, remote_filename, filesize, user=None
     ):
         eventManager().fire(
-            Events.TRANSFER_STARTED, {"local": local_filename, "remote": remote_filename}
+            Events.TRANSFER_STARTED,
+            {"local": local_filename, "remote": remote_filename},
         )
 
         self._sdStreaming = True

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -606,7 +606,7 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
     def set_temperature(self, heater, value, *args, **kwargs):
         if not PrinterInterface.valid_heater_regex.match(heater):
             raise ValueError(
-                'heater must match "tool[0-9]+", "bed" or "chamber": {heater}'.format(
+                'heater must match "tool([0-9]+|Current_Extruder)", "bed" or "chamber": {heater}'.format(
                     heater=heater
                 )
             )
@@ -621,8 +621,12 @@ class Printer(PrinterInterface, comm.MachineComPrintCallback):
             extruder_count = printer_profile["extruder"]["count"]
             shared_nozzle = printer_profile["extruder"]["sharedNozzle"]
             if extruder_count > 1 and not shared_nozzle:
-                toolNum = int(heater[len("tool") :])
-                self.commands(f"M104 T{toolNum} S{value}", tags=tags)
+                if heater[len("tool") :] == "Current_Extruder":
+                    toolNum = "current_extruder"
+                    self.commands(f"M104 T{toolNum} S{value}", tags=tags)
+                else:
+                    toolNum = int(heater[len("tool") :])
+                    self.commands(f"M104 T{toolNum} S{value}", tags=tags)
             else:
                 self.commands(f"M104 S{value}", tags=tags)
 

--- a/src/octoprint/server/api/printer.py
+++ b/src/octoprint/server/api/printer.py
@@ -83,14 +83,15 @@ def printerToolCommand():
     if response is not None:
         return response
 
-    validation_regex = re.compile(r"tool\d+")
+    validation_regex_current = re.compile(r"tool\d*")
+    validation_regex_specific = re.compile(r"tool\d+")
 
     tags = {"source:api", "api:printer.tool"}
 
     ##~~ tool selection
     if command == "select":
         tool = data["tool"]
-        if not isinstance(tool, str) or re.match(validation_regex, tool) is None:
+        if not isinstance(tool, str) or re.match(validation_regex_specific, tool) is None:
             abort(400, description="tool is invalid")
 
         printer.change_tool(tool, tags=tags)
@@ -102,7 +103,7 @@ def printerToolCommand():
         # make sure the targets are valid and the values are numbers
         validated_values = {}
         for tool, value in targets.items():
-            if re.match(validation_regex, tool) is None:
+            if re.match(validation_regex_current, tool) is None:
                 abort(400, description="targets contains invalid tool")
             if not isinstance(value, (int, float)):
                 abort(400, description="targets contains invalid value")
@@ -119,7 +120,7 @@ def printerToolCommand():
         # make sure the targets are valid, the values are numbers and in the range [-50, 50]
         validated_values = {}
         for tool, value in offsets.items():
-            if re.match(validation_regex, tool) is None:
+            if re.match(validation_regex_specific, tool) is None:
                 abort(400, description="offsets contains invalid tool")
             if not isinstance(value, (int, float)) or not -50 <= value <= 50:
                 abort(400, description="offsets contains invalid value")


### PR DESCRIPTION
This solves  :
https://github.com/OctoPrint/OctoPrint/issues/5018
Adds a "Current_Extruder" option for the toolNum element for setting hotend temp via a REST call.
when the new element is used, it leverages the "current_extruder" variable in the gcode call, since we currently have no tracking of which toolhead/extruder is active and there is no call to retrieve the data from the printer.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This adds an additional endpoint for controlling the "current" toolhead on a multiple toolhead printer, leveraging the "current_extruder" gcode variable, since we have no tracking of which toolhead is active.

#### How was it tested? How can it be tested by the reviewer?
Have at least 2 toolheads, select toolhead two (T1).
Make the following POST request:
POST /api/printer/tool HTTP/1.1
Content-Type: application/json
{
  "command": "target",
  "targets": {
    "toolCurrent_Extruder": 220
  }
}

The terminal should show the following being sent:
M104 T{current_extruder} S{220}

#### Any background context you want to provide?

#### What are the relevant tickets if any?
https://github.com/OctoPrint/OctoPrint/issues/5018

#### Screenshots (if appropriate)

#### Further notes
