### PR TITLE
Implement the M106, M107 and M123 gcodes in the virtual printer

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -188,6 +188,7 @@ date of first contribution):
   * [Nathan Schulte](https://github.com/nmschulte)
   * [Michon van Dooren](https://github.com/MaienM)
   * [Hilton Shumway](https://github.com/Hillshum)
+  * [Tom Davie](https://github.com/beelsebob)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/docs/development/virtual_printer.rst
+++ b/docs/development/virtual_printer.rst
@@ -228,7 +228,22 @@ There many configuration options via ``config.yaml`` for the virtual printer tha
        # - heater: The heater id (eg. T0, T1, B)
        # - actual: The actual temperature of the heater
        m105NoTargetFormatString: {heater}:{actual:.2f}
-
+       
+       # Response to M123 for fan RPM
+       # Placeholders:
+       # - fan: The fan id (e.g. E0)
+       # - rpm: The rotation speed of the fan
+       m123RPMFormatString: {fan}:{rpm} RPM
+       
+       # Response to M123 for fan power level
+       # Placeholders:
+       # - fan: The fan id (e.g. E0)
+       # - power: The power level being delivered to the fan
+       m123RPMFormatString: {fan}@:{power}
+       
+       # The maximum speed (in RPM) the virtual printer's virtual fans can spin at.
+       fanMaxSpeed: 4560
+       
        # Enable virtual EEPROM
        # If enabled, a file `eeprom.json` will be created in the plugin data folder
        # to enable settings persistence across connections. Enables M500/1/2/4 commands

--- a/docs/development/virtual_printer.rst
+++ b/docs/development/virtual_printer.rst
@@ -228,22 +228,22 @@ There many configuration options via ``config.yaml`` for the virtual printer tha
        # - heater: The heater id (eg. T0, T1, B)
        # - actual: The actual temperature of the heater
        m105NoTargetFormatString: {heater}:{actual:.2f}
-       
+
        # Response to M123 for fan RPM
        # Placeholders:
        # - fan: The fan id (e.g. E0)
        # - rpm: The rotation speed of the fan
        m123RPMFormatString: {fan}:{rpm} RPM
-       
+
        # Response to M123 for fan power level
        # Placeholders:
        # - fan: The fan id (e.g. E0)
        # - power: The power level being delivered to the fan
        m123RPMFormatString: {fan}@:{power}
-       
+
        # The maximum speed (in RPM) the virtual printer's virtual fans can spin at.
        fanMaxSpeed: 4560
-       
+
        # Enable virtual EEPROM
        # If enabled, a file `eeprom.json` will be created in the plugin data folder
        # to enable settings persistence across connections. Enables M500/1/2/4 commands

--- a/src/octoprint/plugins/virtual_printer/__init__.py
+++ b/src/octoprint/plugins/virtual_printer/__init__.py
@@ -65,7 +65,10 @@ class VirtualPrinterPlugin(
             "m114FormatString": "X:{x} Y:{y} Z:{z} E:{e[current]} Count: A:{a} B:{b} C:{c}",
             "m105TargetFormatString": "{heater}:{actual:.2f}/ {target:.2f}",
             "m105NoTargetFormatString": "{heater}:{actual:.2f}",
+            "m123RPMFormatString": "{fan}:{rpm} RPM",
+            "m123PowerFormatString": "{fan}@:{power}",
             "ambientTemperature": 21.3,
+            "fanMaxSpeed": 4560,
             "errors": {
                 "checksum_mismatch": "Checksum mismatch",
                 "checksum_missing": "Missing checksum",

--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -103,6 +103,7 @@ class VirtualPrinter:
 
         self.temp = [self._ambient_temperature] * self.temperatureCount
         self.targetTemp = [0.0] * self.temperatureCount
+        self.fanPower = 0.0
         self.bedTemp = self._ambient_temperature
         self.bedTargetTemp = 0.0
         self.chamberTemp = self._ambient_temperature
@@ -171,6 +172,7 @@ class VirtualPrinter:
         self._locked = self._settings.get_boolean(["locked"])
 
         self._temperature_reporter = None
+        self._fan_reporter = None
         self._sdstatus_reporter = None
         self._pos_reporter = None
 
@@ -295,6 +297,10 @@ class VirtualPrinter:
             if self._temperature_reporter is not None:
                 self._temperature_reporter.cancel()
                 self._temperature_reporter = None
+
+            if self._fan_reporter is not None:
+                self._fan_reporter.cancel()
+                self._fan_reporter = None
 
             if self._sdstatus_reporter is not None:
                 self._sdstatus_reporter.cancel()
@@ -606,6 +612,23 @@ class VirtualPrinter:
         self._processTemperatureQuery()
         return True
 
+    def _gcode_M106(self, data: str) -> None:
+        matchS = re.search(r"S([0-9]+)", data)
+        if matchS is None:
+            return
+
+        matchP = re.search(r"P([0-9]+)", data)
+        power = matchS.group(1) / 255.0
+        fan = int(matchP.group(1)) if matchP else 0
+        if fan == 0:
+            self.fanPower = power
+
+    def _gcode_M107(self, data: str) -> None:
+        matchP = re.search(r"P([0-9]+)", data)
+        fan = int(matchP.group(1)) if matchP else 0
+        if fan == 0:
+            self.fanPower = 0
+
     # noinspection PyUnusedLocal
     def _gcode_M20(self, data: str) -> None:
         if self._sdCardReady:
@@ -815,6 +838,23 @@ class VirtualPrinter:
                 self._send(f"echo:{text}")
             else:
                 self._send(text)
+
+    def _gcode_M123(self, data: str) -> None:
+        matchS = re.search(r"S([0-9]+)", data)
+        if matchS is not None:
+            interval = int(matchS.group(1))
+            if self._fan_reporter is not None:
+                self._fan_reporter.cancel()
+
+            if interval > 0:
+                self._fan_reporter = RepeatedTimer(
+                    interval, lambda: self._send(self._generateFanOutput())
+                )
+                self._fan_reporter.start()
+            else:
+                self._fan_reporter = None
+        else:
+            self._generateFanOutput()
 
     def _gcode_M154(self, data: str) -> None:
         matchS = re.search(r"S([0-9]+)", data)
@@ -1676,6 +1716,37 @@ class VirtualPrinter:
         )
         output += " @:64\n"
         return output
+
+    def _generateFanOutput(self) -> str:
+        rpmTemplate = self._settings.get(["m123RPMFormatString"])
+        powerTemplate = self._settings.get(["m123PowerFormatString"])
+
+        speeds = collections.OrderedDict()
+
+        # send simulated fan speed data - there's 1 fan per extruder which turns on if the temperature of
+        # that extruder exceeds 50ºC.  Then there's a single part cooling fan.
+        if self.extruderCount > 1:
+            for i in range(0, self.extruderCount):
+                speeds[f"E{i}"] = 1.0 if self.temp[i] > 50 else 0.0
+        else:
+            extruder = "E"
+            if self._settings.get_boolean(["klipperTemperatureReporting"]):
+                extruder = "E0"
+
+            speeds[extruder] = 1.0 if self.temp[0] > 50 else 0.0
+
+        speeds["PRN1"] = self.fanPower
+
+        rpmOutput = " ".join(
+            rpmTemplate.format(
+                fan=x[0], rpm=int(x[1] * self._settings.get(["fanMaxSpeed"]))
+            )
+            for x in speeds.items()
+        )
+        powerOutput = " ".join(
+            powerTemplate.format(fan=x[0], power=int(x[1] * 255)) for x in speeds.items()
+        )
+        return rpmOutput + " " + powerOutput + "\n"
 
     def _processTemperatureQuery(self):
         includeOk = not self._okBeforeCommandOutput


### PR DESCRIPTION
  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
    (Technically, they are possible to do in a plugin, which is why I'm doing it in a plugin)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?
Adds support for M106, M107, and M123 in the virtual printer.  Technically, it's not necessary, but it is useful.  I'm using this to test octopussy features, other people might find it useful too.

#### How was it tested? How can it be tested by the reviewer?
A bunch of "printing" different bits of gcode and verifying the results.  I'd love to add a unit test, but there isn't really a framework for testing the virtual printer, and it didn't seem in scope to do that.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
