### PR TITLE
fix(api): fix http 500 when subgroups are missing

### DIFF
--- a/src/octoprint/server/api/access.py
+++ b/src/octoprint/server/api/access.py
@@ -48,6 +48,8 @@ def add_group():
         abort(400, description="name is missing")
     if "permissions" not in data:
         abort(400, description="permissions are missing")
+    if "subgroups" not in data:
+        abort(400, description="subgroups are missing")
 
     key = data["key"]
     name = data["name"]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Per [documentation](https://docs.octoprint.org/en/dev/api/access.html#post--api-access-groups), `subgroups` is a mandatory parameter when making a POST request to the `/api/access/groups` endpoint.

This PR adds a friendly HTTP 400 message, as already done for the other parameters, instead of raising an HTTP 500 exception, when the parameter is missing.

I believe this bug also affects the `main` branch.

#### How was it tested? How can it be tested by the reviewer?

```bash
curl -s http://localhost:8081/api/access/groups \
  -X POST \
  -H "X-Api-Key: YOUR_API_KEY" \
  --json '{"key":"temp","name":"temp","description":null,"permissions":[]}'
```

Output before the fix:
```json
{
  "error": "The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application."
}
```

Output after the fix:
```json
{
  "error": "subgroups are missing"
}
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
