### PR TITLE
fix(serial): fix crash in get_file_position()

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -376,9 +376,8 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         if self._comm is None:
             return None
 
-        with self._selectedFileMutex:
-            if self._selectedFile is None:
-                return None
+        if self._job is None:
+            return None
 
         return self._comm.getFilePosition()
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in the `get_file_position()` function of the serial connector.
Specifically, the crash occurred whenever a plugin attempted to access `self._printer.current_connection.get_file_position()`.

The issue arises because `self._selectedFileMutex` and `self._selectedFile` do not exist within the serial connector context. The affected code is likely the result of a copy-paste error from when the serial connector was decoupled from the main printer logic.

This bug affects only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

I drafted a convenience plugin that prints the output of `get_file_position()` to the console whenever a user authenticates via web: [OctoPrint-Jacopotest.zip](https://github.com/user-attachments/files/25455387/OctoPrint-Jacopotest.zip)

Output before the fix:

~~~stacktrace
2026-02-21 04:30:41,479 - octoprint.plugin - ERROR - Error while calling plugin jacopotest
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-Jacopotest/octoprint_jacopotest/__init__.py", line 14, in on_event
    file_pos = self._printer.current_connection.get_file_position()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/connector.py", line 379, in get_file_position
    with self._selectedFileMutex:
         ^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'ConnectedSerialPrinter' object has no attribute '_selectedFileMutex'
~~~

Output after the fix, if no file is selected:
```
2026-02-21 04:31:17,224 - octoprint.plugins.jacopotest - INFO - FILE POS: None
```

Output after the fix, if a file is selected:
```
2026-02-21 04:31:24,804 - octoprint.plugins.jacopotest - INFO - FILE POS: {'origin': 'local', 'filename': '/home/user/.octoprint/upload/3DBenchy_150um_MINI_PLA_2h.gcode', 'pos': 0}
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
