### PR TITLE
Fix get_slicer_properties docstring

### DIFF
--- a/src/octoprint/plugin/types.py
+++ b/src/octoprint/plugin/types.py
@@ -2452,8 +2452,8 @@ class SlicerPlugin(OctoPrintPlugin):
             paths within the extension tree. Plugins may add additional file types through the :ref:`sec-plugins-hook-filemanager-extensiontree` hook.
             The system will test source files contains in incoming slicing requests via :meth:`octoprint.filemanager.valid_file_type` against the
             targeted slicer's ``source_file_types``.
-        destination_extension
-            The possible extensions of slicing result files.
+        destination_extensions
+            A list of possible extensions of slicing result files.
 
         Returns:
             dict: A dict describing the slicer as outlined above.


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [X] You have read through `CONTRIBUTING.md`
- [X] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [X] Your PR targets OctoPrint's `dev` branch
- [ ] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [X] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [X] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [X] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [X] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [X] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Fixes the `get_slicer_properties` docstring: the return value key was incorrectly documented as `destination_extension`.  
The correct key is `destination_extensions`, which contains a list of extensions instead of a single one.

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?
No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
