### PR TITLE
fix(printer): active_job was always None

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -353,7 +353,7 @@ class CommonPrinterMixin:
 
     @property
     def active_job(self):
-        if self.is_printing() or self.is_pausing or self.is_paused():
+        if self.is_printing() or self.is_pausing() or self.is_paused():
             return self.current_job
         return None
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -797,6 +797,11 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
 
         self._connection.flow_rate(factor, tags=tags)
 
+    @property
+    def current_job(self):
+        with self._selected_job_mutex:
+            return self._selected_job
+
     def set_job(
         self,
         job: PrintJob,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I was quite surprised when I tried to upload a file trying to overwrite the one currently being printed and it worked.

After a brief investigation, I discovered that the huge comm layer refactor commit, 0b12b9494, forgot to override the `current_job` property in Printer, causing it to always return `None`.

As a consequence, `active_job` also always returned `None`, and that was exactly the property checked by files.py to prevent overwriting the file currently being printed:

https://github.com/OctoPrint/OctoPrint/blob/ce3ce04db3803870d3d0ee24f97cdbad6a62fd77/src/octoprint/server/api/files.py#L808-L814

As a sidenote, I also noticed that `active_job` had a bug: the parentheses were missing in `if ... self.is_pausing()`:

https://github.com/OctoPrint/OctoPrint/blob/ce3ce04db3803870d3d0ee24f97cdbad6a62fd77/src/octoprint/printer/__init__.py#L356

This PR fixes these bugs, which only affected the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Try to overwrite the file currently being printed by uploading one with the same name.

Before the fix, you can overwrite it.

After the fix, you correctly get an error message.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
