### PR TITLE
get_state_id is unimplemented

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -459,7 +459,7 @@ class PrinterInterface:
         """
         raise NotImplementedError()
 
-    def get_state_id(self, *args, **kwargs):
+    def get_state_id(self, *args, **kwargs) -> str:
         """
         Identifier of the current communication state.
 
@@ -483,6 +483,7 @@ class PrinterInterface:
         Returns:
              (str) A unique identifier corresponding to the current communication state.
         """
+        raise NotImplementedError()
 
     def get_current_data(self, *args, **kwargs):
         """


### PR DESCRIPTION
There’s currently no return or raise in `PrinterInterface::get_state_id`, this patch simply adds in a rais NotImplementError() like the other methods to stop the interpretter/type checker being upset.  Because I was touching the function, I also threw on a `-> str` to document the return type.

Tested by verifying that the type checker no longer complains about functions that call get_state_id expecting to get a str back, and some basic "does it still run/pass the unit tests".

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

  * [x] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [x] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [x] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [x] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [x] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [x] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes a missing implementation in the `PrinterInterface` class.  It's necessary, because at the moment the type checker will throw errors for anyone calling this function and expecting to get a `str` back, blocking plugin developers from using the type checker.

#### How was it tested? How can it be tested by the reviewer?
- Run octoprint - still runs, yay!
- Run the tests - tests pass, yay!
- Verify that the type checker no longer fails for callers to get_state_id.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes
