### PR TITLE
fix(settings): apply preprocessors to nested values (#5231)

### DIFF
--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -1844,6 +1844,24 @@ class Settings:
             current = current[key]
         return current
 
+    def _process_with_preprocessor(self, value, preprocessor):
+        if preprocessor is None:
+            return value
+
+        if callable(preprocessor):
+            return preprocessor(value)
+
+        if isinstance(preprocessor, dict) and isinstance(value, dict):
+            result = {}
+            for key, val in value.items():
+                if key in preprocessor:
+                    result[key] = self._process_with_preprocessor(val, preprocessor[key])
+                else:
+                    result[key] = val
+            return result
+
+        return value
+
     def _get_value(
         self,
         path,
@@ -1908,8 +1926,7 @@ class Settings:
                     # no default value, so nothing to merge
                     pass
 
-            if callable(preprocessor):
-                value = preprocessor(value)
+            value = self._process_with_preprocessor(value, preprocessor)
 
             if do_copy:
                 if isinstance(value, KeysView):
@@ -2175,8 +2192,7 @@ class Settings:
         except NoSuchSettingsPath:
             pass
 
-        if callable(preprocessor):
-            value = preprocessor(value)
+        value = self._process_with_preprocessor(value, preprocessor)
 
         try:
             current = chain.get_by_path(path)

--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -1844,7 +1844,7 @@ class Settings:
             current = current[key]
         return current
 
-    def _process_with_preprocessor(self, value, preprocessor):
+    def _preprocess_value(self, value, preprocessor):
         if preprocessor is None:
             return value
 
@@ -1853,11 +1853,8 @@ class Settings:
 
         if isinstance(preprocessor, dict) and isinstance(value, dict):
             result = {}
-            for key, val in value.items():
-                if key in preprocessor:
-                    result[key] = self._process_with_preprocessor(val, preprocessor[key])
-                else:
-                    result[key] = val
+            for k, v in value.items():
+                result[k] = self._preprocess_value(v, preprocessor.get(k))
             return result
 
         return value
@@ -1926,7 +1923,7 @@ class Settings:
                     # no default value, so nothing to merge
                     pass
 
-            value = self._process_with_preprocessor(value, preprocessor)
+            value = self._preprocess_value(value, preprocessor)
 
             if do_copy:
                 if isinstance(value, KeysView):
@@ -2192,7 +2189,7 @@ class Settings:
         except NoSuchSettingsPath:
             pass
 
-        value = self._process_with_preprocessor(value, preprocessor)
+        value = self._preprocess_value(value, preprocessor)
 
         try:
             current = chain.get_by_path(path)

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -523,6 +523,21 @@ class SettingsTest(unittest.TestCase):
 
             self.assertEqual("SOME STRING", value)
 
+    def test_get_preprocessor_parent_path(self):
+        with self.settings() as settings:
+            config = {}
+            defaults = {"foo_preprocessor": {"bar": "fnord"}}
+            preprocessors = {"foo_preprocessor": {"bar": lambda x: x.upper()}}
+
+            value = settings.get(
+                ["foo_preprocessor"],
+                config=config,
+                defaults=defaults,
+                preprocessors=preprocessors,
+            )
+
+            self.assertEqual("FNORD", value["bar"])
+
     def test_set_preprocessor(self):
         with self.settings() as settings:
             config = {}
@@ -532,6 +547,22 @@ class SettingsTest(unittest.TestCase):
             settings.set(
                 ["foo_preprocessor", "bar"],
                 "value",
+                config=config,
+                defaults=defaults,
+                preprocessors=preprocessors,
+            )
+
+            self.assertEqual("VALUE", config["foo_preprocessor"]["bar"])
+
+    def test_set_preprocessor_parent_path(self):
+        with self.settings() as settings:
+            config = {}
+            defaults = {"foo_preprocessor": {"bar": "fnord"}}
+            preprocessors = {"foo_preprocessor": {"bar": lambda x: x.upper()}}
+
+            settings.set(
+                ["foo_preprocessor"],
+                {"bar": "value"},
                 config=config,
                 defaults=defaults,
                 preprocessors=preprocessors,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR should (hopefully) fix #5231.
The settings preprocessors were not being correctly applied to child values when performing get/set operations on parent paths.

#### How was it tested? How can it be tested by the reviewer?

I added two new test cases in `tests/settings/test_settings.py`.
They were failing before the patch and now they pass.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

- #5231

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->

I am not fully confident about the placement and naming convention of the new `_process_with_preprocessor` function, so I leave that decision to you.