### PR TITLE
fix(gcodeviewer): fix crash when rendering large files

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/gcodeviewer.js
@@ -707,6 +707,7 @@ $(function () {
         self.approveLargeFile = function () {
             self.waitForApproval(false);
             self.loadFile(
+                self.selectedFile.storage(),
                 self.selectedFile.path(),
                 self.selectedFile.date(),
                 self.selectedFile.size()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug that caused a JavaScript exception when attempting to approve the rendering of a file larger than 20MB in the gcode viewer.

Commit https://github.com/OctoPrint/OctoPrint/commit/97b3db3e9 added the `storage` parameter to the `loadFile()` function but omitted it when calling the function within `approveLargeFile()`.

I think this bug is only present in the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Try rendering a gcode file larger than 20MB (e.g. [this one](https://github.com/user-attachments/files/25366045/Tung.Tung.Tung.Sahur_0.15mm_PLA_MK3SMMU3_4h53m.zip)).

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

Before the fix:

<img width="1917" height="966" alt="image" src="https://github.com/user-attachments/assets/88ce9adb-0e10-4294-891e-d8fed94e3310" />

After the fix:

<img width="1917" height="1086" alt="image" src="https://github.com/user-attachments/assets/eb6ed2af-d98a-401e-ba02-4ade9ad317e0" />

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
