### PR TITLE
fix: fix watched folder crash on upload

### DIFF
--- a/src/octoprint/printer/job.py
+++ b/src/octoprint/printer/job.py
@@ -32,7 +32,11 @@ class PrintJob(BaseModel):
         return f"{self.storage}:{self.path}"
 
     def __eq__(self, value):
-        return self.storage == value.origin and self.path == value.path
+        if isinstance(value, PrintJob):
+            return self.storage == value.storage and self.path == value.path
+        if isinstance(value, str):
+            return str(self) == value
+        return NotImplemented
 
 
 class UploadJob(PrintJob):

--- a/src/octoprint/server/util/watchdog.py
+++ b/src/octoprint/server/util/watchdog.py
@@ -113,7 +113,12 @@ class GcodeWatchdogHandler(watchdog.events.PatternMatchingEventHandler):
             ):
                 return
 
-            reselect = self._printer.is_current_file(futureFullPathInStorage, False)
+            current = self._printer.current_job
+            reselect = (
+                current is not None
+                and current.storage == octoprint.filemanager.FileDestinations.LOCAL
+                and current.path == futureFullPathInStorage
+            )
 
             added_file = self._file_manager.add_file(
                 octoprint.filemanager.FileDestinations.LOCAL,


### PR DESCRIPTION
### Please review this PR after merging #5288, because that bug also affects watchdog and otherwise it would be harder to reproduce the bugs described in this PR.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

When creating a new file in the `.octoprint/watched` folder, I got this stacktrace:

~~~stacktrace
2026-03-06 22:44:50,108 - octoprint.server.util.watchdog - ERROR - There was an error while processing the file /home/user/.octoprint/watched/a.gcode in the watched folder
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/watchdog.py", line 116, in _upload
    reselect = self._printer.is_current_file(futureFullPathInStorage, False)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Printer' object has no attribute 'is_current_file'
~~~

This was because the `CommonPrinterMixin.is_current_file()` method was removed by the huge comm layer refactor commit 0b12b9494.

I then fixed the `reselect` assignment in the watchdog by mimicking what the removed `is_current_file()` method did, but again, when creating a new file in the watched folder during an ongoing print, I ran into an additional bug:

~~~stacktrace
2026-03-06 23:10:37,222 - octoprint.server.util.watchdog - ERROR - There was an error while processing the file /home/user/.octoprint/watched/a.gcode in the watched folder
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/watchdog.py", line 111, in _upload
    self._printer.active_job
    == f"{octoprint.filemanager.FileDestinations.LOCAL}:{futureFullPathInStorage}"
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/job.py", line 35, in __eq__
    return self.storage == value.origin and self.path == value.path
                           ^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'origin'
~~~

This was because the further refactoring commit 1dd935208 had changed `PrintJob.origin` to `PrintJob.storage`, but forgot to update the name in `PrintJob.__eq__` as well.

This PR fixes both bugs.

These bugs only affect the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

See above for the stacktraces before the fix. No more crashes after the fix.

The bug described in this PR is better reproducible after merging #5288, since watchdog is also affected by that bug.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
