### PR TITLE
feat: add support for plugin apikeys

### DIFF
--- a/src/octoprint/access/users.py
+++ b/src/octoprint/access/users.py
@@ -76,8 +76,13 @@ class UserManager(GroupChangeListener):
     def anonymous_user_factory(self):
         return AnonymousUser([self._group_manager.guest_group])
 
-    def api_user_factory(self):
+    def api_user_factory(self):  # TODO Remove in 1.13.0
         return ApiUser([self._group_manager.admin_group, self._group_manager.user_group])
+
+    def internal_user_factory(self):
+        return InternalUser(
+            [self._group_manager.admin_group, self._group_manager.user_group]
+        )
 
     @property
     def enabled(self):
@@ -840,7 +845,7 @@ class FilebasedUserManager(UserManager):
             self._settings.save()
 
     def signature_key_for_user(self, username, secret):
-        if username == "_api":
+        if username == "_internal" or username == "_api":  # TODO Remove _api in 1.13.0
             return super().signature_key_for_user(username, secret)
         if username not in self._users:
             raise UnknownUser(username)
@@ -1510,6 +1515,11 @@ class SessionUser(wrapt.ObjectProxy):
 ##~~ User object to use when global api key is used to access the API
 
 
-class ApiUser(User):
+class ApiUser(User):  # TODO Remove in 1.13.0
     def __init__(self, groups):
         User.__init__(self, "_api", "", True, [], groups)
+
+
+class InternalUser(User):
+    def __init__(self, groups):
+        super().__init__("_internal", "", True, [], groups)

--- a/src/octoprint/plugin/__init__.py
+++ b/src/octoprint/plugin/__init__.py
@@ -419,13 +419,15 @@ class PluginSettings:
 
         if get_preprocessors is None:
             get_preprocessors = {}
-        self.get_preprocessors = {"plugins": {}}
-        self.get_preprocessors["plugins"][plugin_key] = get_preprocessors
+        self.get_preprocessors = {
+            "plugins": {plugin_key: get_preprocessors},
+        }
 
         if set_preprocessors is None:
             set_preprocessors = {}
-        self.set_preprocessors = {"plugins": {}}
-        self.set_preprocessors["plugins"][plugin_key] = set_preprocessors
+        self.set_preprocessors = {
+            "plugins": {plugin_key: set_preprocessors},
+        }
 
         def prefix_path_in_args(args, index=0):
             result = []
@@ -501,6 +503,10 @@ class PluginSettings:
 
         Directly forwards to :func:`octoprint.settings.Settings.get`.
         """
+        if path == ["api", "key"]:
+            self._logger.warning(
+                f'DeprecationWarning: Detected access to deprecated settings path ["api", "key"] by plugin {self.plugin_key}. The global api key is deprecated, will be removed in 1.13.0 and should no longer be used. Plugins should instead use OctoPrintPlugin.plugin_apikey.'
+            )
         return self.settings.get(path, **kwargs)
 
     def global_get_int(self, path, **kwargs):
@@ -528,6 +534,10 @@ class PluginSettings:
 
         Directly forwards to :func:`octoprint.settings.Settings.set`.
         """
+        if path == ["api", "key"]:
+            self._logger.warning(
+                f'DeprecationWarning: Detected access to deprecated settings path ["api", "key"] by plugin {self.plugin_key}. The global api key is deprecated, will be removed in 1.13.0 and should no longer be used. Plugins should instead use OctoPrintPlugin.plugin_apikey.'
+            )
         self.settings.set(path, value, **kwargs)
 
     def global_set_int(self, path, value, **kwargs):

--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -132,6 +132,17 @@ class OctoPrintPlugin(Plugin):
         """
         pass
 
+    @property
+    def plugin_apikey(self):
+        """
+        Returns a single-use API key that may be used by the plugin
+        to perform authenticated requests against the server's HTTP endpoints,
+        e.g. to call the endpoints of other third party plugins without
+        registered helpers.
+        """
+
+        return self._plugin_manager.generate_plugin_apikey(self._identifier, uses=1)
+
 
 class ReloadNeedingPlugin(Plugin):
     """

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -239,7 +239,7 @@ def load_user_from_request(request):
     # API key?
     apikey = util.get_api_key(request)
     if apikey:
-        user = util.get_user_for_apikey(apikey)
+        user = util.get_user_for_apikey(apikey, remote_address=request.remote_addr)
         if user:
             return user
 

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -200,8 +200,11 @@ def load_user(id):
     if id is None:
         return None
 
-    if id == "_api":
+    if id == "_api":  # TODO Remove in 1.13.0
         return userManager.api_user_factory()
+
+    if id == "_internal":
+        return userManager.internal_user_factory()
 
     if session and "usersession.id" in session:
         sessionid = session["usersession.id"]

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -190,7 +190,7 @@ def get_user_for_apikey(apikey: str) -> "Optional[octoprint.access.users.User]":
 
     user = None
 
-    if apikey == settings().get(["api", "key"]):
+    if apikey == settings().get(["api", "key"]):  # TODO Remove in 1.13.0
         # global api key was used
         logging.getLogger(__name__).warning(
             "The global API key was just used. The global API key is deprecated and will cease to function with OctoPrint 1.13.0."
@@ -216,6 +216,11 @@ def get_user_for_apikey(apikey: str) -> "Optional[octoprint.access.users.User]":
                         ),
                         extra={"plugin": name},
                     )
+
+            else:
+                plugin = plugin_manager().resolve_plugin_apikey(apikey)
+                if plugin:
+                    user = octoprint.server.userManager.internal_user_factory()
 
     if user:
         _flask.session["login_mechanism"] = LoginMechanism.APIKEY

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1569,7 +1569,9 @@ def get_flask_user_from_request(request):
     apikey = octoprint.server.util.get_api_key(request)
     if apikey is not None:
         # user from api key?
-        user = octoprint.server.util.get_user_for_apikey(apikey)
+        user = octoprint.server.util.get_user_for_apikey(
+            apikey, remote_address=request.remote_addr
+        )
 
     if user is None:
         # user still None -> current session user

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -281,7 +281,10 @@ $(function () {
         self.userString = ko.pureComputed(function () {
             var user = self.user();
             if (user === "_api") {
+                // TODO Remove in 1.13.0
                 user = "API client";
+            } else if (user === "_internal") {
+                user = "Internal client";
             }
 
             var file = self.filename();

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -183,6 +183,21 @@ def is_lan_address(address, additional_private=None):
         return True
 
 
+def is_loopback_address(address):
+    if not address:
+        return False
+
+    try:
+        address = sanitize_address(address)
+        ip = netaddr.IPAddress(address)
+        return ip.is_loopback()
+    except Exception:
+        logging.get_logger(__name__).exception(
+            f"Error while trying to determine whether {address} is a loopback address"
+        )
+        return False
+
+
 def sanitize_address(address):
     address = unmap_v4_as_v6(address)
     address = strip_interface_tag(address)

--- a/tests/util/test_net.py
+++ b/tests/util/test_net.py
@@ -55,6 +55,28 @@ def test_is_lan_address(input_address, input_additional, expected):
 
 
 @pytest.mark.parametrize(
+    "input_address,expected",
+    [
+        (None, False),
+        ("", False),
+        ("127.0.0.1", True),
+        ("127.100.200.1", True),
+        ("::1", True),
+        ("192.168.123.234", False),
+        ("172.24.0.1", False),
+        ("10.1.2.3", False),
+        ("fc00::1", False),
+        ("::ffff:192.168.1.1", False),
+        ("::ffff:8.8.8.8", False),
+        ("11.1.2.3", False),
+    ],
+)
+def test_is_loopback_address(input_address, expected):
+    with mock.patch.object(octoprint.util.net, "HAS_V6", True):
+        assert octoprint.util.net.is_loopback_address(input_address) == expected
+
+
+@pytest.mark.parametrize(
     "address,expected",
     [
         ("fe80::89f3:31bb:ced0:2093%wlan0", "fe80::89f3:31bb:ced0:2093"),


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Plugins may request a single-use api key with full access to make requests to the http endpoints other plugins on the same instance via `OctoPrintPlugin.plugin_apikey`.

This is keep a workflow available for plugins that need to work around missing helpers from other plugins they want to interact with, using the HTTP API as a workaround.

#### How was it tested? How can it be tested by the reviewer?

Single file plugin for retrieving a single use key, then querying the api with that and verifying that the key only works once:

```python
import octoprint.plugin
from flask import jsonify


class InternalKeyTest(
    octoprint.plugin.SimpleApiPlugin, octoprint.plugin.SettingsPlugin
):
    # ~~ SimpleApiPlugin mixin

    def on_api_get(self, request):
        self._settings.global_get(["api", "key"])  # should log a deprecation warning
        return jsonify({"key": self.plugin_apikey})

    def is_api_protected(self):
        return False


__plugin_name__ = "Internal Key Test"
__plugin_version__ = "0.1.0"
__plugin_description__ = "A SimpleApiPlugin for testing single use Plugin API keys"
__plugin_pythoncompat__ = ">=3,<4"
__plugin_implementation__ = InternalKeyTest()
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#5191

#### Screenshots (if appropriate)

#### Further notes

