### PR TITLE
fix(serial): ignore missing blocklisted baudrate

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -281,7 +281,10 @@ def baudrateList(candidates=None):
     )
     if blocklistedBaudrates:
         for baudrate in blocklistedBaudrates:
-            candidates.remove(baudrate)
+            try:
+                candidates.remove(baudrate)
+            except ValueError:
+                pass
 
     # last used baudrate = first to try, move to start
     prev = settings().getInt(["plugins", "serial_connector", "baudrate"])


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash when the user sets as blocklisted baudrate a number which is not in `candidates` variable.

The bug affects both `main` and `dev`, so I think it could be bugfix relevant.

Stacktrace:
~~~stacktrace
candidates.remove(baudrate)
~~~~~~~~~~~~~~~~~^^^^^^^^^^
ValueError: list.remove(x): x not in list
~~~

#### How was it tested? How can it be tested by the reviewer?

Go to "OctoPrint Settings" -> "Serial Connection" -> "General" -> "Blocklisted baud rates" and set a non-existent baudrate, e.g. `123456`. Save settings, reload the page and look for screenshots below to see what happens.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

On `main` branch, the server is totally broken and the user needs to manually edit their `config.yaml` to fix:

<img width="1326" height="370" alt="image" src="https://github.com/user-attachments/assets/6b38f85c-8775-4af0-be84-13178d3f1d35" />

On `dev` branch, the page loads, but the Printer State is stuck on `Detecting serial connection`:

<img width="1208" height="810" alt="image" src="https://github.com/user-attachments/assets/4e1676cd-3649-4bf0-8308-35cb3a71398e" />

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
