### PR TITLE
fix(upmgr): crash on recursive thumbnail refresh

### DIFF
--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -825,21 +825,20 @@ class LocalFileStorage(StorageInterface):
 
         if os.path.isdir(path_on_disk):
 
-            def process_folder(folder: str):
+            def process_folder(folder: str, base: str):
                 for item in os.scandir(folder):
                     if item.name.startswith("."):
                         continue
 
                     if item.is_dir():
                         if recursive:
-                            process_folder(item.path)
-                        else:
-                            continue
+                            process_folder(item.path, f"{base}/{item.name}")
+                        continue
 
                     if force or len(self._get_thumbnails(folder, item.name)) == 0:
-                        self._extract_thumbnails(f"{path}/{item.name}")
+                        self._extract_thumbnails(f"{base}/{item.name}")
 
-            process_folder(path_on_disk)
+            process_folder(path_on_disk, path)
 
         elif force or not self.has_thumbnail(path):
             self._extract_thumbnails(path)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash that occurs when the `refresh_thumbnails` function is called with `recursive=True`. Technical details are in the commit description.

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

1. Add a logging statement at the top of [`_extract_thumbnails`](https://github.com/OctoPrint/OctoPrint/blob/9c7b69cb5bbeadafbf0039b718ecb788c67b137c/src/octoprint/filemanager/storage/local.py#L1647) to see which paths are passed to the function:
```python
self._logger.warning(f"_extract_thumbnails: {path}")
```
This function is expected to only receive complete, valid paths pointing to files (not directories).

2. Create a directory tree in the OctoPrint storage as follows:
```
a
|- 3DBenchy_150um_MINI_PLA_2h.gcode
|- b
   |- 3DBenchy_150um_MINI_PLA_2h.gcode
```

3. Run the following command:
```bash
curl -X POST http://localhost:8081/api/files/local/a \
-H "Content-Type: application/json" \
-H "X-Api-Key: YOUR_API_KEY" \
-d '{"force":true,"recursive":true,"command":"refresh_thumbnails"}'
```

Before this fix, the following stacktrace is thrown because the function receives the path of folder `a/b`:
~~~stacktrace
2026-03-05 18:34:25,280 - tornado.access - WARNING - 415 POST /api/files/local/a (127.0.0.1) 1.97ms
2026-03-05 18:34:59,901 - octoprint.filemanager.storage.local - WARNING - _extract_thumbnails: a/3DBenchy_150um_MINI_PLA_2h.gcode
2026-03-05 18:34:59,910 - octoprint.filemanager.storage.local - WARNING - _extract_thumbnails: a/b
2026-03-05 18:34:59,910 - octoprint - ERROR - Exception on /api/files/local/a [POST]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 1640, in decorated_view
    return func(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/files.py", line 1298, in gcodeFileCommand
    fileManager.refresh_thumbnails(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        storage, path, force=force, recursive=recursive
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/__init__.py", line 1399, in refresh_thumbnails
    self._storage(location).refresh_thumbnails(path, force=force, recursive=recursive)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/local.py", line 842, in refresh_thumbnails
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/local.py", line 840, in process_folder
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/local.py", line 1652, in _extract_thumbnails
        os.path.join(folder, name)
                 ^^^^^^^^^^^^^^^^^
    )
    ^
    if not thumbnails:
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/gcode_thumbnail_tool.py", line 222, in extract_thumbnail_bytes_from_gcode_file
    result = extract_thumbnails_from_gcode_file(gcode_path)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/gcode_thumbnail_tool.py", line 178, in extract_thumbnails_from_gcode_file
    potential_lines = _potential_lines_from_gcode_file(gcode_path)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/gcode_thumbnail_tool.py", line 143, in _potential_lines_from_gcode_file
    with open(path, encoding="utf8", errors="ignore") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
IsADirectoryError: [Errno 21] Is a directory: '/home/user/.octoprint/upload/a/b'
~~~

After the fix, both the files in folder `a` and those in subfolder `b` are correctly processed:
~~~stacktrace
2026-03-05 18:49:09,217 - octoprint.filemanager.storage.local - WARNING - _extract_thumbnails: a/b/3DBenchy_150um_MINI_PLA_2h.gcode
2026-03-05 18:49:09,231 - octoprint.filemanager.storage.local - WARNING - _extract_thumbnails: a/3DBenchy_150um_MINI_PLA_2h.gcode
~~~


#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

It might be a good idea to add `recursive=True` to the refresh thumbnails button shown in the file manager? Currently it is set to `False`, which seems like counterintuitive behavior from a UX perspective (?).

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
