### PR TITLE
Making SD card reference unambiguous

### DIFF
--- a/translations/messages.pot
+++ b/translations/messages.pot
@@ -4996,7 +4996,7 @@ msgstr ""
 #: src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2:47
 #: src/octoprint/templates/overlays/dragndrop.jinja2:7
 #: src/octoprint/templates/sidebar/files.jinja2:78
-msgid "Upload to SD"
+msgid "Upload to printer SD card"
 msgstr ""
 
 #: src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2:49
@@ -8727,7 +8727,7 @@ msgid "Cannot upload to printer's SD while printing"
 msgstr ""
 
 #: src/octoprint/templates/overlays/dragndrop.jinja2:7
-msgid "SD not initialized"
+msgid "Printer SD not initialized"
 msgstr ""
 
 #: src/octoprint/templates/overlays/offline.jinja2:9
@@ -8835,7 +8835,7 @@ msgid "Refresh file list"
 msgstr ""
 
 #: src/octoprint/templates/sidebar/files_header.jinja2:44
-msgid "SD Card operations"
+msgid "Printer SD Card operations"
 msgstr ""
 
 #: src/octoprint/templates/sidebar/files_header.jinja2:48


### PR DESCRIPTION
People often have OctoPrint running on a Raspberry Pi which also has an SD card so it's easy to get confused about what "SD card" is referring to. These text updates make it more clear that "SD card" refers to the printer's SD card.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
People often have OctoPrint running on a Raspberry Pi which also has an SD card so it's easy to get confused about what "SD card" is referring to. These text updates make it more clear that "SD card" refers to the printer's SD card.

#### How was it tested? How can it be tested by the reviewer?
Drag a .gcode file into OctoPrint. The new text should be seen. Also, simply hover over the SD card icon in the files section to see the updated title tag.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?
No

#### Any background context you want to provide?
No

#### What are the relevant tickets if any?


#### Screenshots (if appropriate)


#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
