### PR TITLE
fix: don't save session if login mechanism is apikey

### DIFF
--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -590,7 +590,7 @@ class OctoPrintSessionInterface(flask.sessions.SecureCookieSessionInterface):
     def save_session(self, app, session, response):
         from octoprint.server.util import LoginMechanism
 
-        if session.get("_login_mechanism") == LoginMechanism.APIKEY:
+        if session.get("login_mechanism") == LoginMechanism.APIKEY:
             return
         return super().save_session(app, session, response)
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I was wondering why I was receiving a session cookie in response to API calls using the API key as the authentication method, as it seemed unusual.

Looking at the code, I noticed that there was indeed a condition meant to return before saving the session when using the API key, but it was checking `session.get("_login_mechanism")` instead of `session.get("login_mechanism")` - looks like a typo.

This PR removes that extra underscore.

I believe this bug also affects the `main` branch.

#### How was it tested? How can it be tested by the reviewer?

```bash
curl -s http://localhost:8081/api/version -H "X-Api-Key: YOUR_API_KEY" -v
```

Output before the fix:
```bash
[...]
>
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 119
< Cache-Control: max-age=0
< X-Clacks-Overhead: GNU Terry Pratchett
< Server-Timing: app;dur=1
< Vary: Cookie
< Set-Cookie: session_P8081=.eJxNys0KhSAQBtB3-dYR2X--jEgONaRzI20h0btHd9X6nAvzQY4ksfXRRCKBVsOg6rZq1Vg2dT91TQH-l5RLe6bVpLwTtJzef4QdNKwLLCjgfwuLCTSvVjiGV3beKON-AFSfJkY.aZL74g.8mPJTiNKo1ItrysnxyrK5AkHMvg; HttpOnly; Path=/; SameSite=Lax
< X-Robots-Tag: noindex, nofollow, noimageindex
< X-Content-Type-Options: nosniff
< X-Frame-Options: sameorigin
<
[...]
```

Output after the fix:
```bash
[...]
>
* Request completely sent off
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 119
< Cache-Control: max-age=0
< X-Clacks-Overhead: GNU Terry Pratchett
< Server-Timing: app;dur=0
< X-Robots-Tag: noindex, nofollow, noimageindex
< X-Content-Type-Options: nosniff
< X-Frame-Options: sameorigin
<
[...]
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
