### PR TITLE
fix broken deque button in plugin manager

### DIFF
--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -1227,7 +1227,8 @@ $(function () {
                     command: self.installed(plugin) ? "reinstall" : "install",
                     url: plugin.archive,
                     dependency_links:
-                        plugin.follow_dependency_links || self.followDependencyLinks()
+                        plugin.follow_dependency_links || self.followDependencyLinks(),
+                    from_repo: true
                 }
             };
             OctoPrint.simpleApiCommand("pluginmanager", "clear_queued_plugin", data).done(


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [X] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

updates payload being sent to clear_queued_plugin API command to match the same payload as install command.

#### How was it tested? How can it be tested by the reviewer?

manually in dev environment

#### Any background context you want to provide?

the new from_repo property was added to the install command in https://github.com/OctoPrint/OctoPrint/commit/a0d7eb0fe761543adae3642d990e1c1f78531735 but not the removeFromQueue command to match.

#### What are the relevant tickets if any?

resolves #5057 

#### Screenshots (if appropriate)

#### Further notes
