### PR TITLE
fix(printer): fix get_current_connection crash

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -993,7 +993,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         baudrate = parameters.get("baudrate")
         profile = parameters.get("profile")
 
-        return self._connection.state_string(), port, baudrate, profile
+        return self._connection.get_state_string(), port, baudrate, profile
 
     def is_closed_or_error(self, *args, **kwargs):
         return self._connection is None or self._connection.is_closed_or_error()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash when a plugin calls `Printer.get_current_connection()`.

Stacktrace:
~~~stacktrace
2026-02-19 04:36:51,781 - octoprint.plugin - ERROR - Error while calling plugin jacopotest
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-Jacopotest/octoprint_jacopotest/__init__.py", line 14, in on_event
    connection_info = self._printer.get_current_connection()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/__init__.py", line 460, in wrapper
    return f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/standard.py", line 996, in get_current_connection
    return self._connection.state_string(), port, baudrate, profile
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ConnectedSerialPrinter' object has no attribute 'state_string'. Did you mean: 'get_state_string'?
~~~

This bug affects only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

To facilitate troubleshooting, I drafted a test plugin that prints to console the current connection information every times a print is started:
[OctoPrint-Jacopotest.zip](https://github.com/user-attachments/files/25404912/OctoPrint-Jacopotest.zip)

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
