### PR TITLE
Fix broken HTML tags

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_tab.jinja2
+++ b/src/octoprint/plugins/gcodeviewer/templates/gcodeviewer_tab.jinja2
@@ -138,7 +138,7 @@
         <button class="btn btn-warning btn-block" data-bind="click: approveLargeFile">
             {{ _('Yes, please visualize %(name)s regardless of its size', name='<span data-bind="text: selectedFile.path"></span>'|safe) }}
         </button>
-    <p>
+    </p>
 
     <div data-bind="ifnot: ((settings.settings.plugins.gcodeviewer.alwaysCompress()) ||
 	((settings.settings.plugins.gcodeviewer.compressionSizeThreshold() > 0) &&
@@ -154,6 +154,6 @@
             <label class="checkbox">
                 <input type="checkbox" data-bind="checked: reader_forceCompression">{{ _('Force compression') }}
             </label>
-        <p>
+        </p>
     </div>
 </div>

--- a/src/octoprint/plugins/health_check/templates/health_check.jinja2
+++ b/src/octoprint/plugins/health_check/templates/health_check.jinja2
@@ -8,7 +8,7 @@
 
             <div data-bind="visible: checkResults().length">
                 <!-- ko if: issueResults().length -->
-                <h3>{{ _('Issues') }} (<span data-bind="text: issueResults().length"></span>)</h2>
+                <h3>{{ _('Issues') }} (<span data-bind="text: issueResults().length"></span>)</h3>
                 <p>{% trans %}
                     The following issues were found with your OctoPrint installation. You should solve them as soon as possible.
                 {% endtrans %}</p>
@@ -21,7 +21,7 @@
                 <!-- /ko -->
 
                 <!-- ko if: warningResults().length -->
-                <h3>{{ _('Warnings') }} (<span data-bind="text: warningResults().length"></span>)</h2>
+                <h3>{{ _('Warnings') }} (<span data-bind="text: warningResults().length"></span>)</h3>
                 <p>{% trans %}
                     The following warnings were found with your OctoPrint installation. You should look into them sooner rather than later.
                 {% endtrans %}</p>

--- a/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
+++ b/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
@@ -88,10 +88,10 @@
                     <thead>
                         <tr>
                             <th class="icon">&nbsp;</th>
-                            <th class="title"><span data-bind="click: function() {toggleSort('name')}">{{ _('Name') }}</a>&nbsp;<i data-bind="class: columnIcon('name')"></i></th>
-                            <th class="uploaded"><span data-bind="click: function() {toggleSort('upload')}">{{ _('Uploaded') }}</a>&nbsp;<i data-bind="class: columnIcon('upload')"></i></th>
-                            <th class="printed"><span data-bind="click: function() {toggleSort('lastPrint')}">{{ _('Last Printed') }}</a>&nbsp;<i data-bind="class: columnIcon('lastPrint')"></i></th>
-                            <th class="size"><span data-bind="click: function() {toggleSort('size')}">{{ _('Size') }}</a>&nbsp;<i data-bind="class: columnIcon('size')"></i></th>
+                            <th class="title"><span data-bind="click: function() {toggleSort('name')}">{{ _('Name') }}</span>&nbsp;<i data-bind="class: columnIcon('name')"></i></th>
+                            <th class="uploaded"><span data-bind="click: function() {toggleSort('upload')}">{{ _('Uploaded') }}</span>&nbsp;<i data-bind="class: columnIcon('upload')"></i></th>
+                            <th class="printed"><span data-bind="click: function() {toggleSort('lastPrint')}">{{ _('Last Printed') }}</span>&nbsp;<i data-bind="class: columnIcon('lastPrint')"></i></th>
+                            <th class="size"><span data-bind="click: function() {toggleSort('size')}">{{ _('Size') }}</span>&nbsp;<i data-bind="class: columnIcon('size')"></i></th>
                         </tr>
                     </thead>
                     <tbody>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [X] You have read through `CONTRIBUTING.md`
- [X] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [X] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [X] Your PR targets OctoPrint's `maintenance` branch
- [X] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `master`, `maintenance`, or `devel`
  please), e.g. `dev/my_new_feature` or `fix/my_bugfix`
- [X] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [X] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [X] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [X] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [X] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
I found some broken HTML tags in the Jinja templates: some were mistakenly left unclosed, while others had mismatched closing tags. This PR aims to fix them. The impact of these bugs was negligible anyway, as modern browsers typically auto-correct invalid HTML by themselves.

#### How was it tested? How can it be tested by the reviewer?
I verified that the visual rendering of the templates in Chrome hasn't changed. For the tag mismatches, I assumed the opening tag was correct and the closing tag was wrong, since that's how Chrome renders such cases.

#### Any background context you want to provide?
These bugs were found while testing the [djLint](https://github.com/djlint/djLint) pre-commit hook. They were reported by the rule `H025 Tag seems to be an orphan`.

I suggest considering the integration of this pre-commit hook into OctoPrint, as currently the Jinja templates are not checked by any linter or formatter.

The setup should be relatively straightforward, although some rules are triggered multiple times on the current codebase and might be worth evaluating for exclusion. Mainly:

- `H019 Replace 'javascript:abc()' with an on_ event and a real URL.`
- `H021 Inline styles should be avoided.`
- `H023 Do not use entity references.`

#### What are the relevant tickets if any?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
