### PR TITLE
chore: migrate to pydantic 2.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ core_deps = [
     "pathvalidate>=2.5.2,<3",
     "pkginfo>=1.9.6,<2",
     "psutil>=5.9.8,<6",
-    "pydantic==1.10.12",  # to be kept pinned until https://github.com/pydantic/pydantic/issues/7689 is resolved
+    "pydantic>=2.7.3,<3 ; python_version>='3.8'",
+    "pydantic==1.10.12 ; python_version<'3.8'",  # to be kept pinned until https://github.com/pydantic/pydantic/issues/7689 is resolved
     "pylru>=1.2.1,<2",
     "pyserial>=3.5,<4",
     "pytz",

--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,7 @@ core_deps = [
     "pathvalidate>=2.5.2,<3",
     "pkginfo>=1.9.6,<2",
     "psutil>=5.9.8,<6",
-    "pydantic>=2.7.3,<3 ; python_version>='3.8'",
+    "pydantic>=2.7.4,<3 ; python_version>='3.8'",
     "pydantic==1.10.12 ; python_version<'3.8'",  # to be kept pinned until https://github.com/pydantic/pydantic/issues/7689 is resolved
     "pylru>=1.2.1,<2",
     "pyserial>=3.5,<4",

--- a/src/octoprint/plugins/achievements/__init__.py
+++ b/src/octoprint/plugins/achievements/__init__.py
@@ -11,13 +11,13 @@ from typing import List
 
 from flask import abort, jsonify
 from flask_babel import gettext
-from pydantic import BaseModel
 
 import octoprint.plugin
 import octoprint.util
 from octoprint.access import ADMIN_GROUP, READONLY_GROUP, USER_GROUP
 from octoprint.access.permissions import Permissions
 from octoprint.events import Events
+from octoprint.schema import BaseModel
 from octoprint.util.version import get_octoprint_version
 
 from .achievements import Achievement, Achievements

--- a/src/octoprint/plugins/achievements/__init__.py
+++ b/src/octoprint/plugins/achievements/__init__.py
@@ -249,11 +249,11 @@ class AchievementsPlugin(
 
             if payload["time"] > self._data.stats.longest_print_duration:
                 self._data.stats.longest_print_duration = payload["time"]
-                self._data.stats.longest_print_date = self._now().timestamp()
+                self._data.stats.longest_print_date = int(self._now().timestamp())
 
             if payload["time"] > self._year_data.longest_print_duration:
                 self._year_data.longest_print_duration = payload["time"]
-                self._year_data.longest_print_date = self._now().timestamp()
+                self._year_data.longest_print_date = int(self._now().timestamp())
 
             self._trigger_achievement(Achievements.ONE_SMALL_STEP_FOR_MAN, write=False)
 
@@ -657,7 +657,7 @@ class AchievementsPlugin(
     def _reset_data(self):
         self._data = Data(
             stats=Stats(
-                created=self._now().timestamp(),
+                created=int(self._now().timestamp()),
                 created_version=get_octoprint_version().base_version,
             ),
             achievements={},

--- a/src/octoprint/plugins/achievements/achievements.py
+++ b/src/octoprint/plugins/achievements/achievements.py
@@ -1,7 +1,7 @@
 import os
 import re
 
-from pydantic import BaseModel
+from octoprint.schema import BaseModel
 
 ROMAN_NUMERAL = re.compile(
     "^M{0,4}(CM|CD|D?C{0,3})(XC|XL|L?X{0,3})(IX|IV|V?I{0,3})$", re.IGNORECASE

--- a/src/octoprint/plugins/achievements/data.py
+++ b/src/octoprint/plugins/achievements/data.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from pydantic import BaseModel
+from octoprint.schema import BaseModel
 
 
 class StatsBase(BaseModel):

--- a/src/octoprint/schema/__init__.py
+++ b/src/octoprint/schema/__init__.py
@@ -3,21 +3,11 @@ __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms
 
 
 from pydantic import BaseModel as PydanticBaseModel
+from pydantic import ConfigDict
+from pydantic import __version__ as pydantic_version
 
-try:
-    # pydantic 2.x
-    import pydantic.v1 as pydantic_v1  # noqa: F401
-
-    del pydantic_v1
-
-    from pydantic import ConfigDict
-
-    class BaseModel(PydanticBaseModel):
-        model_config = ConfigDict(use_enum_values=True)
-
-except ImportError:
+if pydantic_version.startswith("1."):
     # pydantic 1.x
-
     class BaseModel(PydanticBaseModel):
         class Config:
             use_enum_values = True
@@ -31,3 +21,10 @@ except ImportError:
             kwargs.pop("serialize_as_any", None)
 
             return self.dict(*args, **kwargs)
+
+else:
+    # pydantic 2.x
+    from pydantic import ConfigDict
+
+    class BaseModel(PydanticBaseModel):
+        model_config = ConfigDict(use_enum_values=True)

--- a/src/octoprint/schema/__init__.py
+++ b/src/octoprint/schema/__init__.py
@@ -24,10 +24,10 @@ except ImportError:
 
         def model_dump(self, *args, **kwargs):
             # not supported in pydantic 1.x
-            kwargs.pop("mode")
-            kwargs.pop("context")
-            kwargs.pop("round_trip")
-            kwargs.pop("warnings")
-            kwargs.pop("serialize_as_any")
+            kwargs.pop("mode", None)
+            kwargs.pop("context", None)
+            kwargs.pop("round_trip", None)
+            kwargs.pop("warnings", None)
+            kwargs.pop("serialize_as_any", None)
 
             return self.dict(*args, **kwargs)

--- a/src/octoprint/schema/__init__.py
+++ b/src/octoprint/schema/__init__.py
@@ -1,9 +1,33 @@
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
+
 from pydantic import BaseModel as PydanticBaseModel
 
+try:
+    # pydantic 2.x
+    import pydantic.v1 as pydantic_v1  # noqa: F401
 
-class BaseModel(PydanticBaseModel):
-    class Config:
-        use_enum_values = True
+    del pydantic_v1
+
+    from pydantic import ConfigDict
+
+    class BaseModel(PydanticBaseModel):
+        model_config = ConfigDict(use_enum_values=True)
+
+except ImportError:
+    # pydantic 1.x
+
+    class BaseModel(PydanticBaseModel):
+        class Config:
+            use_enum_values = True
+
+        def model_dump(self, *args, **kwargs):
+            # not supported in pydantic 1.x
+            kwargs.pop("mode")
+            kwargs.pop("context")
+            kwargs.pop("round_trip")
+            kwargs.pop("warnings")
+            kwargs.pop("serialize_as_any")
+
+            return self.dict(*args, **kwargs)

--- a/src/octoprint/vendor/with_attrs_docs.py
+++ b/src/octoprint/vendor/with_attrs_docs.py
@@ -7,26 +7,53 @@ from typing import Type
 from class_doc import extract_docs_from_cls_obj
 from pydantic import BaseModel
 
+try:
+    # pydantic 2.x
+    import pydantic.v1 as pydantic_v1
+    del pydantic_v1
 
-def apply_attributes_docs(
-    model: Type[BaseModel], override_existing: bool = True
-) -> None:
-    """
-    Apply model attributes documentation in-place. Resulted docs are placed
-    inside :code:`field.schema.description` for *pydantic* model field.
-    :param model: any pydantic model
-    :param override_existing: override existing descriptions
-    """
-    docs = extract_docs_from_cls_obj(model)
+    def apply_attributes_docs(
+        model: Type[BaseModel], override_existing: bool = True
+    ) -> None:
+        """
+        Apply model attributes documentation in-place. Resulted docs are placed
+        inside :code:`field.schema.description` for *pydantic* model field.
+        :param model: any pydantic model
+        :param override_existing: override existing descriptions
+        """
+        docs = extract_docs_from_cls_obj(model)
 
-    for field in model.__fields__.values():
-        if field.field_info.description and not override_existing:
-            continue
+        for name, field in model.model_fields.items():
+            if field.description and not override_existing:
+                continue
 
-        try:
-            field.field_info.description = '\n'.join(docs[field.name])
-        except KeyError:
-            pass
+            try:
+                field.description = '\n'.join(docs[name])
+            except KeyError:
+                pass
+
+
+except ImportError:
+    # pydantic 1.x
+    def apply_attributes_docs(
+        model: Type[BaseModel], override_existing: bool = True
+    ) -> None:
+        """
+        Apply model attributes documentation in-place. Resulted docs are placed
+        inside :code:`field.schema.description` for *pydantic* model field.
+        :param model: any pydantic model
+        :param override_existing: override existing descriptions
+        """
+        docs = extract_docs_from_cls_obj(model)
+
+        for field in model.__fields__.values():
+            if field.field_info.description and not override_existing:
+                continue
+
+            try:
+                field.field_info.description = '\n'.join(docs[field.name])
+            except KeyError:
+                pass
 
 
 def with_attrs_docs(

--- a/src/octoprint/vendor/with_attrs_docs.py
+++ b/src/octoprint/vendor/with_attrs_docs.py
@@ -6,8 +6,31 @@ from typing import Type
 
 from class_doc import extract_docs_from_cls_obj
 from pydantic import BaseModel
+from pydantic import __version__ as pydantic_version
 
-try:
+if pydantic_version.startswith("1."):
+    # pydantic 1.x
+    def apply_attributes_docs(
+        model: Type[BaseModel], override_existing: bool = True
+    ) -> None:
+        """
+        Apply model attributes documentation in-place. Resulted docs are placed
+        inside :code:`field.schema.description` for *pydantic* model field.
+        :param model: any pydantic model
+        :param override_existing: override existing descriptions
+        """
+        docs = extract_docs_from_cls_obj(model)
+
+        for field in model.__fields__.values():
+            if field.field_info.description and not override_existing:
+                continue
+
+            try:
+                field.field_info.description = '\n'.join(docs[field.name])
+            except KeyError:
+                pass
+
+else:
     # pydantic 2.x
     import pydantic.v1 as pydantic_v1
     del pydantic_v1
@@ -31,30 +54,6 @@ try:
                 field.description = '\n'.join(docs[name])
             except KeyError:
                 pass
-
-
-except ImportError:
-    # pydantic 1.x
-    def apply_attributes_docs(
-        model: Type[BaseModel], override_existing: bool = True
-    ) -> None:
-        """
-        Apply model attributes documentation in-place. Resulted docs are placed
-        inside :code:`field.schema.description` for *pydantic* model field.
-        :param model: any pydantic model
-        :param override_existing: override existing descriptions
-        """
-        docs = extract_docs_from_cls_obj(model)
-
-        for field in model.__fields__.values():
-            if field.field_info.description and not override_existing:
-                continue
-
-            try:
-                field.field_info.description = '\n'.join(docs[field.name])
-            except KeyError:
-                pass
-
 
 def with_attrs_docs(
     model_cls: Type[BaseModel]


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Migrates OctoPrint to using pydantic 2.x under Python 3.8+

#### How was it tested? How can it be tested by the reviewer?

Development testing (especially checking that settings still load and save fine, achievements work etc), automatic test suite, CI

#### Any background context you want to provide?

Pydantic 1.x will soon go the way of the dodo, so we need to upgrade to 2.x. That however doesn't support Python 3.7 which still is used by the majority of OctoPrint instances out there (56% at the time of writing, likely thanks to high use of OctoPi 0.17 and 0.18). Thus, the migration isn't as straightforward as hoped for - we need to depend on pydantic 1.x on Python 3.7, and pydantic 2.x everywhere else. The customized `BaseModel` has thus been enhanced to support the use of `model_dump` instead of `dict` in case of pydantic 1.x, to allow a Pydantic 2.x focused use in code even under Python 3.7. If OctoPrint core starts using more of the Pydantic 2.x API, we might have to add that too, but for now this suffices. 

The vendored `with_attrs_docs` decorator has been adjusted as well.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

The docs rewrite will likely need its tooling adjusted.
