### PR TITLE
fix(serial): fix crash calling home() w/o tags

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -237,7 +237,7 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             "G91",
             "G28 {}".format(" ".join(f"{x.upper()}0" for x in axes)),
             "G90",
-            tags=kwargs.get("tags", set) | {"trigger:printer.home"},
+            tags=kwargs.get("tags", set()) | {"trigger:printer.home"},
         )
 
     def extrude(self, amount, speed=None, *args, **kwargs):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in the `home()` function of the serial connector. The crash was caused by a typo (`set` instead of `set()`) in the assignment of default tags when the `tags` parameter was not specified.

This bug affects only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

The crash occurs when a plugin calls `self._printer.current_connection.home(axes=["x"])`.
To replicate this, I drafted a convenience plugin that executes this command whenever a user authenticates via web: [octoprint_jacopotest.zip](https://github.com/user-attachments/files/25437672/octoprint_jacopotest.zip)

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
