### PR TITLE
fix(cli): fix user activate/deactivate outputs

### DIFF
--- a/src/octoprint/cli/user.py
+++ b/src/octoprint/cli/user.py
@@ -172,7 +172,7 @@ def activate_command(ctx, username):
 
         user = ctx.obj.user_manager.find_user(username)
         if user:
-            click.echo("User created:")
+            click.echo("User status:")
             click.echo(f"\t{_user_to_line(user.asDict())}")
     except UnknownUser:
         click.echo(f"User {username} does not exist!", err=True)
@@ -182,14 +182,14 @@ def activate_command(ctx, username):
 @click.argument("username", type=click.STRING)
 @click.pass_context
 def deactivate_command(ctx, username):
-    """Activate a user account."""
+    """Deactivate a user account."""
     try:
         ctx.obj.user_manager.change_user_activation(username, False)
-        click.echo(f"User {username} activated.")
+        click.echo(f"User {username} deactivated.")
 
         user = ctx.obj.user_manager.find_user(username)
         if user:
-            click.echo("User created:")
+            click.echo("User status:")
             click.echo(f"\t{_user_to_line(user.asDict())}")
     except UnknownUser:
         click.echo(f"User {username} does not exist!", err=True)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR fixes the output of the cli commands `octoprint user activate` and `octoprint user deactivate`.
The previous output was incorrect or misleading, likely due to a copy-and-paste error from the command `octoprint user add`.

#### How was it tested? How can it be tested by the reviewer?
I just ran the commands `octoprint user activate test` and `octoprint user deactivate test` and checked that the new outputs are okay

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?
No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

Before this PR:

<img width="791" height="395" alt="before this PR" src="https://github.com/user-attachments/assets/b6f67e15-a804-4822-b5f0-7108e6f2ef8b" />

After this PR:

<img width="953" height="376" alt="after this PR" src="https://github.com/user-attachments/assets/ccdc1a49-b43c-4295-8310-82e50506559c" />

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
