### PR TITLE
fix(comm): use the right capability for position autoreporting

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -5524,7 +5524,7 @@ class MachineCom:
         if match:
             interval = int(match.group("value"))
             self._pos_autoreporting = self._firmware_capabilities.get(
-                self.CAPABILITY_AUTOREPORT_SD_STATUS, False
+                self.CAPABILITY_AUTOREPORT_POS, False
             ) and (interval > 0)
 
     def _gcode_M33_sending(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [ ] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

While reading the OctoPrint code and hopping through git blames, I came across [this commit](https://github.com/OctoPrint/OctoPrint/commit/fcf45f7d5), which introduced position autoreporting.

Reading through the commit, I noticed that the added function `_gcode_M154_sending`, incorrectly sets `_pos_autoreporting` based on the `CAPABILITY_AUTOREPORT_SD_STATUS` capability instead of `CAPABILITY_AUTOREPORT_POS`.

This is likely a copy-paste error, given that the function right above it is `_gcode_M27_sending`, which correctly uses `CAPABILITY_AUTOREPORT_SD_STATUS` and from which I think this code was presumably copied.

This PR fixes the capability check to use the correct constant.

#### How was it tested? How can it be tested by the reviewer?

This change hasn't really been tested, it just seems reasonable to me.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
