### PR TITLE
fix(docs): fix build crash on python 3.14

### DIFF
--- a/docs/sphinxext/pydanticext.py
+++ b/docs/sphinxext/pydanticext.py
@@ -7,7 +7,7 @@ import inspect
 import re
 from dataclasses import dataclass
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Literal, Optional, Union, get_args, get_origin
 
 import yaml
 from docutils import nodes
@@ -51,7 +51,7 @@ class PydanticFieldDoc:
 
 
 class PydanticModelInspector:
-    CONTAINER_TYPES = ("Optional", "Literal")
+    CONTAINER_TYPE_ORIGINS = (Union, Literal)
 
     def __init__(self):
         self.scanner = self._create_scanner()
@@ -107,8 +107,8 @@ class PydanticModelInspector:
         return enum_
 
     def _strip_container_types(self, type_: type) -> type:
-        while any(str(type_).startswith(f"typing.{x}") for x in self.CONTAINER_TYPES):
-            args = type_.__args__
+        while get_origin(type_) in self.CONTAINER_TYPE_ORIGINS:
+            args = get_args(type_)
             if args:
                 type_ = args[0]
             else:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in docs compilation on Python 3.14.

The `_strip_container_types` function used a string comparison (`if str(type_).startswith(f"typing.{x}")`) to identify container types.

In Python 3.14 the string representation of `Optional` has changed, causing the comparison to fail and a subsequent crash elsewhere in the code because the container type was not stripped correctly.

In Python < 3.14: `str(Optional[Enum])` -> `"typing.Optional[Enum]"`
In Python 3.14: `str(Optional[Enum])` -> `"Enum | None"`

In general, converting to string seems like a fragile approach that may cause further issues if future Python releases change the string representation of other types.

This PR fixes the root cause by using `typing.get_origin` and `typing.get_args`, which are the robust way to inspect types. Please note that the origin of `Optional` is `Union`.

#### How was it tested? How can it be tested by the reviewer?

```bash
task docs-build
```

Before this fix, this was the staktrace on Python 3.14:

<details>
  <summary>Stacktrace</summary>

~~~stacktrace
Traceback
=========

    Traceback (most recent call last):
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/cmd/build.py", line 432, in build_main
        app.build(args.force_all, args.filenames)
        ~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/application.py", line 426, in build
        self.builder.build_update()
        ~~~~~~~~~~~~~~~~~~~~~~~~~^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/builders/__init__.py", line 375, in build_update
        self.build(
        ~~~~~~~~~~^
            to_build,
            ^^^^^^^^^
        ...<2 lines>...
            method='update',
            ^^^^^^^^^^^^^^^^
        )
        ^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/builders/__init__.py", line 403, in build
        updated_docnames = set(self.read())
                               ~~~~~~~~~^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/builders/__init__.py", line 519, in read
        self._read_serial(docnames)
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/builders/__init__.py", line 584, in _read_serial
        self.read_doc(docname)
        ~~~~~~~~~~~~~^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/builders/__init__.py", line 648, in read_doc
        publisher.publish()
        ~~~~~~~~~~~~~~~~~^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/core.py", line 234, in publish
        self.document = self.reader.read(self.source, self.parser,
                        ~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
                                         self.settings)
                                         ^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/io.py", line 103, in read
        self.parse()
        ~~~~~~~~~~^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/readers/__init__.py", line 76, in parse
        self.parser.parse(self.input, document)
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/sphinx/parsers.py", line 86, in parse
        self.statemachine.run(inputlines, document, inliner=self.inliner)
        ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 169, in run
        results = StateMachineWS.run(self, input_lines, input_offset,
                                     input_source=document['source'])
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 233, in run
        context, next_state, result = self.check_line(
                                      ~~~~~~~~~~~~~~~^
            context, state, transitions)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 445, in check_line
        return method(match, context, next_state)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2790, in underline
        self.section(title, source, style, lineno - 1, messages)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 325, in section
        self.new_subsection(title, lineno, messages)
        ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 391, in new_subsection
        newabsoffset = self.nested_parse(
              self.state_machine.input_lines[offset:], input_offset=absoffset,
              node=section_node, match_titles=True)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 279, in nested_parse
        state_machine.run(block, input_offset, memo=self.memo,
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          node=node, match_titles=match_titles)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 195, in run
        results = StateMachineWS.run(self, input_lines, input_offset)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 233, in run
        context, next_state, result = self.check_line(
                                      ~~~~~~~~~~~~~~~^
            context, state, transitions)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 445, in check_line
        return method(match, context, next_state)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2790, in underline
        self.section(title, source, style, lineno - 1, messages)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 325, in section
        self.new_subsection(title, lineno, messages)
        ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 391, in new_subsection
        newabsoffset = self.nested_parse(
              self.state_machine.input_lines[offset:], input_offset=absoffset,
              node=section_node, match_titles=True)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 279, in nested_parse
        state_machine.run(block, input_offset, memo=self.memo,
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          node=node, match_titles=match_titles)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 195, in run
        results = StateMachineWS.run(self, input_lines, input_offset)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 233, in run
        context, next_state, result = self.check_line(
                                      ~~~~~~~~~~~~~~~^
            context, state, transitions)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 445, in check_line
        return method(match, context, next_state)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2790, in underline
        self.section(title, source, style, lineno - 1, messages)
        ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 325, in section
        self.new_subsection(title, lineno, messages)
        ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 391, in new_subsection
        newabsoffset = self.nested_parse(
              self.state_machine.input_lines[offset:], input_offset=absoffset,
              node=section_node, match_titles=True)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 279, in nested_parse
        state_machine.run(block, input_offset, memo=self.memo,
        ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
                          node=node, match_titles=match_titles)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 195, in run
        results = StateMachineWS.run(self, input_lines, input_offset)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 233, in run
        context, next_state, result = self.check_line(
                                      ~~~~~~~~~~~~~~~^
            context, state, transitions)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/statemachine.py", line 445, in check_line
        return method(match, context, next_state)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2357, in explicit_markup
        nodelist, blank_finish = self.explicit_construct(match)
                                 ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2369, in explicit_construct
        return method(self, expmatch)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2106, in directive
        return self.run_directive(
               ~~~~~~~~~~~~~~~~~~^
            directive_class, match, type_name, option_presets)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/docutils/parsers/rst/states.py", line 2156, in run_directive
        result = directive_instance.run()
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 361, in run
        fields = self.inspector.process_model(clz, subs=subs)
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 63, in process_model
        return self._model_doc(model, subs=subs)
               ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 227, in _model_doc
        result += self._model_doc(field.annotation, prefix=f"{prefix}{name}.")
                  ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 254, in _model_doc
        self._field_doc(prefix + name, field, field.annotation, subs=subs)
        ~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 156, in _field_doc
        elif isinstance(default, Enum) and self._convert_enum(t) is not t:
                                           ~~~~~~~~~~~~~~~~~~^^^
      File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/docs/sphinxext/pydanticext.py", line 104, in _convert_enum
        bases = [base for base in enum_.__bases__ if not issubclass(base, Enum)]
                                  ^^^^^^^^^^^^^^^
    AttributeError: 'typing.Union' object has no attribute '__bases__'. Did you mean: '__args__'?
~~~

</details>

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

Yes, I used Claude Opus to translate the above explanation of this PR from Italian to English.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
