### PR TITLE
fix(api): fix file reselection after upload

### DIFF
--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -828,7 +828,7 @@ def uploadGcodeFile(target):
                     description="File already exists, cannot overwrite due to a lack of permissions",
                 )
 
-            reselect = str(printer.active_job) == f"{target}:{futureFullPathInStorage}"
+            reselect = str(printer.current_job) == f"{target}:{futureFullPathInStorage}"
 
             upload_done = False
 


### PR DESCRIPTION
### Please review this PR after merging #5288, because this PR depends on that.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

When overwriting the currently selected file, it was not reselected because it was compared against `active_job` (which is `None` when not printing) instead of `current_job`. This bug was introduced by d9f0e0052.

This bug affects only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Please test this PR after merging #5288, because this PR depends on that.

Steps to reproduce:

1. Upload a gcode, let's say `a.gcode`.
2. Select it.
3. Upload a completely different gcode with the same `a.gcode` name, overwriting it.

Before this fix, the file is not reselected, so all its data in the State sidebar (thumbnail, upload date, print times, file size...) are not updated.

After this fix, the file is reselected and its data is correctly updated in the State sidebar.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
