### PR TITLE
Replace user-facing Blacklist/Whitelist with Blocklist/Allowlist

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -191,6 +191,7 @@ date of first contribution):
   * [Tom Davie](https://github.com/beelsebob)
   * [Emmanuel Ferdman](https://github.com/emmanuel-ferdman)
   * [Will Schlitzer](https://github.com/willschlitzer)
+  * [John Brady](https://github.com/bradyjoh)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -818,7 +818,7 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
     logger = log.getLogger(__name__ + ".startup")
 
     if connectivity_checker is not None and not connectivity_checker.online:
-        logger.info("We don't appear to be online, not fetching plugin blacklist")
+        logger.info("We don't appear to be online, not fetching plugin blocklist")
         return []
 
     def format_blacklist(entries):
@@ -851,7 +851,7 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
 
             if "pluginversions" in entry:
                 logger.debug(
-                    "Blacklisted plugin: %s, versions: %s",
+                    "Blocklisted plugin: %s, versions: %s",
                     entry["plugin"],
                     ", ".join(entry["pluginversions"]),
                 )
@@ -859,14 +859,14 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
                     result.append((entry["plugin"], version))
             elif "versions" in entry:
                 logger.debug(
-                    "Blacklisted plugin: %s, versions: %s",
+                    "Blocklisted plugin: %s, versions: %s",
                     entry["plugin"],
                     ", ".join(entry["versions"]),
                 )
                 for version in entry["versions"]:
                     result.append((entry["plugin"], f"=={version}"))
             else:
-                logger.debug("Blacklisted plugin: %s", entry["plugin"])
+                logger.debug("Blocklisted plugin: %s", entry["plugin"])
                 result.append(entry["plugin"])
 
         return result
@@ -898,12 +898,12 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
                     yaml.save_to_file(result, path=cache)
                 except Exception as e:
                     logger.info(
-                        "Fetched plugin blacklist but couldn't write it to its cache file: %s",
+                        "Fetched plugin blocklist but couldn't write it to its cache file: %s",
                         e,
                     )
         except Exception as e:
             logger.info(
-                "Unable to fetch plugin blacklist from %s, proceeding without it: %s",
+                "Unable to fetch plugin blocklist from %s, proceeding without it: %s",
                 url,
                 e,
             )
@@ -927,17 +927,17 @@ def get_plugin_blacklist(settings, connectivity_checker=None):
 
         if blacklist:
             logger.info(
-                "Blacklist processing done, adding %s blacklisted plugin versions: %s",
+                "Blocklist processing done, adding %s blocklisted plugin versions: %s",
                 len(blacklist),
                 format_blacklist(blacklist),
             )
         else:
-            logger.info("Blacklist processing done")
+            logger.info("Blocklist processing done")
 
         return blacklist
     except Exception:
         logger.exception(
-            "Something went wrong while processing the plugin blacklist. Proceeding without it."
+            "Something went wrong while processing the plugin blocklist. Proceeding without it."
         )
 
 

--- a/src/octoprint/cli/server.py
+++ b/src/octoprint/cli/server.py
@@ -219,7 +219,7 @@ server_options = bulk_options(
             "ignore_blacklist",
             is_flag=True,
             callback=set_ctx_obj_option,
-            help="Disable processing of the plugin blacklist.",
+            help="Disable processing of the plugin blocklist.",
         ),
     ]
 )

--- a/src/octoprint/plugin/core.py
+++ b/src/octoprint/plugin/core.py
@@ -885,7 +885,7 @@ class PluginManager:
                     processed_blacklist.append((key, SpecifierSet(version)))
                 except Exception:
                     self.logger.warning(
-                        "Invalid version requirement {} for blacklist "
+                        "Invalid version requirement {} for blocklist "
                         "entry {}, ignoring".format(version, key)
                     )
             else:
@@ -1263,7 +1263,7 @@ class PluginManager:
             plugin.version is not None
             and self._is_plugin_version_blacklisted(key, plugin.version)
         ):
-            self.logger.warning(f"Plugin {plugin} is blacklisted.")
+            self.logger.warning(f"Plugin {plugin} is blocklisted.")
             plugin.blacklisted = True
 
         python_version = get_python_version_string()
@@ -1454,7 +1454,7 @@ class PluginManager:
                 ):
                     if plugin.blacklisted:
                         self.logger.warning(
-                            f"Plugin {plugin} is blacklisted. Not enabling it."
+                            f"Plugin {plugin} is blocklisted. Not enabling it."
                         )
                         continue
                     self.enable_plugin(
@@ -2073,7 +2073,7 @@ class PluginManager:
                 )
                 formatted_plugins += "\n"
 
-            legend = "Prefix legend: {1} = disabled, {2} = blacklisted, {3} = incompatible".format(
+            legend = "Prefix legend: {1} = disabled, {2} = blocklisted, {3} = incompatible".format(
                 *enabled_str
             )
 

--- a/src/octoprint/plugins/corewizard/static/js/corewizard.js
+++ b/src/octoprint/plugins/corewizard/static/js/corewizard.js
@@ -259,9 +259,9 @@ $(function () {
 
         self._showDecisionNeededDialog = function () {
             showMessageDialog({
-                title: gettext("Please set up the plugin blacklist processing"),
+                title: gettext("Please set up the plugin blocklist processing"),
                 message: gettext(
-                    "You haven't yet decided on whether to enable or disable the plugin blacklist processing. You need to either enable or disable it before continuing."
+                    "You haven't yet decided on whether to enable or disable the plugin blocklist processing. You need to either enable or disable it before continuing."
                 )
             });
         };

--- a/src/octoprint/plugins/corewizard/subwizards.py
+++ b/src/octoprint/plugins/corewizard/subwizards.py
@@ -119,7 +119,7 @@ class PluginBlacklistSubwizard:
         return {"required": self._is_pluginblacklist_wizard_required()}
 
     def _get_pluginblacklist_wizard_name(self):
-        return gettext("Plugin Blacklist")
+        return gettext("Plugin Blocklist")
 
     def _get_pluginblacklist_additional_wizard_template_data(self):
         return {"mandatory": self._is_pluginblacklist_wizard_required()}

--- a/src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2
+++ b/src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2
@@ -1,23 +1,23 @@
-<h3>{{ _("Configure plugin blacklist processing") }}</h3>
+<h3>{{ _("Configure plugin blocklist processing") }}</h3>
 
 <p>
     {% trans %}
     To protect against known severe issues with certain versions of third party plugins, OctoPrint supports the use
-    of a centralized plugin version blacklist to automatically disable such plugin versions before they can interfere with
+    of a centralized plugin version blocklist to automatically disable such plugin versions before they can interfere with
     normal operation, allowing you to uninstall or update them to a newer version.
 {% endtrans %}
 </p>
 
 <p>
     {% trans url="https://plugins.octoprint.org/blacklist/" %}
-    By default, OctoPrint will use the blacklist hosted at <code>plugins.octoprint.org/blacklist.json</code> which you
+    By default, OctoPrint will use the blocklist hosted at <code>plugins.octoprint.org/blacklist.json</code> which you
     can also take a look at in a more human readable format <a href="{{ url }}" target="_blank">here</a>.
 {% endtrans %}
 </p>
 
 <p>
     {% trans %}
-    Please decide whether to allow fetch and use of this centralized blacklist starting with the next server start.
+    Please decide whether to allow fetch and use of this centralized blocklist starting with the next server start.
     You may also change your decision at any time through Settings > Server right from within OctoPrint.
 {% endtrans %}
 </p>
@@ -26,12 +26,12 @@
     <a href="#"
        class="btn btn-danger span6"
        data-bind="click: function() { if(!setup() || decision()){disablePluginBlacklist()}}, enable: !setup() || decision(), css: {disabled: setup() && !decision()}">
-        {{ _("Disable Plugin Blacklist Processing") }}
+        {{ _("Disable Plugin Blocklist Processing") }}
     </a>
     <a href="#"
        class="btn btn-primary span6"
        data-bind="click: function() { if(!setup() || !decision()){enablePluginBlacklist()}}, enable: !setup() || !decision(), css: {disabled: setup() && decision()}">
-        {{ _("Enable Plugin Blacklist Processing") }}
+        {{ _("Enable Plugin Blocklist Processing") }}
     </a>
 </div>
 
@@ -42,14 +42,14 @@
          style="display: none"
          data-bind="visible: decision()">
         {% trans %}
-        Plugin blacklist processing is <strong class="text-success">enabled</strong>.
+        Plugin blocklist processing is <strong class="text-success">enabled</strong>.
     {% endtrans %}
 </div>
 <div class="text-center"
      style="display: none"
      data-bind="visible: !decision()">
     {% trans %}
-    Plugin blacklist processing is <strong class="text-danger">disabled</strong>.
+    Plugin blocklist processing is <strong class="text-danger">disabled</strong>.
 {% endtrans %}
 </div>
 </div>

--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -2047,7 +2047,7 @@ $(function () {
             var command = self._getToggleCommand(data);
             if (command === "enable") {
                 if (data.blacklisted) {
-                    return gettext("Blacklisted");
+                    return gettext("Blocklisted");
                 } else if (data.safe_mode_victim) {
                     return gettext("Disabled due to active safe mode");
                 } else {

--- a/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
+++ b/src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2
@@ -237,7 +237,7 @@
     data-bind="visible: safe_mode_victim"></i> <i class="fas fa-exclamation-triangle"
     title="{{ _('There are notices available regarding this plugin') |edq }}"
     data-bind="visible: notifications && notifications.length"></i> <i class="fas fa-ban"
-    title="{{ _('This plugin is blacklisted') |edq }}"
+    title="{{ _('This plugin is blocklisted') |edq }}"
     data-bind="visible: blacklisted"></i>
                             </div>
                             <div data-bind="css: {muted: !enabled}">
@@ -385,12 +385,12 @@
                 All plugins in OctoPrint's repository are open source, so you and anyone else from the community can look at their published source code and see what they do for yourself.
             </li>
             <li>
-                <strong>Plugin blacklist:</strong>
-                We maintain a blacklist of plugins/plugin versions that are known to cause issues. Unless you have disabled the blacklist, OctoPrint will refuse to load and run any plugins installed in your system matching an entry on it.
+                <strong>Plugin blocklist:</strong>
+                We maintain a blocklist of plugins/plugin versions that are known to cause issues. Unless you have disabled the blocklist, OctoPrint will refuse to load and run any plugins installed in your system matching an entry on it.
             </li>
             <li>
                 <strong>Report mechanism:</strong>
-                If you encounter suspicious activity of a plugin, you can report it to us. We will then investigate and potentially remove it from the repository and/or add it to the blacklist.
+                If you encounter suspicious activity of a plugin, you can report it to us. We will then investigate and potentially remove it from the repository and/or add it to the blocklist.
             </li>
             <li>
                 <strong>Safe mode & recovery page:</strong>

--- a/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
+++ b/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
@@ -47,26 +47,26 @@
                     </div>
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="settings-serialBlacklistedPorts">{{ _("Blacklisted serial ports") }}</label>
+                    <label class="control-label" for="settings-serialBlacklistedPorts">{{ _("Blocklisted serial ports") }}</label>
                     <div class="controls">
                         <textarea rows="4"
                                   class="block"
                                   id="settings-serialBlacklistedPorts"
                                   data-bind="value: mapped.blacklistedPorts"></textarea>
                         <span class="help-inline">{% trans glob_url="http://docs.python.org/3/library/glob.html" %}
-                            Use this to define <a href="{{ glob_url }}" target="_blank" rel="noopener noreferer">glob patterns</a> matching serial ports to blacklist for
+                            Use this to define <a href="{{ glob_url }}" target="_blank" rel="noopener noreferer">glob patterns</a> matching serial ports to blocklist for
                             connecting against, e.g. <code>/dev/ttyS*</code>. One entry per line.
                         {% endtrans %}</span>
                     </div>
                 </div>
                 <div class="control-group">
-                    <label class="control-label" for="settings-serialBlacklistedBaudrates">{{ _("Blacklisted baud rates") }}</label>
+                    <label class="control-label" for="settings-serialBlacklistedBaudrates">{{ _("Blocklisted baud rates") }}</label>
                     <div class="controls">
                         <input type="text"
                                class="input-block-level"
                                id="settings-serialBlacklistedBaudrates"
                                data-bind="value: mapped.blacklistedBaudrates">
-                        <span class="help-inline">{{ _("Use this to define serial port baud rates to blacklist for connecting with, e.g. <code>123456</code>. Comma separated.") }}</span>
+                        <span class="help-inline">{{ _("Use this to define serial port baud rates to blocklist for connecting with, e.g. <code>123456</code>. Comma separated.") }}</span>
                     </div>
                 </div>
                 <div class="control-group">

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -367,7 +367,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                 )
             except Exception:
                 self._logger.exception(
-                    "Error while retrieving additional data from plugin {}, blacklisting it for further loops".format(
+                    "Error while retrieving additional data from plugin {}, blocklisting it for further loops".format(
                         name
                     ),
                     extra={"plugin": name},

--- a/src/octoprint/schema/config/server.py
+++ b/src/octoprint/schema/config/server.py
@@ -144,16 +144,16 @@ class OnlineCheckConfig(BaseModel):
 @with_attrs_docs
 class PluginBlacklistConfig(BaseModel):
     enabled: Optional[bool] = None
-    """Whether use of the blacklist is enabled. If unset, the user will be asked to make a decision as part of the setup wizard."""
+    """Whether use of the blocklist is enabled. If unset, the user will be asked to make a decision as part of the setup wizard."""
 
     url: str = "https://plugins.octoprint.org/blacklist.json"
-    """The URL from which to fetch the blacklist."""
+    """The URL from which to fetch the blocklist."""
 
     ttl: int = CONST_15MIN
-    """Time to live of the cached blacklist, in seconds (default: 15 minutes)."""
+    """Time to live of the cached blocklist, in seconds (default: 15 minutes)."""
 
     timeout: float = 3.05
-    """Timeout for fetching the blacklist, in seconds (default: 3.05 seconds)."""
+    """Timeout for fetching the blocklist, in seconds (default: 3.05 seconds)."""
 
 
 @with_attrs_docs
@@ -288,7 +288,7 @@ class ServerConfig(BaseModel):
     """Configuration of the regular online connectivity check."""
 
     pluginBlacklist: PluginBlacklistConfig = PluginBlacklistConfig()
-    """Configuration of the plugin blacklist."""
+    """Configuration of the plugin blocklist."""
 
     pythonEolCheck: PythonEolCheckConfig = PythonEolCheckConfig()
     """Configuration of the Python EOL warning."""

--- a/src/octoprint/templates/dialogs/settings/features.jinja2
+++ b/src/octoprint/templates/dialogs/settings/features.jinja2
@@ -114,7 +114,7 @@
     <div class="control-group"
          title="{{ _('Commands to not completely auto uppercase in the terminal tab') |edq }}">
         <label class="control-label" for="settings-featureAutoUppercaseBlacklist">
-            {{ _("Terminal Auto Uppercase Blacklist") }}
+            {{ _("Terminal Auto Uppercase Blocklist") }}
         </label>
         <div class="controls">
             <input type="text"

--- a/src/octoprint/templates/dialogs/settings/server.jinja2
+++ b/src/octoprint/templates/dialogs/settings/server.jinja2
@@ -19,7 +19,7 @@
 {% include "snippets/settings/server/serverOnlineCheckDescription.jinja2" %}
 {% include "snippets/settings/server/serverOnlineCheck.jinja2" %}
 
-<h3>{{ _("Plugin blacklist processing") }}</h3>
+<h3>{{ _("Plugin blocklist processing") }}</h3>
 
 {% include "snippets/settings/server/serverPluginBlacklistDescription.jinja2" %}
 {% include "snippets/settings/server/serverPluginBlacklist.jinja2" %}

--- a/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistDescription.jinja2
+++ b/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistDescription.jinja2
@@ -1,14 +1,14 @@
 <p>
     {% trans %}
     <strong>To protect against known severe issues with certain versions of third party plugins</strong>, OctoPrint supports
-    the use of a centralized plugin version blacklist to automatically disable such plugins before they can interfere
+    the use of a centralized plugin version blocklist to automatically disable such plugins before they can interfere
     with normal operation.
 {% endtrans %}
 </p>
 
 <p>
     {% trans url="https://plugins.octoprint.org/blacklist/" %}
-    By default, OctoPrint will use the blacklist hosted at <code>plugins.octoprint.org/blacklist.json</code> which you
+    By default, OctoPrint will use the blocklist hosted at <code>plugins.octoprint.org/blacklist.json</code> which you
     can also take a look at in a more human readable format <a href="{{ url }}" target="_blank">here</a>.
 {% endtrans %}
 </p>

--- a/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2
+++ b/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2
@@ -4,7 +4,7 @@
             <input type="checkbox"
                    data-bind="checked: server_pluginBlacklist_enabled"
                    id="settings-serverPluginBlacklistEnabled">
-            {{ _("Enable plugin blacklist processing on startup") }}
+            {{ _("Enable plugin blocklist processing on startup") }}
             <span class="help-block">{{ _("Any changes take effect only on the next server start.") }}</span>
         </label>
     </div>

--- a/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2
+++ b/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2
@@ -1,6 +1,6 @@
 <div class="control-group"
-     title="{{ _('How long to cache the blacklist, in minutes. You should normally not have to change this.') |edq }}">
-    <label class="control-label" for="settings-serverPluginBlacklistTtl">{{ _("Blacklist cache TTL") }}</label>
+     title="{{ _('How long to cache the blocklist, in minutes. You should normally not have to change this.') |edq }}">
+    <label class="control-label" for="settings-serverPluginBlacklistTtl">{{ _("Blocklist cache TTL") }}</label>
     <div class="controls">
         <div class="input-append">
             <input type="number"

--- a/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2
+++ b/src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2
@@ -1,6 +1,6 @@
 <div class="control-group"
-     title="{{ _('Plugin blacklist URL. You should normally not have to change this.') |edq }}">
-    <label class="control-label" for="settings-serverPluginBlacklistUrl">{{ _("Blacklist URL") }}</label>
+     title="{{ _('Plugin blocklist URL. You should normally not have to change this.') |edq }}">
+    <label class="control-label" for="settings-serverPluginBlacklistUrl">{{ _("Blocklist URL") }}</label>
     <div class="controls">
         <input type="text"
                class="input-block-level"

--- a/src/octoprint/translations/de/LC_MESSAGES/messages.po
+++ b/src/octoprint/translations/de/LC_MESSAGES/messages.po
@@ -1757,8 +1757,8 @@ msgid "Online Connectivity Check"
 msgstr "Onlineprüfung"
 
 #: src/octoprint/plugins/corewizard/subwizards.py:122
-msgid "Plugin Blacklist"
-msgstr "Plugin Blackliste"
+msgid "Plugin Blocklist"
+msgstr "Plugin Blockliste"
 
 #: src/octoprint/plugins/corewizard/subwizards.py:143
 msgid "Default Printer Profile"
@@ -1792,16 +1792,16 @@ msgstr ""
 "fortfahren kannst."
 
 #: src/octoprint/plugins/corewizard/static/js/corewizard.js:262
-msgid "Please set up the plugin blacklist processing"
-msgstr "Bitte konfiguriere die Plugin Blackliste"
+msgid "Please set up the plugin blocklist processing"
+msgstr "Bitte konfiguriere die Plugin Blockliste"
 
 #: src/octoprint/plugins/corewizard/static/js/corewizard.js:263
 msgid ""
 "You haven't yet decided on whether to enable or disable the plugin "
-"blacklist processing. You need to either enable or disable it before "
+"blocklist processing. You need to either enable or disable it before "
 "continuing."
 msgstr ""
-"Du hast noch nicht entschieden, ob die Plugin Blackliste aktiviert werden"
+"Du hast noch nicht entschieden, ob die Plugin Blockliste aktiviert werden"
 " soll. Du musst sie entweder aktivieren oder deaktivieren bevor du "
 "fortfahren kannst."
 
@@ -1976,15 +1976,15 @@ msgstr ""
 "    "
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:1
-msgid "Configure plugin blacklist processing"
-msgstr "Pluginblackliste konfigurieren"
+msgid "Configure plugin blocklist processing"
+msgstr "Pluginblockliste konfigurieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:3
 msgid ""
 "\n"
 "    To protect against known severe issues with certain versions of third"
 " party plugins, OctoPrint supports the use\n"
-"    of a centralized plugin version blacklist to automatically disable "
+"    of a centralized plugin version blocklist to automatically disable "
 "such plugin versions before they can interfere with\n"
 "    normal operation, allowing you to uninstall or update them to a newer"
 " version.\n"
@@ -1992,7 +1992,7 @@ msgstr ""
 "\n"
 "    Um vor bekannten schweren Fehler mit bestimmten Third-Party-Plugins "
 "zu schützen, unterstützt OctoPrint \n"
-"    die Verwendung einer zentralen Pluginblackliste um automatisiert "
+"    die Verwendung einer zentralen Pluginblockliste um automatisiert "
 "solche Pluginversionen zu deaktivieren \n"
 "    bevor sie mit dem normalen Betrieb von OctoPrint interferieren "
 "können. Du kannst solche Plugins dann \n"
@@ -2003,13 +2003,13 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"    By default, OctoPrint will use the blacklist hosted at "
+"    By default, OctoPrint will use the blocklist hosted at "
 "<code>plugins.octoprint.org/blacklist.json</code> which you\n"
 "    can also take a look at in a more human readable format <a "
 "href=\"%(url)s\" target=\"_blank\">here</a>.\n"
 msgstr ""
 "\n"
-"    Standardmäßig wird OctoPrint die Blackliste von "
+"    Standardmäßig wird OctoPrint die Blockliste von "
 "<code>plugins.octoprint.org/blacklist.json</code> verwenden, \n"
 "    auf die du <a href=\"%(url)s\" target=\"_blank\">hier</a> auch einen "
 "Blick in menschenlesbarer Form werfen kannst.\n"
@@ -2018,45 +2018,45 @@ msgstr ""
 msgid ""
 "\n"
 "    Please decide whether to allow fetch and use of this centralized "
-"blacklist starting with the next server start.\n"
+"blocklist starting with the next server start.\n"
 "    You may also change your decision at any time through Settings > "
 "Server right from within OctoPrint.\n"
 msgstr ""
 "\n"
-"    Bitte entscheide, ob die zentrale Pluginblackliste ab dem nächsten "
+"    Bitte entscheide, ob die zentrale Pluginblockliste ab dem nächsten "
 "Serverstart genutzt werden soll. \n"
 "    Du kannst diese Entscheidung auch jederzeit unter Einstellungen > "
 "Server später noch ändern.\n"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:21
-msgid "Disable Plugin Blacklist Processing"
-msgstr "Pluginblackliste deaktivieren"
+msgid "Disable Plugin Blocklist Processing"
+msgstr "Pluginblockliste deaktivieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:24
-msgid "Enable Plugin Blacklist Processing"
-msgstr "Pluginblackliste aktivieren"
+msgid "Enable Plugin Blocklist Processing"
+msgstr "Pluginblockliste aktivieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:29
 msgid ""
 "\n"
-"        Plugin blacklist processing is <strong class=\"text-"
+"        Plugin blocklist processing is <strong class=\"text-"
 "success\">enabled</strong>.\n"
 "    "
 msgstr ""
 "\n"
-"        Pluginblackliste <strong class=\"text-"
+"        Pluginblockliste <strong class=\"text-"
 "success\">aktiviert</strong>.\n"
 "    "
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:32
 msgid ""
 "\n"
-"        Plugin blacklist processing is <strong class=\"text-"
+"        Plugin blocklist processing is <strong class=\"text-"
 "danger\">disabled</strong>.\n"
 "    "
 msgstr ""
 "\n"
-"        Pluginblackliste <strong class=\"text-"
+"        Pluginblockliste <strong class=\"text-"
 "danger\">deaktiviert</strong>.\n"
 "    "
 
@@ -3763,8 +3763,8 @@ msgid "Done!"
 msgstr "Fertig!"
 
 #: src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js:2050
-msgid "Blacklisted"
-msgstr "Geblacklistet"
+msgid "Blocklisted"
+msgstr "Geblocklistet"
 
 #: src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js:2052
 msgid "Disabled due to active safe mode"
@@ -4077,8 +4077,8 @@ msgid "There are notices available regarding this plugin"
 msgstr "Es gibt keine Nachrichten zu diesem Plugin"
 
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:149
-msgid "This plugin is blacklisted"
-msgstr "Das Plugin ist geblacklistet"
+msgid "This plugin is blocklisted"
+msgstr "Das Plugin ist geblocklistet"
 
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:151
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:343
@@ -4181,9 +4181,9 @@ msgid ""
 "source code and see what they do for yourself.\n"
 "            </li>\n"
 "            <li>\n"
-"                <strong>Plugin blacklist:</strong>\n"
-"                We maintain a blacklist of plugins/plugin versions that "
-"are known to cause issues. Unless you have disabled the blacklist, "
+"                <strong>Plugin blocklist:</strong>\n"
+"                We maintain a blocklist of plugins/plugin versions that "
+"are known to cause issues. Unless you have disabled the blocklist, "
 "OctoPrint will refuse to load and run any plugins installed in your "
 "system matching an entry on it.\n"
 "            </li>\n"
@@ -4191,7 +4191,7 @@ msgid ""
 "                <strong>Report mechanism:</strong>\n"
 "                If you encounter suspicious activity of a plugin, you can"
 " report it to us. We will then investigate and potentially remove it from"
-" the repository and/or add it to the blacklist.\n"
+" the repository and/or add it to the blocklist.\n"
 "            </li>\n"
 "            <li>\n"
 "                <strong>Safe mode & recovery page:</strong>\n"
@@ -4237,11 +4237,11 @@ msgstr ""
 "Quellcode lesen und für euch selbst analysieren könnt.\n"
 "            </li>\n"
 "            <li>\n"
-"                <strong>Pluginblacklist:</strong>\n"
-"                Wir unterhalten eine Blacklist von "
+"                <strong>Pluginblocklist:</strong>\n"
+"                Wir unterhalten eine Blocklist von "
 "Plugins/Pluginversionen, von denen                 bekannt ist, dass sie "
 "Probleme verursachen. Solange du die Verarbeitung dieser                 "
-"Blacklist nicht deaktiviert hast, wird OctoPrint sich weigern, ein darauf"
+"Blocklist nicht deaktiviert hast, wird OctoPrint sich weigern, ein darauf"
 " enthaltenes                 Plugin zu laden und auszuführen.\n"
 "            </li>\n"
 "            <li>\n"
@@ -4249,7 +4249,7 @@ msgstr ""
 "                Falls du verdächtige Aktivitäten bei einem Plugin "
 "beobachtest, kannst du das                 an uns melden. Wir werden das "
 "dann untersuchen und gegebenenfalls das Plugin aus dem                 "
-"Repository entfernen und/oder der Blacklist hinzufügen.\n"
+"Repository entfernen und/oder der Blocklist hinzufügen.\n"
 "            </li>\n"
 "            <li>\n"
 "                <strong>Safemode & Recoverypage:</strong>\n"
@@ -8583,8 +8583,8 @@ msgstr ""
 " werden sollen"
 
 #: src/octoprint/templates/dialogs/settings/features.jinja2:83
-msgid "Terminal Auto Uppercase Blacklist"
-msgstr "Terminal Auto Uppercase Blackliste"
+msgid "Terminal Auto Uppercase Blocklist"
+msgstr "Terminal Auto Uppercase Blockliste"
 
 #: src/octoprint/templates/dialogs/settings/features.jinja2:86
 msgid ""
@@ -8869,14 +8869,14 @@ msgstr ""
 "konfigurieren, <code>123456</code>. Komma-separiert."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:51
-msgid "Blacklisted serial ports"
-msgstr "Geblacklistete Serialports"
+msgid "Blocklisted serial ports"
+msgstr "Geblocklistete Serialports"
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:54
 #, python-format
 msgid ""
 "Use this to define <a href=\"%%(glob_url)s\">glob patterns</a> matching "
-"serial ports to blacklist for connecting against, e.g. "
+"serial ports to blocklist for connecting against, e.g. "
 "<code>/dev/ttyS*</code>. One entry per line."
 msgstr ""
 "Nutze diese Einstellung, um <a href=\"%%(glob_url)s\">glob patterns</a> "
@@ -8884,15 +8884,15 @@ msgstr ""
 "<code>/dev/ttyS*</code>. Ein Eintrag pro Zeile."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:58
-msgid "Blacklisted baud rates"
-msgstr "Geblacklistete Baudraten"
+msgid "Blocklisted baud rates"
+msgstr "Geblocklistete Baudraten"
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:61
 msgid ""
-"Use this to define serial port baud rates to blacklist for connecting "
+"Use this to define serial port baud rates to blocklist for connecting "
 "with, e.g. <code>123456</code>. Comma separated."
 msgstr ""
-"Nutze diese Einstellung um Baudraten zur Verbindung zu blacklisten, z.B. "
+"Nutze diese Einstellung um Baudraten zur Verbindung zu blocklisten, z.B. "
 "<code>123456</code>. Komma-separiert."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:67
@@ -9757,8 +9757,8 @@ msgid "Connectivity check"
 msgstr "Onlineprüfung"
 
 #: src/octoprint/templates/dialogs/settings/server.jinja2:16
-msgid "Plugin blacklist processing"
-msgstr "Pluginblackliste"
+msgid "Plugin blocklist processing"
+msgstr "Pluginblockliste"
 
 #: src/octoprint/templates/dialogs/settings/server.jinja2:21
 msgid "Debug options"
@@ -10767,20 +10767,20 @@ msgid ""
 "\n"
 "    <strong>To protect against known severe issues with certain versions "
 "of third party plugins</strong>, OctoPrint supports\n"
-"    the use of a centralized plugin version blacklist to automatically "
+"    the use of a centralized plugin version blocklist to automatically "
 "disable such plugins before they can interfere\n"
 "    with normal operation.\n"
 msgstr ""
 "\n"
 "<strong>Um vor bekannten Probleme mit bestimmten Versionen von "
 "Thirdpartyplugins zu schützen</strong> unterstützt OctoPrint die "
-"Verwendung einer zentralen Pluginblackliste, über die automatisch solche "
+"Verwendung einer zentralen Pluginblockliste, über die automatisch solche "
 "Plugins deaktiviert werden können, bevor sie mit dem normalen Betrieb "
 "interferieren können.\n"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2:4
-msgid "Enable plugin blacklist processing on startup"
-msgstr "Pluginblackliste beim Serverstart nutzen"
+msgid "Enable plugin blocklist processing on startup"
+msgstr "Pluginblockliste beim Serverstart nutzen"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2:5
 msgid "Any changes take effect only on the next server start."
@@ -10788,25 +10788,25 @@ msgstr "Alle Änderungen treten erst mit dem nächsten Serverstart in Kraft."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2:1
 msgid ""
-"How long to cache the blacklist, in minutes. You should normally not have"
+"How long to cache the blocklist, in minutes. You should normally not have"
 " to change this."
 msgstr ""
-"Wie lange die Pluginblackliste gecached werden sollen, in Minuten. Du "
+"Wie lange die Pluginblockliste gecached werden sollen, in Minuten. Du "
 "solltest hier normalerweise nichts ändern müssen."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2:2
-msgid "Blacklist cache TTL"
-msgstr "Blacklistencache TTL"
+msgid "Blocklist cache TTL"
+msgstr "Blocklistencache TTL"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2:1
-msgid "Plugin blacklist URL. You should normally not have to change this."
+msgid "Plugin blocklist URL. You should normally not have to change this."
 msgstr ""
-"URL der Pluginblackliste. Du solltest hier normalerweise nichts ändern "
+"URL der Pluginblockliste. Du solltest hier normalerweise nichts ändern "
 "müssen."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2:2
-msgid "Blacklist URL"
-msgstr "Blacklist-URL"
+msgid "Blocklist URL"
+msgstr "Blocklist-URL"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginTimings.jinja2:4
 msgid "Enable <code>plugintimings.log</code>"

--- a/translations/de/LC_MESSAGES/messages.po
+++ b/translations/de/LC_MESSAGES/messages.po
@@ -1757,8 +1757,8 @@ msgid "Online Connectivity Check"
 msgstr "Onlineprüfung"
 
 #: src/octoprint/plugins/corewizard/subwizards.py:122
-msgid "Plugin Blacklist"
-msgstr "Plugin Blackliste"
+msgid "Plugin Blocklist"
+msgstr "Plugin Blockliste"
 
 #: src/octoprint/plugins/corewizard/subwizards.py:143
 msgid "Default Printer Profile"
@@ -1792,16 +1792,16 @@ msgstr ""
 "fortfahren kannst."
 
 #: src/octoprint/plugins/corewizard/static/js/corewizard.js:262
-msgid "Please set up the plugin blacklist processing"
-msgstr "Bitte konfiguriere die Plugin Blackliste"
+msgid "Please set up the plugin blocklist processing"
+msgstr "Bitte konfiguriere die Plugin Blockliste"
 
 #: src/octoprint/plugins/corewizard/static/js/corewizard.js:263
 msgid ""
 "You haven't yet decided on whether to enable or disable the plugin "
-"blacklist processing. You need to either enable or disable it before "
+"blocklist processing. You need to either enable or disable it before "
 "continuing."
 msgstr ""
-"Du hast noch nicht entschieden, ob die Plugin Blackliste aktiviert werden"
+"Du hast noch nicht entschieden, ob die Plugin Blockliste aktiviert werden"
 " soll. Du musst sie entweder aktivieren oder deaktivieren bevor du "
 "fortfahren kannst."
 
@@ -1976,15 +1976,15 @@ msgstr ""
 "    "
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:1
-msgid "Configure plugin blacklist processing"
-msgstr "Pluginblackliste konfigurieren"
+msgid "Configure plugin blocklist processing"
+msgstr "Pluginblockliste konfigurieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:3
 msgid ""
 "\n"
 "    To protect against known severe issues with certain versions of third"
 " party plugins, OctoPrint supports the use\n"
-"    of a centralized plugin version blacklist to automatically disable "
+"    of a centralized plugin version blocklist to automatically disable "
 "such plugin versions before they can interfere with\n"
 "    normal operation, allowing you to uninstall or update them to a newer"
 " version.\n"
@@ -1992,7 +1992,7 @@ msgstr ""
 "\n"
 "    Um vor bekannten schweren Fehler mit bestimmten Third-Party-Plugins "
 "zu schützen, unterstützt OctoPrint \n"
-"    die Verwendung einer zentralen Pluginblackliste um automatisiert "
+"    die Verwendung einer zentralen Pluginblockliste um automatisiert "
 "solche Pluginversionen zu deaktivieren \n"
 "    bevor sie mit dem normalen Betrieb von OctoPrint interferieren "
 "können. Du kannst solche Plugins dann \n"
@@ -2003,13 +2003,13 @@ msgstr ""
 #, python-format
 msgid ""
 "\n"
-"    By default, OctoPrint will use the blacklist hosted at "
+"    By default, OctoPrint will use the blocklist hosted at "
 "<code>plugins.octoprint.org/blacklist.json</code> which you\n"
 "    can also take a look at in a more human readable format <a "
 "href=\"%(url)s\" target=\"_blank\">here</a>.\n"
 msgstr ""
 "\n"
-"    Standardmäßig wird OctoPrint die Blackliste von "
+"    Standardmäßig wird OctoPrint die Blockliste von "
 "<code>plugins.octoprint.org/blacklist.json</code> verwenden, \n"
 "    auf die du <a href=\"%(url)s\" target=\"_blank\">hier</a> auch einen "
 "Blick in menschenlesbarer Form werfen kannst.\n"
@@ -2018,45 +2018,45 @@ msgstr ""
 msgid ""
 "\n"
 "    Please decide whether to allow fetch and use of this centralized "
-"blacklist starting with the next server start.\n"
+"blocklist starting with the next server start.\n"
 "    You may also change your decision at any time through Settings > "
 "Server right from within OctoPrint.\n"
 msgstr ""
 "\n"
-"    Bitte entscheide, ob die zentrale Pluginblackliste ab dem nächsten "
+"    Bitte entscheide, ob die zentrale Pluginblockliste ab dem nächsten "
 "Serverstart genutzt werden soll. \n"
 "    Du kannst diese Entscheidung auch jederzeit unter Einstellungen > "
 "Server später noch ändern.\n"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:21
-msgid "Disable Plugin Blacklist Processing"
-msgstr "Pluginblackliste deaktivieren"
+msgid "Disable Plugin Blocklist Processing"
+msgstr "Pluginblockliste deaktivieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:24
-msgid "Enable Plugin Blacklist Processing"
-msgstr "Pluginblackliste aktivieren"
+msgid "Enable Plugin Blocklist Processing"
+msgstr "Pluginblockliste aktivieren"
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:29
 msgid ""
 "\n"
-"        Plugin blacklist processing is <strong class=\"text-"
+"        Plugin blocklist processing is <strong class=\"text-"
 "success\">enabled</strong>.\n"
 "    "
 msgstr ""
 "\n"
-"        Pluginblackliste <strong class=\"text-"
+"        Pluginblockliste <strong class=\"text-"
 "success\">aktiviert</strong>.\n"
 "    "
 
 #: src/octoprint/plugins/corewizard/templates/corewizard_pluginblacklist_wizard.jinja2:32
 msgid ""
 "\n"
-"        Plugin blacklist processing is <strong class=\"text-"
+"        Plugin blocklist processing is <strong class=\"text-"
 "danger\">disabled</strong>.\n"
 "    "
 msgstr ""
 "\n"
-"        Pluginblackliste <strong class=\"text-"
+"        Pluginblockliste <strong class=\"text-"
 "danger\">deaktiviert</strong>.\n"
 "    "
 
@@ -3763,8 +3763,8 @@ msgid "Done!"
 msgstr "Fertig!"
 
 #: src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js:2050
-msgid "Blacklisted"
-msgstr "Geblacklistet"
+msgid "Blocklisted"
+msgstr "Geblocklistet"
 
 #: src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js:2052
 msgid "Disabled due to active safe mode"
@@ -4077,8 +4077,8 @@ msgid "There are notices available regarding this plugin"
 msgstr "Es gibt keine Nachrichten zu diesem Plugin"
 
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:149
-msgid "This plugin is blacklisted"
-msgstr "Das Plugin ist geblacklistet"
+msgid "This plugin is blocklisted"
+msgstr "Das Plugin ist geblocklistet"
 
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:151
 #: src/octoprint/plugins/pluginmanager/templates/pluginmanager_settings.jinja2:343
@@ -4181,9 +4181,9 @@ msgid ""
 "source code and see what they do for yourself.\n"
 "            </li>\n"
 "            <li>\n"
-"                <strong>Plugin blacklist:</strong>\n"
-"                We maintain a blacklist of plugins/plugin versions that "
-"are known to cause issues. Unless you have disabled the blacklist, "
+"                <strong>Plugin blocklist:</strong>\n"
+"                We maintain a blocklist of plugins/plugin versions that "
+"are known to cause issues. Unless you have disabled the blocklist, "
 "OctoPrint will refuse to load and run any plugins installed in your "
 "system matching an entry on it.\n"
 "            </li>\n"
@@ -4191,7 +4191,7 @@ msgid ""
 "                <strong>Report mechanism:</strong>\n"
 "                If you encounter suspicious activity of a plugin, you can"
 " report it to us. We will then investigate and potentially remove it from"
-" the repository and/or add it to the blacklist.\n"
+" the repository and/or add it to the blocklist.\n"
 "            </li>\n"
 "            <li>\n"
 "                <strong>Safe mode & recovery page:</strong>\n"
@@ -4237,11 +4237,11 @@ msgstr ""
 "Quellcode lesen und für euch selbst analysieren könnt.\n"
 "            </li>\n"
 "            <li>\n"
-"                <strong>Pluginblacklist:</strong>\n"
-"                Wir unterhalten eine Blacklist von "
+"                <strong>Pluginblocklist:</strong>\n"
+"                Wir unterhalten eine Blocklist von "
 "Plugins/Pluginversionen, von denen                 bekannt ist, dass sie "
 "Probleme verursachen. Solange du die Verarbeitung dieser                 "
-"Blacklist nicht deaktiviert hast, wird OctoPrint sich weigern, ein darauf"
+"Blocklist nicht deaktiviert hast, wird OctoPrint sich weigern, ein darauf"
 " enthaltenes                 Plugin zu laden und auszuführen.\n"
 "            </li>\n"
 "            <li>\n"
@@ -4249,7 +4249,7 @@ msgstr ""
 "                Falls du verdächtige Aktivitäten bei einem Plugin "
 "beobachtest, kannst du das                 an uns melden. Wir werden das "
 "dann untersuchen und gegebenenfalls das Plugin aus dem                 "
-"Repository entfernen und/oder der Blacklist hinzufügen.\n"
+"Repository entfernen und/oder der Blocklist hinzufügen.\n"
 "            </li>\n"
 "            <li>\n"
 "                <strong>Safemode & Recoverypage:</strong>\n"
@@ -8583,8 +8583,8 @@ msgstr ""
 " werden sollen"
 
 #: src/octoprint/templates/dialogs/settings/features.jinja2:83
-msgid "Terminal Auto Uppercase Blacklist"
-msgstr "Terminal Auto Uppercase Blackliste"
+msgid "Terminal Auto Uppercase Blocklist"
+msgstr "Terminal Auto Uppercase Blockliste"
 
 #: src/octoprint/templates/dialogs/settings/features.jinja2:86
 msgid ""
@@ -8869,14 +8869,14 @@ msgstr ""
 "konfigurieren, <code>123456</code>. Komma-separiert."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:51
-msgid "Blacklisted serial ports"
-msgstr "Geblacklistete Serialports"
+msgid "Blocklisted serial ports"
+msgstr "Geblocklistete Serialports"
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:54
 #, python-format
 msgid ""
 "Use this to define <a href=\"%%(glob_url)s\">glob patterns</a> matching "
-"serial ports to blacklist for connecting against, e.g. "
+"serial ports to blocklist for connecting against, e.g. "
 "<code>/dev/ttyS*</code>. One entry per line."
 msgstr ""
 "Nutze diese Einstellung, um <a href=\"%%(glob_url)s\">glob patterns</a> "
@@ -8884,15 +8884,15 @@ msgstr ""
 "<code>/dev/ttyS*</code>. Ein Eintrag pro Zeile."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:58
-msgid "Blacklisted baud rates"
-msgstr "Geblacklistete Baudraten"
+msgid "Blocklisted baud rates"
+msgstr "Geblocklistete Baudraten"
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:61
 msgid ""
-"Use this to define serial port baud rates to blacklist for connecting "
+"Use this to define serial port baud rates to blocklist for connecting "
 "with, e.g. <code>123456</code>. Comma separated."
 msgstr ""
-"Nutze diese Einstellung um Baudraten zur Verbindung zu blacklisten, z.B. "
+"Nutze diese Einstellung um Baudraten zur Verbindung zu blocklisten, z.B. "
 "<code>123456</code>. Komma-separiert."
 
 #: src/octoprint/templates/dialogs/settings/serialconnection.jinja2:67
@@ -9757,8 +9757,8 @@ msgid "Connectivity check"
 msgstr "Onlineprüfung"
 
 #: src/octoprint/templates/dialogs/settings/server.jinja2:16
-msgid "Plugin blacklist processing"
-msgstr "Pluginblackliste"
+msgid "Plugin blocklist processing"
+msgstr "Pluginblockliste"
 
 #: src/octoprint/templates/dialogs/settings/server.jinja2:21
 msgid "Debug options"
@@ -10767,20 +10767,20 @@ msgid ""
 "\n"
 "    <strong>To protect against known severe issues with certain versions "
 "of third party plugins</strong>, OctoPrint supports\n"
-"    the use of a centralized plugin version blacklist to automatically "
+"    the use of a centralized plugin version blocklist to automatically "
 "disable such plugins before they can interfere\n"
 "    with normal operation.\n"
 msgstr ""
 "\n"
 "<strong>Um vor bekannten Probleme mit bestimmten Versionen von "
 "Thirdpartyplugins zu schützen</strong> unterstützt OctoPrint die "
-"Verwendung einer zentralen Pluginblackliste, über die automatisch solche "
+"Verwendung einer zentralen Pluginblockliste, über die automatisch solche "
 "Plugins deaktiviert werden können, bevor sie mit dem normalen Betrieb "
 "interferieren können.\n"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2:4
-msgid "Enable plugin blacklist processing on startup"
-msgstr "Pluginblackliste beim Serverstart nutzen"
+msgid "Enable plugin blocklist processing on startup"
+msgstr "Pluginblockliste beim Serverstart nutzen"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistEnabled.jinja2:5
 msgid "Any changes take effect only on the next server start."
@@ -10788,25 +10788,25 @@ msgstr "Alle Änderungen treten erst mit dem nächsten Serverstart in Kraft."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2:1
 msgid ""
-"How long to cache the blacklist, in minutes. You should normally not have"
+"How long to cache the blocklist, in minutes. You should normally not have"
 " to change this."
 msgstr ""
-"Wie lange die Pluginblackliste gecached werden sollen, in Minuten. Du "
+"Wie lange die Pluginblockliste gecached werden sollen, in Minuten. Du "
 "solltest hier normalerweise nichts ändern müssen."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistTtl.jinja2:2
-msgid "Blacklist cache TTL"
-msgstr "Blacklistencache TTL"
+msgid "Blocklist cache TTL"
+msgstr "Blocklistencache TTL"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2:1
-msgid "Plugin blacklist URL. You should normally not have to change this."
+msgid "Plugin blocklist URL. You should normally not have to change this."
 msgstr ""
-"URL der Pluginblackliste. Du solltest hier normalerweise nichts ändern "
+"URL der Pluginblockliste. Du solltest hier normalerweise nichts ändern "
 "müssen."
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginBlacklistUrl.jinja2:2
-msgid "Blacklist URL"
-msgstr "Blacklist-URL"
+msgid "Blocklist URL"
+msgstr "Blocklist-URL"
 
 #: src/octoprint/templates/snippets/settings/server/serverPluginTimings.jinja2:4
 msgid "Enable <code>plugintimings.log</code>"


### PR DESCRIPTION



- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [x] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)


#### What does this PR do and why is it necessary?

This PR replaces string instances of Blacklist and Whitelist (and their derivatives black list and white list, CAPS and no caps) with a more inclusive alternative, Blocklist and Allowlist. More discussion in the ticket https://github.com/OctoPrint/OctoPrint/issues/5207

#### How was it tested? How can it be tested by the reviewer?

I ran `pytest` locally after following https://github.com/OctoPrint/OctoPrint/blob/main/CONTRIBUTING.md#setting-up-a-development-environment and https://docs.octoprint.org/en/main/development/environment.html. `1096 passed, 47 warnings in 64.99s (0:01:04)`

I also manually ran the  pre-commit check suite with `pre-commit run --hook-stage manual --all-files` and those all passed.

I also ran the octoprint server locally on my macbook with `octoprint serve --port 12345` and tried to go through the setup wizard. I also went into the settings after the setup wizard to confirm the UI showed the Blocklist language

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

None, I used PyCharm to find and replace all the instances by hand

#### Any background context you want to provide?

N/A

#### What are the relevant tickets if any?

https://github.com/OctoPrint/OctoPrint/issues/5207

#### Screenshots (if appropriate)

<img width="763" height="504" alt="Screenshot 2025-11-24 at 12 20 38" src="https://github.com/user-attachments/assets/0bb35c5f-3563-4b55-8031-a783bb6e9238" />
<img width="310" height="359" alt="Screenshot 2025-11-24 at 12 20 26" src="https://github.com/user-attachments/assets/ea14cc7c-c894-4e5e-a4b8-bf57433b3334" />
<img width="953" height="364" alt="Screenshot 2025-11-24 at 12 32 45" src="https://github.com/user-attachments/assets/059c2fd6-5b66-49ca-9403-82a40c7b3f90" />
<img width="884" height="144" alt="Screenshot 2025-11-24 at 12 30 50" src="https://github.com/user-attachments/assets/2c2e0c82-cc3a-41d4-99a1-8f2d24823185" />


#### Further notes

Thank you so much for setting up this project to make contributions easy ❤️ 

