### PR TITLE
fix(api): preserve error in job state pre-1.12 response

### DIFF
--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -92,6 +92,7 @@ def jobState():
         job=job_info_pre_1_12,
         progress=response.progress,
         state=response.state,
+        error=response.error,
     )
 
     return jsonify(**response_pre_1_12.model_dump(by_alias=True))


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
This PR fixes a bug introduced by [this commit](https://github.com/OctoPrint/OctoPrint/commit/dcc5a48fb1b7fe89db5f2b5c34014d434004b323) that caused the `error` field of the job state API response to always be `null` when using API version < 1.12.

Bug present only in the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

1. Connect to virtual printer and send `M112` via the terminal tab.

2. Request job state via API:

```bash
curl -s http://localhost:8081/api/job -H "X-Api-Key: YOUR_API_KEY" -H "X-OctoPrint-Api-Version: 1.11.0"
```

Output before the fix:
```json
{
  "error": null,
  "job": {
    "estimatedPrintTime": null,
    "filament": null,
    "file": {
      "date": null,
      "display": null,
      "name": null,
      "origin": null,
      "path": null,
      "size": null
    },
    "lastPrintTime": null,
    "user": null
  },
  "progress": {
    "completion": null,
    "filepos": null,
    "printTime": null,
    "printTimeLeft": null,
    "printTimeLeftOrigin": null
  },
  "state": "Offline"
}
```

Output after the fix:
```json
{
  "error": "Closing serial port due to emergency stop M112.",
  "job": {
    "estimatedPrintTime": null,
    "filament": null,
    "file": {
      "date": null,
      "display": null,
      "name": null,
      "origin": null,
      "path": null,
      "size": null
    },
    "lastPrintTime": null,
    "user": null
  },
  "progress": {
    "completion": null,
    "filepos": null,
    "printTime": null,
    "printTimeLeft": null,
    "printTimeLeftOrigin": null
  },
  "state": "Offline"
}
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
