### PR TITLE
fix(printer): fix crash setting temperature offsets

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -293,7 +293,6 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             return
 
         self._comm.setTemperatureOffset(offsets)
-        self._setOffsets(self._comm.getOffsets())
 
     @property
     def temperature_offsets(self) -> dict:

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -754,6 +754,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         tags |= {"trigger:printer.set_temperature_offset"}
 
         self._connection.set_temperature_offset(offsets=offsets, tags=tags)
+        self._set_offsets(self._connection.temperature_offsets)
 
     def _convert_rate_value(self, factor, min_val=None, max_val=None):
         if not isinstance(factor, (int, float)):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash when setting a temperature offset, with the following stacktrace:

<details>
<summary>Stacktrace</summary>

```bash
2026-02-18 12:10:32,234 - octoprint - ERROR - Exception on /api/printer/tool [POST]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 1640, in decorated_view
    return func(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/vendor/flask_principal.py", line 196, in _decorated
    rv = f(*args, **kw)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/printer.py", line 134, in printerToolCommand
    printer.set_temperature_offset(validated_values)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/standard.py", line 756, in set_temperature_offset
    self._connection.set_temperature_offset(offsets=offsets, tags=tags)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/connector.py", line 297, in set_temperature_offset
    self._setOffsets(self._comm.getOffsets())
    ^^^^^^^^^^^^^^^^
AttributeError: 'ConnectedSerialPrinter' object has no attribute '_setOffsets'
```

</details>

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Setting a temperature offset via the Temperature tab.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

I think this got broken while porting to the new serial connector.
I hope I correctly understood how the Printer class interacts with the Serial Connector and that I applied the right fix - I'm not entirely sure, to be honest.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
