### PR TITLE
Fix Construction of a cookie using user-supplied input

### DIFF
--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -1235,7 +1235,14 @@ class LargeResponseHandler(
             self._path_validation(path)
 
         if "cookie" in self.request.arguments:
-            self.set_cookie(self.request.arguments["cookie"][0], "true", path="/")
+            cookie_name = self.request.arguments["cookie"][0]
+            # Validate and sanitize the cookie name
+            if re.match(r"^[a-zA-Z0-9_-]{1,50}$", cookie_name):  # Allow alphanumeric, dashes, and underscores, max length 50
+                self.set_cookie(cookie_name, "true", path="/")
+            else:
+                logging.getLogger(__name__).warning(
+                    f"Invalid cookie name provided: {cookie_name}"
+                )
 
         if self.should_use_precompressed():
             if os.path.exists(os.path.join(self.root, path + ".gz")):


### PR DESCRIPTION
https://github.com/OctoPrint/OctoPrint/blob/96e48c5662274a1941486d3e0853141661fc0455/src/octoprint/server/util/tornado.py#L1238-L1238

Fix the issue need to ensure that user-supplied input is sanitized or validated before being used to construct a cookie. A safe approach is to define a whitelist of acceptable cookie names and values or to reject invalid input outright. Additionally, we should avoid directly using raw user input and instead use a controlled, sanitized version of the input.

In this case, we will:
1. Validate the `cookie` argument to ensure it meets expected criteria (e.g., alphanumeric characters only, length restrictions).
2. Reject or sanitize invalid input.
3. Use the sanitized input to set the cookie.

The changes will be made in the `get` method where the cookie is set.

---


Constructing cookies from user input can allow an attacker to control a user's cookie. This may lead to a session fixation attack. Additionally, client code may not expect a cookie to contain attacker-controlled data, and fail to sanitize it for common vulnerabilities such as Cross Site Scripting (XSS). An attacker manipulating the raw cookie header may additionally be able to set cookie attributes such as `HttpOnly` to insecure values.

In the following cases, a cookie is constructed for a Flask response using user input. The first uses `set_cookie`, and the second sets a cookie's raw value through the `set-cookie` header.
```py
from flask import request, make_response


@app.route("/1")
def set_cookie():
    resp = make_response()
    resp.set_cookie(request.args["name"], # BAD: User input is used to set the cookie's name and value
                    value=request.args["name"])
    return resp


@app.route("/2")
def set_cookie_header():
    resp = make_response()
    resp.headers['Set-Cookie'] = f"{request.args['name']}={request.args['name']};" # BAD: User input is used to set the raw cookie header.
    return resp
```

[Session Fixation](https://en.wikipedia.org/wiki/Session_fixation)



  * [ ] Your changes are not possible to do through a plugin and relevant
    to a large audience (ideally all users of OctoPrint)
  * [ ] If your changes are large or otherwise disruptive: You have
    made sure your changes don't interfere with current development by
    talking it through with the maintainers, e.g. through a
    Brainstorming ticket
  * [ ] Your PR targets OctoPrint's `devel` branch if it's a completely
    new feature, or `maintenance` if it's a bug fix or improvement of
    existing functionality for the current stable version (no PRs
    against `master` or anything else please)
  * [ ] Your PR was opened from a custom branch on your repository
    (no PRs from your version of `master`, `maintenance`, or `devel`
    please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
  * [ ] Your PR only contains relevant changes: no unrelated files,
    no dead code, ideally only one commit - rebase and squash your PR
    if necessary!
  * [x] Your changes follow the existing coding style
  * [ ] If your changes include style sheets: You have modified the
    `.less` source files, not the `.css` files (those are generated
    with `lessc`)
  * [x] You have tested your changes (please state how!) - ideally you
    have added unit tests
  * [x] You have run the existing unit tests against your changes and
    nothing broke
  * [x] You have added yourself to the `AUTHORS.md` file :)

