### PR TITLE
fix: Log flooding with no serial

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -209,6 +209,9 @@ def serialList():
                         i += 1
                 except OSError:
                     pass
+        except FileNotFoundError:
+            _logger.debug("No hardware serial devices found")
+            pass
         except Exception:
             _logger.exception("Error while enumerating the available serial ports")
 


### PR DESCRIPTION
- [X] You have read through `CONTRIBUTING.md`
- [X] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [X] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [X] Your PR targets OctoPrint's `dev` branch
- [X] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [X] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [X] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [ ] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [X] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

suppress FileNotFoundError exception on windows when polling for serial connections to avoid flooding the log every second.

#### How was it tested? How can it be tested by the reviewer?

ran in dev mode and monitored logging with no serial devices connected.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#5291

#### Screenshots (if appropriate)

#### Further notes
