### PR TITLE
fix(terminal): command history never trimmed

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/terminal.js
+++ b/src/octoprint/static/js/app/viewmodels/terminal.js
@@ -444,7 +444,7 @@ $(function () {
             if (commandToSend) {
                 OctoPrint.control.sendGcode(commandToSend).done(function () {
                     self.cmdHistory.push(command);
-                    self.cmdHistory.slice(-300); // just to set a sane limit to how many manually entered commands will be saved...
+                    self.cmdHistory = self.cmdHistory.slice(-300); // just to set a sane limit to how many manually entered commands will be saved...
                     self.cmdHistoryIdx = self.cmdHistory.length;
                     self.command("");
                 });


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the terminal command history limit. The intent to trim the history was already in place, but it was inadvertently not applied because in JavaScript `slice()` returns a new array rather than modifying the original.

This bug affected also `main` branch (bugfix release relevant).

#### How was it tested? How can it be tested by the reviewer?

See the MDN Web Docs: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/slice#return_a_portion_of_an_existing_array

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
