### PR TITLE
fix(virtualprinter): fix "G28 E" crash

### DIFF
--- a/src/octoprint/plugins/virtual_printer/virtual.py
+++ b/src/octoprint/plugins/virtual_printer/virtual.py
@@ -1979,7 +1979,7 @@ class VirtualPrinter:
             if z:
                 self._lastZ = 0
             if e:
-                self._lastE = 0
+                self._lastE[self.currentExtruder] = 0
 
     def _writeSdFile(self, filename: str) -> None:
         if filename.startswith("/"):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in the virtual printer. Specifically, when the virtual printer received the `G28 E` command, it set `self._lastE` (which is a list) to 0, instead of updating `self._lastE[self.currentExtruder]`, which contains the position of the current extruder. Consequently, the next time `self._lastE` was accessed anywhere in the virtual printer code, it triggered a `TypeError: 'int' object does not support item assignment` exception.

This bug is present in both the `dev` and `main` branches (relevant for a bugfix release).

#### How was it tested? How can it be tested by the reviewer?

I downloaded a Benchy G-code from Printables and replaced `G28` with `G28 E` at the top of the file. Edited file here: [3DBenchy_150um_MINI_PLA_2h.zip](https://github.com/user-attachments/files/25439850/3DBenchy_150um_MINI_PLA_2h.zip)

When printing it with the virtual printer before the fix, an exception is thrown in the console and the printer stops updating progress. With the fix applied, the print completes successfully.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

I have some doubts about whether `G28 E` [is a valid G-code](https://marlinfw.org/docs/gcode/G028.html); however, it was already supported by the virtual printer, so I am leaving it as is.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
