### PR TITLE
fix(api): fix error 500 on /api/job endpoint

### DIFF
--- a/src/octoprint/schema/api/job.py
+++ b/src/octoprint/schema/api/job.py
@@ -15,7 +15,7 @@ class ApiJobFile(BaseModel):
 class ApiJobInfo(BaseModel):
     file: ApiJobFile
     estimatedPrintTime: Optional[float] = None
-    filament: Optional[dict[str, dict[str, float]]] = None
+    filament: Optional[dict[str, Optional[dict[str, float]]]] = None
     user: Optional[str] = None
 
 

--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -8,7 +8,11 @@ from octoprint.access.permissions import Permissions
 from octoprint.schema.api import job as apischema
 from octoprint.server import NO_CONTENT, current_user, printer
 from octoprint.server.api import api
-from octoprint.server.util.flask import get_json_command_from_request, no_firstrun_access
+from octoprint.server.util.flask import (
+    api_versioned,
+    get_json_command_from_request,
+    no_firstrun_access,
+)
 
 
 @api.route("/job", methods=["POST"])
@@ -70,8 +74,21 @@ def controlJob():
 
 
 @api.route("/job", methods=["GET"])
+@api_versioned
 @Permissions.STATUS.require(403)
 def jobState():
+    response = _get_api_job_response().model_dump(by_alias=True)
+    response["job"]["lastPrintTime"] = None  # backwards compatibility
+    return jsonify(**response)
+
+
+@jobState.version(">=1.12.0")
+@Permissions.STATUS.require(403)
+def jobState_post_1_12():
+    return jsonify(**_get_api_job_response().model_dump(by_alias=True, exclude_none=True))
+
+
+def _get_api_job_response():
     current_data = printer.get_current_data()
 
     file_data = current_data["job"].get("file", {})
@@ -101,4 +118,4 @@ def jobState():
     if current_data["state"]["error"]:
         response.error = current_data["state"]["error"]
 
-    return jsonify(**response.model_dump(by_alias=True, exclude_none=True))
+    return response

--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -74,12 +74,7 @@ def controlJob():
 def jobState():
     current_data = printer.get_current_data()
 
-    file_data = current_data["job"].get("job", {})
-
-    timestamp = None
-    date = file_data.get("date")
-    if date:
-        timestamp = date.astimezone(None).timestamp()
+    file_data = current_data["job"].get("file", {})
 
     file = apischema.ApiJobFile(
         name=file_data.get("name"),
@@ -87,7 +82,7 @@ def jobState():
         display=file_data.get("display"),
         origin=file_data.get("origin"),
         size=file_data.get("size"),
-        date=timestamp,
+        date=file_data.get("date"),
     )
 
     job_data = current_data["job"]
@@ -101,7 +96,7 @@ def jobState():
     progress = apischema.ApiProgressInfo(**current_data["progress"])
 
     response = apischema.ApiJobResponse(
-        job, progress, state=current_data["state"]["text"]
+        job=job, progress=progress, state=current_data["state"]["text"]
     )
     if current_data["state"]["error"]:
         response.error = current_data["state"]["error"]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that on the `dev` branch, a GET request to the `/api/job` endpoint was returning an HTTP 500 error, with the following stacktrace:

<details>
<summary>Stacktrace</summary>

```bash
octoprint - ERROR - Exception on /api/job [GET]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/vendor/flask_principal.py", line 196, in _decorated
    rv = f(*args, **kw)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/job.py", line 94, in jobState
    job = apischema.ApiJobInfo(
        file=file,
    ...<2 lines>...
        user=job_data.get("user"),
    )
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ApiJobInfo
filament.length
  Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/dict_type
filament.volume
  Input should be a valid dictionary [type=dict_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/dict_type
```

</details>

Since the API was working correctly on the `main` branch, I checked the git blame and found that the endpoint was likely broken since this commit: https://github.com/OctoPrint/OctoPrint/commit/1ea98f736.

The commit title mentions a refactor, but it actually does much more than that: it defines new response schemas for the endpoint and significantly changes the response structure.

Specifically, I found four bugs introduced by that commit:
- the `filament` schema was wrong, causing the pydantic validation errors shown in the stacktrace above
- `file_data` was read from the wrong key (`current_data["job"].get("job", {})` instead of `current_data["job"].get("file", {})`)
- date to timestamp conversion failed because the value was already a timestamp
- response schema validation failed because pydantic v2 doesn't support positional args

This PR fixes these bugs while preserving the behavior that commit intended (if I understood correctly) to introduce, so that the endpoint no longer returns HTTP 500.

#### How was it tested? How can it be tested by the reviewer?

```bash
curl -s http://localhost:8081/api/job -H "X-Api-Key: YOUR_API_KEY"
```

<details>
<summary><code>main</code> branch response (not printing)</summary>

```json
{
  "job": {
    "estimatedPrintTime": null,
    "filament": {
      "length": null,
      "volume": null
    },
    "file": {
      "date": null,
      "name": null,
      "origin": null,
      "path": null,
      "size": null
    },
    "lastPrintTime": null,
    "user": null
  },
  "progress": {
    "completion": null,
    "filepos": null,
    "printTime": null,
    "printTimeLeft": null,
    "printTimeLeftOrigin": null
  },
  "state": "Offline"
}
```

</details>

<details>
<summary><code>dev</code> branch response before this fix (not printing)</summary>

```json
{
  "error": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
}
```

</details>

<details>
<summary><code>dev</code> branch response after this fix (not printing)</summary>

```json
{
  "job": {
    "filament": {
      "length": null,
      "volume": null
    },
    "file": {}
  },
  "progress": {},
  "state": "Operational"
}
```

</details>

<details>
<summary><code>dev</code> branch response after this fix (while printing)</summary>

```json
{
  "job": {
    "file": {
      "date": 1755700069,
      "display": "Raspberry UPS Lite Spacers 12mm_0.2mm_ASA_MK3SMMU3_20m.gcode",
      "name": "Raspberry UPS Lite Spacers 12mm_0.2mm_ASA_MK3SMMU3_20m.gcode",
      "origin": "local",
      "path": "Raspberry UPS Lite Spacers 12mm_0.2mm_ASA_MK3SMMU3_20m.gcode",
      "size": 1648577
    },
    "user": "admin"
  },
  "progress": {
    "completion": 0,
    "filepos": 11177,
    "printTime": 0,
    "printTimeLeft": 1140,
    "printTimeLeftOrigin": "printer"
  },
  "state": "Printing"
}
```

</details>

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

I used Claude Opus 4.6 to generate a large number of automatic tests to spot bugs, until it caught that the `/api/job` endpoint was returning HTTP 500. After that, I analyzed and fixed the bugs manually. No further AI usage was involved in this PR.

#### Any background context you want to provide?

**I still have some concerns about the new response schema that that commit introduced**, particularly the removal of the `lastPrintTime` field and the new `exclude_none=True` when returning the response, which causes all `None` fields to be stripped from the response instead of being returned as `null`. This is a breaking change and will likely break many plugins that don't expect it.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
