### PR TITLE
fix(serial): use detection timeouts during serial detection

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -3893,7 +3893,7 @@ class MachineCom:
 
     def _get_communication_timeout_interval(self):
         # special rules during serial detection
-        if self._state != self.STATE_DETECT_SERIAL:
+        if self._state == self.STATE_DETECT_SERIAL:
             if self._detection_retry == 0:
                 # first try
                 return self._timeout_intervals.get("detectionFirst", 10.0)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [ ] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
I believe that the commit https://github.com/OctoPrint/OctoPrint/commit/45bbb25daa8564712b8ef29d2f54ef7c43575be4 accidentally inverted a condition in the `_get_communication_timeout_interval` function of the serial connector:

<img width="1103" height="546" alt="image" src="https://github.com/user-attachments/assets/fb9e3e20-1de7-49dd-9705-4ae573ec24b3" />

This causes timeouts to be determined incorrectly.

This PR swaps the condition back.

#### How was it tested? How can it be tested by the reviewer?

I didn't tested this one (yet), sorry. It just seems legit.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

This bug was spotted by Claude Opus 4.6, by analyzing the commits history. It seems legit, but I can confirm it at runtime / perform further analysis if needed.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
