### PR TITLE
docs: clarify OctoPrint server in Getting Started

### DIFF
--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -1,5 +1,18 @@
 # Getting Started
 
+## What is OctoPrint?
+
+OctoPrint is a **server application** that provides a web interface to control a 3D printer.
+It usually runs on a small, always-on computer near the printer (e.g. a Raspberry Pi), but it can also run on a regular PC.
+
+### Typical setup
+
+- **OctoPrint server**: runs on a device near the printer (commonly a Raspberry Pi), but can also run on a regular PC; Docker is also an option
+- **3D printer**: connected to the server (usually via USB)
+- **Your computer/phone/tablet**: opens OctoPrint in a browser over the network
+
+This makes printing independent from your main computer.
+
 ## Installation
 
 Installation instructions for installing from source for different operating


### PR DESCRIPTION
- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [ ] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

Adds a short "What is OctoPrint?" introduction section to the Getting Started documentation to clarify that OctoPrint is a server application rather than a desktop application. This includes a description of the typical setup (server device, printer connection, browser-based access) to address common user confusion.

This change addresses feedback from issue #4804 where new users expected OctoPrint to be a native desktop application and were unclear about the server-based architecture and recommended deployment scenarios.

#### How was it tested? How can it be tested by the reviewer?

- All existing unit tests pass: `pytest` (1097 passed, 47 warnings)
- Pre-commit checks pass: `pre-commit run --hook-stage manual --all-files` (all hooks passed)
- Documentation builds successfully: `sphinx-build -b html ./docs ./docs/_build` (build succeeded with existing warnings, no new warnings introduced by this change)

The reviewer can verify the change by reviewing the documentation locally or checking the rendered markdown in the PR diff.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

Yes — GitHub Copilot was used for drafting and refining the documentation text, including assistance with wording and structure.

#### Any background context you want to provide?

Issue #4804 highlighted that new users often expect OctoPrint to be a desktop application they can install on their PC like a slicer, rather than understanding it as a server that typically runs on a dedicated device. The user specifically requested that the documentation "state clearly and at the beginning" what OctoPrint is and the typical deployment architecture.

This minimal addition aims to set clear expectations upfront without being overly verbose.

#### What are the relevant tickets if any?

- #4804

#### Screenshots (if appropriate)

N/A - documentation text change only

#### Further notes

Note: I have not added myself to AUTHORS.md as I prefer to remain unlisted for this minor documentation contribution.