### PR TITLE
🔒 Use secrets lib to generate Flask secret key

### DIFF
--- a/src/octoprint/access/users.py
+++ b/src/octoprint/access/users.py
@@ -4,9 +4,9 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 import hashlib
 import logging
 import os
+import secrets
 import shutil
 import time
-import uuid
 
 import wrapt
 from flask_login import AnonymousUserMixin, UserMixin
@@ -1453,7 +1453,7 @@ class SessionUser(wrapt.ObjectProxy):
     def __init__(self, user):
         wrapt.ObjectProxy.__init__(self, user)
 
-        self._self_session = "".join("%02X" % z for z in bytes(uuid.uuid4().bytes))
+        self._self_session = secrets.token_hex()
         self._self_created = self._self_touched = time.monotonic()
 
     @property

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -1540,11 +1540,9 @@ class Server:
 
         secret_key = s.get(["server", "secretKey"])
         if not secret_key:
-            import string
-            from random import choice
+            import secrets
 
-            chars = string.ascii_lowercase + string.ascii_uppercase + string.digits
-            secret_key = "".join(choice(chars) for _ in range(32))
+            secret_key = secrets.token_hex()
             s.set(["server", "secretKey"], secret_key)
             s.save()
 

--- a/src/octoprint/util/__init__.py
+++ b/src/octoprint/util/__init__.py
@@ -1693,9 +1693,9 @@ def time_this(
 
 
 def generate_api_key():
-    import uuid
+    import secrets
 
-    return "".join("%02X" % z for z in bytes(uuid.uuid4().bytes))
+    return secrets.token_urlsafe()
 
 
 def map_boolean(value, true_text, false_text):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket --> Not large/disruptive
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`) --> No style sheets
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [X] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
The current server implementation generates the Flask secret key using `random.choice`, which is not a cryptographically secure pseudo-random number generator (CSPRNG) and should not be used for cryptographic purposes. In fact, [it is known](https://stackered.com/blog/python-random-prediction/) that an attacker can predict the outputs of the `random` library after analyzing a few hundred of them.

However, it should be noted that this attack is difficult or impossible to exploit, as it requires the attacker to be able to observe the outputs of the `random` library before the Flask secret key is stored in the yaml configuration file when OctoPrint is first started. For this reason, this vulnerability is to be considered merely theoretical and is handled via a Pull Request rather than a Github Advisory.

This PR fixes secret key generation using the `secrets` library, as suggested by the Flask [documentation](https://flask.palletsprojects.com/en/latest/config/#SECRET_KEY).

All OctoPrint installations prior to this PR will retain the previous secret key, which should not pose a security concern as this attack is not even retroactive.

#### How was it tested? How can it be tested by the reviewer?
I tested this PR by applying it to the `maintenance` branch in a virtualenv with python 3.10. It passed all unit tests.

By deleting the `server.secretKey` entry from the `~/.octoprint/config.yaml` file, I verified that OctoPrint recreates a different new secret key inside the file after a restart.

The `secrets` library that introduces this PR does not appear to be used anywhere else in the OctoPrint code, but [it is native from python3.6 onwards](https://docs.python.org/3/library/secrets.html). OctoPrint dropped support for older Python versions years ago. Users with older versions can still apply an alternative fix by implementing `os.urandom` or installing the [python2-secrets](https://pypi.org/project/python2-secrets/) library.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
