### PR TITLE
fix(timelapse): checkboxes not showed for unrendered timelapses

### DIFF
--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -349,7 +349,7 @@
                 <tr data-bind="attr: {title: name}">
                     <td class="timelapse_unrendered_checkbox">
                         <input type="checkbox"
-                               data-bind="value: name, checked: $root.markedForUnrenderedDeletion, invisible: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSTIMELAPSE_MANAGE_UNRENDEREDE_DELETE)()">
+                               data-bind="value: name, checked: $root.markedForUnrenderedDeletion, invisible: !$root.loginState.hasPermissionKo($root.access.permissions.TIMELAPSE_MANAGE_UNRENDERED)()">
                     </td>
                     <td class="timelapse_unrendered_name" data-bind="text: name"></td>
                     <td class="timelapse_unrendered_count" data-bind="text: count"></td>


### PR DESCRIPTION
A typo in the frontend permission check prevented checkboxes from being displayed even when the user had permission to delete unrendered timelapses.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [x] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a typo in the frontend permission check that caused the checkboxes for selecting unrendered timelapses to never be displayed.

This typo was introduced in commit efe9c68e9aea541a5eae4b9a8bf0d21a9c13a48f, which replaced the permission required to delete unrendered timelapses from `TIMELAPSE_DELETE` to `TIMELAPSE_MANAGE_UNRENDERED`.

#### How was it tested? How can it be tested by the reviewer?

See screenshots below

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

The typo in the permission check was spotted by an automated AI-analysis. The fix has been made manually and manually reviewed.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

Before the fix:

<img width="770" height="163" alt="image" src="https://github.com/user-attachments/assets/5697f154-673f-4087-9fa4-93d506931895" />

After the fix:

<img width="762" height="181" alt="image" src="https://github.com/user-attachments/assets/de7ca71f-e885-41f0-a6e6-0fc37d75cea8" />


#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
