### PR TITLE
fix(ui): prevent double password prompt on change

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/access.js
+++ b/src/octoprint/static/js/app/viewmodels/access.js
@@ -342,7 +342,8 @@ $(function () {
                         });
                 };
 
-                if (self.isCurrentUser()) {
+                const user = self.currentUser();
+                if (self.isCurrentUser(user)) {
                     proceed();
                 } else {
                     access.loginState.reauthenticateIfNecessary(proceed);


### PR DESCRIPTION
When changing the current user's password via OctoPrint Settings -> Access Control, a re-authentication prompt was triggered. This is redundant because the user is already required to enter their current password in the change password form.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR prevents the re-authentication prompt from appearing when changing your own password via OctoPrint Settings -> Access Control. The check was redundant, as the current password is already required within the change password form.

Reading the code, there was already logic in place to avoid re-authentication in this case, but `self.isCurrentUser()` was being called without passing the user whose password was being changed, thus it always returned `false`. The naming convention for these things seems confusing to me (`self.currentUser()` is an observable of the user whose password is being changed, not the actual current user), but I guess we'll have to live with it.

This bug affects both the `dev` and `main` branches (bugfix release relevant).

#### How was it tested? How can it be tested by the reviewer?

I verified the following:
- Before the fix, re-authentication was requested whether changing your own password or another user's password.
- After the fix, re-authentication is only requested when changing another user's password.
- The password change continues to work correctly both when changing your own password and those of other users.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
