### PR TITLE
add conditional to _set_job_data for NoneType job.date, #5208

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1824,10 +1824,6 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             if job.filament_estimate:
                 filament = {k: v.model_dump() for k, v in job.filament_estimate.items()}
 
-            job_date = 0
-            if job.date:
-                job_date = job.date.astimezone(None).timestamp()
-
             self._stateMonitor.set_job_data(
                 self._dict(
                     file=self._dict(
@@ -1836,7 +1832,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                         display=display_name,
                         origin=job.storage,
                         size=job.size,
-                        date=int(job_date),
+                        date=int(job.date.astimezone(None).timestamp()) if job.date else None,
                     ),
                     estimatedPrintTime=estimatedPrintTime,
                     filament=filament,


### PR DESCRIPTION
- [X] You have read through `CONTRIBUTING.md`
- [X] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [X] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [X] Your PR targets OctoPrint's `dev` branch
- [X] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [X] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [X] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [X] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [ ] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [X] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

Fixes error with astimezone against a NoneType in PrintJob.date

#### How was it tested? How can it be tested by the reviewer?

Ran locally in dev environment with BambuConnector plugin that couldn't identify selected file properly that was printing. 

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#5208 

#### Screenshots (if appropriate)

#### Further notes
