### PR TITLE
fix(ui): fix focus on folder creation

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -634,7 +634,7 @@ $(function () {
                 }
             }
 
-            self._filesToFocus = self._filesToFocus || focus;
+            self._filesToFocus = self._filesToFocus.length ? self._filesToFocus : focus;
             self._switchToPath = self._switchToPath || switchToPath;
 
             if (self._otherRequestInProgress !== undefined) {
@@ -819,10 +819,12 @@ $(function () {
                 .createFolder(storage, name, self.currentPath())
                 .done(function (data) {
                     self.requestData({
-                        focus: {
-                            path: data.folder.name,
-                            location: data.folder.origin
-                        }
+                        focus: [
+                            {
+                                path: data.folder.name,
+                                location: data.folder.origin
+                            }
+                        ]
                     })
                         .done(function () {
                             self.addFolderDialog.modal("hide");
@@ -1925,7 +1927,7 @@ $(function () {
                 type: "success"
             });
 
-            self.requestData({focus: {location: "printer", path: payload.remote}});
+            self.requestData({focus: [{location: "printer", path: payload.remote}]});
         };
 
         self.onEventTransferFailed = function (payload) {


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that creating new folders did not trigger focus on them. This PR fixes that bug.

It is important to remember that the `focus` passed to `requestData` must be an array rather than a single object (since #4633, it is possible to focus on more than one file).

Relevant for a bugfix release.

#### How was it tested? How can it be tested by the reviewer?

1. Create enough folders to fill the sidebar height.
2. Scroll to the top of the sidebar.
3. Create a folder that will be sorted at the bottom of the sidebar (e.g., named `zzzz`).

Before the fix, the folder is created but not focused; the sidebar remains scrolled at the top.
After the fix, the folder is focused, and the sidebar automatically scrolls down to highlight the new folder.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
