### PR TITLE
Manage groups of remote user based on header

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -186,6 +186,7 @@ date of first contribution):
   * [Jeff Mixon](https://github.com/zaventh)
   * [lauren n. liberda](https://selfisekai.rocks/)
   * [Nathan Schulte](https://github.com/nmschulte)
+  * [Michon van Dooren](https://github.com/MaienM)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/schema/config/access_control.py
+++ b/src/octoprint/schema/config/access_control.py
@@ -1,7 +1,7 @@
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from octoprint.schema import BaseModel
 from octoprint.vendor.with_attrs_docs import with_attrs_docs
@@ -50,6 +50,15 @@ class AccessControlConfig(BaseModel):
 
     remoteUserHeader: str = "REMOTE_USER"
     """Header used by the reverse proxy to convey the authenticated user."""
+
+    trustRemoteGroups: bool = False
+    """Whether to trust remote groups headers. If you have setup authentication in front of OctoPrint and the groups names you use there match OctoPrint accounts, by setting this to true the user's groups will be set to the groups provided in the header. **ONLY ENABLE THIS** if your OctoPrint instance is only accessible through a connection locked down through an authenticating reverse proxy!"""
+
+    remoteGroupsHeader: str = "REMOTE_GROUPS"
+    """Header used by the reverse proxy to convey the authenticated user's groups."""
+
+    remoteGroupsMapping: Dict[str, str] = {}
+    """Mapping from groups in the header to groups in OctoPrint."""
 
     addRemoteUsers: bool = False
     """If a remote user is not found, add them. Use this only if all users from the remote system can use OctoPrint."""

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -234,6 +234,17 @@ def get_user_for_remote_user_header(
         )
         user = octoprint.server.userManager.find_user(userid=header)
 
+    if user and settings().getBoolean(["accessControl", "trustRemoteGroups"]):
+        groupHeader = request.headers.get(
+            settings().get(["accessControl", "remoteGroupsHeader"])
+        )
+        if groupHeader:
+            groups = groupHeader.split(",")
+            mapping = settings().get(["accessControl", "remoteGroupsMapping"])
+            if mapping:
+                groups = [mapping.get(group, group) for group in groups]
+            octoprint.server.userManager.change_user_groups(header, groups)
+
     if user:
         _flask.session["login_mechanism"] = LoginMechanism.REMOTE_USER
         _flask.session["credentials_seen"] = datetime.datetime.now().timestamp()


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This extends the existing functionality to automatically manage the users based on headers provided by an auth proxy in front of OctoPrint to include group management. This allows one to use an external source of users with varying levels of access.

By configuring a header that contains a comma-separated list of groups and optionally a mapping of the names in this list to the names of the matching OctoPrint groups (in case these don't match) this will manage the list of groups that a user belongs to.

#### How was it tested? How can it be tested by the reviewer?

I've mostly tested this by configuring it to look at the groups header that OAuth2 Proxy sends. (Note that it doesn't include this header by default, the `--set-xauthrequest` flag enables this.) It can also be tested by simply including these headers in a manual request.

Example configuration:

```yaml
accessControl:
  trustRemoteUser: true
  addRemoteUsers: true
  remoteUserHeader: 'X-Auth-Request-Preferred-Username'
  remoteGroupsHeader: 'X-Auth-Request-Groups'
  remoteGroupsMapping:
    foo: readonly
    bar: users
```

This can be tested by performing a login request with e.g. curl:

```shell
curl 'http://127.0.0.1:8083/api/login?passive' -X POST -H 'X-Auth-Request-Preferred-Username: testuser' -H 'X-Auth-Request-Groups: foo,bar'
```

In the output of this request it can be observed that the user is in the `readonly` and `users` groups. (Most fields have been omitted from this output for the sake of brevity.)

```json
{
  "name": "testuser",
  "groups": [
    "readonly",
    "users"
  ]
}
```

Repeating the request with one of the groups removed will result in the user also losing said group:

```shell
curl 'http://127.0.0.1:8083/api/login?passive' -X POST -H 'X-Auth-Request-Preferred-Username: testuser' -H 'X-Auth-Request-Groups: foo'
```

```json
{
  "name": "testuser",
  "groups": [
    "readonly"
  ]
}
```

#### Any background context you want to provide?

No.

#### What are the relevant tickets if any?

None that I am aware of.

#### Screenshots (if appropriate)

N/A.

#### Further notes

N/A.
