### PR TITLE
fix(jsclient): broken deprecated sd commands

### DIFF
--- a/src/octoprint/static/js/app/client/printer.js
+++ b/src/octoprint/static/js/app/client/printer.js
@@ -56,7 +56,7 @@
         log.warn(
             "OctoPrintClient.printer.issueSdCommand has been deprecated as of OctoPrint 1.12.0, use OctoPrintClient.printer.issueStorageCommand instead"
         );
-        return this.base.issueStorageCommand(command, payload, opts);
+        return this.issueStorageCommand(command, payload, opts);
     };
 
     OctoPrintPrinterClient.prototype.getFullState = function (flags, opts) {
@@ -145,7 +145,7 @@
         log.warn(
             "OctoPrintClient.printer.getSdState has been deprecated as of OctoPrint 1.12.0, use OctoPrintClient.printer.getStorageState instead"
         );
-        return OctoPrintClient.prototype.getStorageState(opts);
+        return this.getStorageState(opts);
     };
 
     OctoPrintPrinterClient.prototype.getErrorInfo = function (opts) {
@@ -293,9 +293,9 @@
     };
     OctoPrintPrinterClient.prototype.initSd = function (opts) {
         log.warn(
-            "OctoPrintClient.printer.getSdState has been deprecated as of OctoPrint 1.12.0, use OctoPrintClient.printer.getStorageState instead"
+            "OctoPrintClient.printer.initSd has been deprecated as of OctoPrint 1.12.0, use OctoPrintClient.printer.initStorage instead"
         );
-        return this.base.initStorage(opts);
+        return this.initStorage(opts);
     };
 
     OctoPrintPrinterClient.prototype.releaseStorage = function (opts) {
@@ -305,7 +305,7 @@
         log.warn(
             "OctoPrintClient.printer.releaseSd has been deprecated as of OctoPrint 1.12.0, use OctoPrintClient.printer.releaseStorage instead"
         );
-        return this.base.releaseStorage(opts);
+        return this.releaseStorage(opts);
     };
 
     OctoPrintPrinterClient.prototype.refreshSd = function (opts) {


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

The deprecated backward-compat jsclient wrappers for sd commands (`issueSdCommand`, `getSdState`, `initSd`, releaseSd) were broken by 82366d05c9: they called methods on `this.base` (the base OctoPrint client) instead of `this` (the printer client), causing a `TypeError` at runtime. Also fixes a copy-paste typo in the `initSd` deprecation warning message.

These bugs affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Before the fix:

<img width="1917" height="580" alt="before" src="https://github.com/user-attachments/assets/b0b2c45d-b663-4401-9069-b788fe3190ff" />

After the fix:

<img width="1917" height="448" alt="after" src="https://github.com/user-attachments/assets/72dc4f90-5cc9-41ef-b42d-b8cf8711b6d4" />

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
