### PR TITLE
fix(printer): fix estimation percentage based weighing

### DIFF
--- a/src/octoprint/printer/estimation.py
+++ b/src/octoprint/printer/estimation.py
@@ -145,9 +145,8 @@ class PrintTimeEstimator:
 
                 # combine
                 totalPrintTime = (
-                    -sub_progress * statisticalTotalPrintTime
-                    + sub_progress * estimatedTotalPrintTime
-                )
+                    1.0 - sub_progress
+                ) * statisticalTotalPrintTime + sub_progress * estimatedTotalPrintTime
 
         printTimeLeft = None
         if totalPrintTime is not None:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I think I found a bug in the print time estimation logic.

The [`estimate()`](https://github.com/OctoPrint/OctoPrint/blob/dcc5a48fb1b7fe89db5f2b5c34014d434004b323/src/octoprint/printer/estimation.py#L57) function is a long flow, but let's focus on the part where I believe the bug is:

https://github.com/OctoPrint/OctoPrint/blob/dcc5a48fb1b7fe89db5f2b5c34014d434004b323/src/octoprint/printer/estimation.py#L147-L150

From point 2 of the docstring:

> [...] we do a percentage based weighing of the statistical data and the intelligent estimate - the closer to the beginning of the print, the more precedence for the statistical data, the closer to the cut off point, the more precedence for the intelligent estimate.

In short, the function should perform a [linear interpolation](https://en.wikipedia.org/wiki/Linear_interpolation) between `statisticalTotalPrintTime` and `estimatedTotalPrintTime`.

For those who, like me, don't digest math easily, here's a simple example. What we want is:
- when progress is 0.1 (10%) -> `totalPrintTime` should be 90% of `statisticalTotalPrintTime` + 10% of `estimatedTotalPrintTime`
- when progress is 0.5 (50%) -> `totalPrintTime` should be 50% of `statisticalTotalPrintTime` + 50% of `estimatedTotalPrintTime`
- when progress is 1.0 (100%) -> `totalPrintTime` should be 0% of `statisticalTotalPrintTime` + 100% of `estimatedTotalPrintTime`

Now let's say `statisticalTotalPrintTime` is 60 minutes and `estimatedTotalPrintTime` is 55 minutes.

Applying the current implementation's formula:

- when progress is 0.1 -> `totalPrintTime = (-0.1 * 60 + 0.1 * 55) = -0.5`
- when progress is 0.5 -> `totalPrintTime = (-0.5 * 60 + 0.5 * 55) = -2.5`
- when progress is 1.0 -> `totalPrintTime = (-1.0 * 60 + 1.0 * 55) = -5`

These are clearly wrong - all negative values - and they will be discarded by the sanity check described in point 3 of the docstring:

> If the total print time is set, we do a sanity check for it. [...] If it's too far off, our total can't be trusted and we fall back on the dumb estimate.

The correct formula should be:
```python
totalPrintTime = (
    (1.0 - sub_progress) * statisticalTotalPrintTime
    + sub_progress * estimatedTotalPrintTime
)
```

Verified with the same example values:

- when progress is 0.1 -> `totalPrintTime = [(1.0 - 0.1) * 60 + 0.1 * 55] = 59.5`
- when progress is 0.5 -> `totalPrintTime = [(1.0 - 0.5) * 60 + 0.5 * 55] = 57.5`
- when progress is 1.0 -> `totalPrintTime = [(1.0 - 1.0) * 60 + 1.0 * 55] = 55`

The bug appears to have been introduced 7 years ago in commit https://github.com/OctoPrint/OctoPrint/commit/c74e3a0a0. The intent of that commit seems to have been a minor refactor to change `-1.0 * self._threshold` to `-self._threshold`, but it also inadvertently broke the lerp formula by changing `(1.0 - sub_progress)` to `(- sub_progress)`.

The impact is that OctoPrint never actually uses the weighted estimate between statistical data and intelligent data, and instead always falls back to the dumb linear estimate. This, of course, only happens if the user hasn't installed a plugin that replaces the estimate and the user's printer or printed file doesn't directly report progress information (e.g., via `M73` gcodes).

This affects both `devel` and `main` branches, so it is bugfix release relevant.

#### How was it tested? How can it be tested by the reviewer?

I tested this PR by printing a gcode file with the virtual printer. 
I ensured the gcode did not contain M73 commands: `sed -i '/^M73 /d' file.gcode`.

I had to print more than once to ensure the statistical data was populated, and I ignored the first print.

Before the fix, hovering over the colored dot next to the remaining print time displayed `Based on a linear approximation`.

After the fix, for the first 50% of the print, it displays `Based on a mix of average total from past prints and calculation`, and then `Based on the calculated estimate`.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

Seeing this bug made me doubt myself and checked it over and over again, because I couldn't believe it had been there for 7 years without anyone complaining, but it seems legit to me.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
