### PR TITLE
fix(serial): fix "wait for start" checkbox binding

### DIFF
--- a/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
+++ b/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
@@ -701,7 +701,7 @@
                     <div class="controls">
                         <label class="checkbox">
                             <input type="checkbox"
-                                   data-bind="checked: settings.settings.plugins.serial_connector.waitForStart"
+                                   data-bind="checked: settings.settings.plugins.serial_connector.waitForStartOnConnect"
                                    id="settings-serialWaitForStart">
                             {{ _("Wait for <code>start</code> on connect") }}
                             <span class="help-block">{{ _("Try checking this if you run into connection timeouts due to your printer taking too long to respond to OctoPrint's handshake attempts on connect.") }}</span>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the binding of the "Wait for start on connect" checkbox in the serial settings. It was bound to `waitForStart` instead of `waitForStartOnConnect`, which is the correct setting name.

This bug affected only the `dev` branch to my knowledge.

#### How was it tested? How can it be tested by the reviewer?

1. Go to **OctoPrint Settings** -> **Serial Connection** -> **Firmware & protocol**.
2. Check or uncheck the **"Wait for start on connect"** checkbox.
3. Save the settings.
4. Verify the `config.yaml` file: the `serial_connector` plugin should now save the setting as `waitForStartOnConnect` instead of `waitForStart`.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
