### PR TITLE
fix(pluginmanager): cleanup tab was always empty

### DIFF
--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -854,7 +854,7 @@ $(function () {
                     deferred.reject();
                 })
                 .done(function (data) {
-                    self.fromOrphanResponse(data.orphans);
+                    self.fromOrphanResponse(data.orphan_data);
                     deferred.resolveWith(data);
                 });
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug in Plugin Manager that was causing the Cleanup tab to always appear empty.

This bug was likely affecting OctoPrint since v1.6.0rc1, so I think this should be selected also as a bugfix release relevant.

#### How was it tested? How can it be tested by the reviewer?

Create a random directory in data folder:

```bash
mkdir -p .octoprint/data/dummy_removed_plugin
```

Restart OctoPrint and notice that in OctoPrint Settings -> Plugin Manager -> Cleanup, it is still reporting "Nothing to cleanup".

After the fix contained in this PR the dummy folder correctly appears to cleanup (see screenshots below).

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

Before the fix:

<img width="1245" height="922" alt="image" src="https://github.com/user-attachments/assets/6ba22011-4bb6-41d1-ad92-d6b23efe5323" />

After the fix:

<img width="1245" height="923" alt="image" src="https://github.com/user-attachments/assets/d9aeaf62-afcf-49af-9957-fbb79749ddcd" />

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
