### PR TITLE
chore: don't pin python version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,20 @@
 default_language_version:
-  python: python3.12
+  python: python3
 exclude: ^(src/octoprint/vendor/|src/octoprint/static/js/lib|src/octoprint/static/vendor|src/octoprint_setuptools|tests/static/js/lib|tests/util/_files|scripts/|translations/|.*\.css|.*\.svg|docs/)
 repos:
+  - repo: local
+    hooks:
+      - id: python-version-reminder
+        name: python version reminder
+        entry: python -c
+        args:
+          [
+            "print('NOTE: If pre-commit fails, make sure you are using a Python version officially supported by OctoPrint.')"
+          ]
+        language: system
+        always_run: true
+        verbose: true
+        files: ^$
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v5.0.0
     hooks:
@@ -13,7 +26,7 @@ repos:
       - id: check-toml
       - id: check-merge-conflict
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.20.0
+    rev: v3.21.2
     hooks:
       - id: pyupgrade
         args: ["--py39-plus"]


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR removes the Python 3.12 pin from pre-commit, allowing it to be used with other Python versions supported by OctoPrint.

As discussed on Discord, I added a note that appears at the top of the pre-commit output reminding users to verify that the Python version in use is officially supported by OctoPrint.

I also had to upgrade the `pyupgrade` hook version to avoid [an exception](https://github.com/asottile/pyupgrade/pull/1040) occurring with Python 3.14.

#### How was it tested? How can it be tested by the reviewer?

```bash
pre-commit run --all-files
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

Being on Arch Linux (`I use Arch, btw`), my system Python version is always forcibly aligned to the latest release. It was becoming tedious to remove the pin from my local pre-commit configuration every time I created a branch.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

This is the pre-commit output you will get:

<img width="1041" height="541" alt="image" src="https://github.com/user-attachments/assets/65b5784c-6995-4e78-b680-57b523a9f258" />

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
