### PR TITLE
include file data payload in onBeforePrintStart viewModel callback

### DIFF
--- a/docs/plugins/viewmodels.rst
+++ b/docs/plugins/viewmodels.rst
@@ -225,11 +225,12 @@ onUserPermissionsChanged(user)
    will be provided as only parameter. Note that this may also be triggered for not logged in guests if the guest
    group is modified. In this case ``user`` will be undefined.
 
-onBeforePrintStart(callback)
+onBeforePrintStart(callback, data)
    Called before a print is started either by clicking the "Print" button in the state panel or the select & print icon
-   in the file list. The callback to actually proceed with starting the print is provided as the only parameter. By returning
+   in the file list. The callback to proceed with starting the print is provided as first parameter. By returning
    ``false`` from this, plugins may prevent a print from actually starting, optionally starting it at a later date by
-   calling ``callback`` themselves. This can be used for example to implement an additional confirmation dialog.
+   calling ``callback`` themselves. This can be used for example to implement an additional confirmation dialog. The
+   second parameter is a file data object that includes details such as name, path, and origin.
 
 onTabChange(next, current)
    Called before the main tab view switches to a new tab, so `before` the new tab becomes visible. Called with the

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -724,7 +724,7 @@ $(function () {
                         self.allViewModels,
                         "onBeforePrintStart",
                         function (method) {
-                            prevented = prevented || method(callback) === false;
+                            prevented = prevented || method(callback, data) === false;
                         }
                     );
                     if (!prevented) callback();

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -75,6 +75,7 @@ $(function () {
             );
         });
 
+        self.fileobject = ko.observable(undefined);
         self.filename = ko.observable(undefined);
         self.filepath = ko.observable(undefined);
         self.filedisplay = ko.observable(undefined);
@@ -320,6 +321,7 @@ $(function () {
 
         self._processJobData = function (data) {
             if (data.file) {
+                self.fileobject(data.file);
                 self.filename(data.file.name);
                 self.filepath(data.file.path);
                 self.filesize(data.file.size);
@@ -327,6 +329,7 @@ $(function () {
                 self.filedate(data.file.date);
                 self.sd(data.file.origin === "sdcard");
             } else {
+                self.fileobject(undefined);
                 self.filename(undefined);
                 self.filepath(undefined);
                 self.filesize(undefined);
@@ -448,7 +451,9 @@ $(function () {
                         self.allViewModels,
                         "onBeforePrintStart",
                         function (method) {
-                            prevented = prevented || method(callback) === false;
+                            prevented =
+                                prevented ||
+                                method(callback, self.fileobject()) === false;
                         }
                     );
 

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -75,7 +75,7 @@ $(function () {
             );
         });
 
-        self.fileobject = ko.observable(undefined);
+        self.filedata = ko.observable(undefined);
         self.filename = ko.observable(undefined);
         self.filepath = ko.observable(undefined);
         self.filedisplay = ko.observable(undefined);
@@ -321,7 +321,6 @@ $(function () {
 
         self._processJobData = function (data) {
             if (data.file) {
-                self.fileobject(data.file);
                 self.filename(data.file.name);
                 self.filepath(data.file.path);
                 self.filesize(data.file.size);
@@ -329,7 +328,6 @@ $(function () {
                 self.filedate(data.file.date);
                 self.sd(data.file.origin === "sdcard");
             } else {
-                self.fileobject(undefined);
                 self.filename(undefined);
                 self.filepath(undefined);
                 self.filesize(undefined);
@@ -452,8 +450,7 @@ $(function () {
                         "onBeforePrintStart",
                         function (method) {
                             prevented =
-                                prevented ||
-                                method(callback, self.fileobject()) === false;
+                                prevented || method(callback, self.filedata()) === false;
                         }
                     );
 

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -76,17 +76,40 @@ $(function () {
         });
 
         self.filedata = ko.observable(undefined);
-        self.filename = ko.observable(undefined);
-        self.filepath = ko.observable(undefined);
-        self.filedisplay = ko.observable(undefined);
-        self.filesize = ko.observable(undefined);
         self.filepos = ko.observable(undefined);
-        self.filedate = ko.observable(undefined);
+
+        self.filename = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["name"] : undefined;
+        });
+        self.filepath = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["path"] : undefined;
+        });
+        self.filedisplay = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["display"] : undefined;
+        });
+        self.filesize = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["size"] : undefined;
+        });
+        self.filedate = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["date"] : undefined;
+        });
+        self.sd = ko.pureComputed(() => {
+            return self.filedata() ? self.filedata()["origin"] === "sdcard" : undefined;
+        });
+
+        self.calcFileKey = (data) => {
+            if (data === undefined) {
+                data = self.filedata();
+            }
+            if (data === undefined) return "null:null:null:null";
+
+            return `${data.origin}:${data.path}:${data.size}:${data.date}`;
+        };
+
         self.progress = ko.observable(undefined);
         self.printTime = ko.observable(undefined);
         self.printTimeLeft = ko.observable(undefined);
         self.printTimeLeftOrigin = ko.observable(undefined);
-        self.sd = ko.observable(undefined);
         self.timelapse = ko.observable(undefined);
         self.user = ko.observable(undefined);
 
@@ -321,19 +344,13 @@ $(function () {
 
         self._processJobData = function (data) {
             if (data.file) {
-                self.filename(data.file.name);
-                self.filepath(data.file.path);
-                self.filesize(data.file.size);
-                self.filedisplay(data.file.display);
-                self.filedate(data.file.date);
-                self.sd(data.file.origin === "sdcard");
+                const currentFileKey = self.calcFileKey();
+                const futureFileKey = self.calcFileKey(data.file);
+                if (currentFileKey !== futureFileKey) {
+                    self._loadFileData(data.file.origin, data.file.path);
+                }
             } else {
-                self.filename(undefined);
-                self.filepath(undefined);
-                self.filesize(undefined);
-                self.filedisplay(undefined);
-                self.filedate(undefined);
-                self.sd(undefined);
+                self.filedata(undefined);
             }
 
             self.estimatedPrintTime(data.estimatedPrintTime);
@@ -399,6 +416,12 @@ $(function () {
             self.resendCount(data.count);
             self.resendTotalTransmitted(data.transmitted);
             self.resendRatio(data.ratio);
+        };
+
+        self._loadFileData = (origin, path) => {
+            OctoPrint.files.get(origin, path).then((data) => {
+                self.filedata(data);
+            });
         };
 
         self._checkResendRatioCriticality = function () {


### PR DESCRIPTION
  * [X] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [X] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [X] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [X] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [X] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [X] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [X] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [ ] You have run the existing unit tests against your changes and
    nothing broke
  * [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?
Adds a second parameter to the onBeforePrintStart viewModel callback that includes selected file details. This allows plugins utilizing the callback to have access to the started file's name, path, and origin (at minimum, see notes below) to use for further processing. 

#### How was it tested? How can it be tested by the reviewer?
Locally in development environment utilizing the callback in my Bambu plugin to validate the data was coming through. 

#### Any background context you want to provide?

#### What are the relevant tickets if any?
resolves #4951 

#### Screenshots (if appropriate)

#### Further notes
It seems that the printerStateViewModel does not include the full file metadata that is provided from the filesViewModel "load and print" button, so the data object passed to the onBeforePrintStart callback varies based on where you start the print from in the UI. I attempted to get around this by adding a dependency to filesViewModel in printerstate.js so I could pass filesViewModel.selectedFile to the callback, but that broke the UI completely due to a dependency loop. Not sure if there's a better way to handle this, like include all the metadata from the server side for data.job in `self._processJobData(data.job);`; but that seems like it might be too much information to send over the websocket continuously. 

Should not impact any other plugins currently using the callback, as it was added as second parameter. 
