### PR TITLE
fix: correctly convert timezone in Last-Modified

### DIFF
--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -1812,10 +1812,8 @@ def _compute_date(files):
 
     if max_timestamp:
         # we set the micros to 0 since microseconds are not speced for HTTP
-        max_timestamp = (
-            datetime.fromtimestamp(max_timestamp)
-            .replace(microsecond=0)
-            .replace(tzinfo=UTC_TZ)
+        max_timestamp = datetime.fromtimestamp(max_timestamp, tz=UTC_TZ).replace(
+            microsecond=0
         )
     return max_timestamp
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that, right after a fresh install (venv recreation), when loading the homepage after login, the date in the `Last-Modified` HTTP header was in the future:

<img width="1918" height="1136" alt="bug" src="https://github.com/user-attachments/assets/d187bdd9-f4b7-465a-85aa-9cd43796b576" />

I traced the bug back to [this commit](https://github.com/OctoPrint/OctoPrint/commit/5a5460d08#diff-69f1b7bf7b59f58452b4c4d2ec2a67cac90b25395d8b74bc364fa22a23e50728), which, while making changes to make `lastmodified` timezone-aware, was incorrectly discarding the timezone (treating local time as if it were UTC) instead of converting it. This caused the date to jump into the future depending on one's timezone. For me, being in Italy (UTC+1), the jump was one hour ahead.

This bug likely affects the `main` branch as well. The impact is that browser caching is not applied for some resources.


#### How was it tested? How can it be tested by the reviewer?

After applying the fix, right after a fresh install (venv recreation), the `Last-Modified` HTTP header date now appears correctly:

<img width="1916" height="1142" alt="fixed" src="https://github.com/user-attachments/assets/fe777c4c-f9c1-42d0-894c-19f81a8dfb31" />


#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
