### PR TITLE
fix(api): neverSendChecksum wrong value in serial settings compat layer

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -1108,7 +1108,7 @@ def _get_serial_settings():
         ),
         "alwaysSendChecksum": s.get(["plugins", "serial_connector", "sendChecksum"])
         == "always",
-        "neverSendChecksum": s.getBoolean(["plugins", "serial_connector", "sendChecksum"])
+        "neverSendChecksum": s.get(["plugins", "serial_connector", "sendChecksum"])
         == "never",
         "sendChecksumWithUnknownCommands": s.getBoolean(
             ["plugins", "serial_connector", "sendChecksumWithUnknownCommands"]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR fixes a typo (usage of `s.getBoolean()` instead of `s.get()` when comparing with a string) that caused `neverSendChecksum` always return `false` when fetching serial settings via the API using the compatibility layer (API version < 1.12.0)

#### How was it tested? How can it be tested by the reviewer?
1. Make sure to configure `sendChecksum: never` in the `serial_connector` section of your `config.yaml`.
```yaml
  serial_connector:
    [...]
    sendChecksum: never
```

2. GET the settings via API; the `neverSendChecksum` value will be incorrectly `false`.
```bash
curl -s http://localhost:8081/api/settings \
    -H "X-Api-Key: YOUR_API_KEY" \
    -H "X-OctoPrint-Api-Version: 1.11.0" \
    | jq '{neverSendChecksum: .serial.neverSendChecksum}'

{
  "neverSendChecksum": false
}
```

3. After applying the fix from this PR, the `neverSendChecksum` value will be returned correctly as `true`:
```bash
curl -s http://localhost:8081/api/settings \
    -H "X-Api-Key: YOUR_API_KEY" \
    -H "X-OctoPrint-Api-Version: 1.11.0" \
    | jq '{neverSendChecksum: .serial.neverSendChecksum}'

{
  "neverSendChecksum": true
}
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?
No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
