### PR TITLE
fix(upmgr): multiple fixes

### DIFF
--- a/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
+++ b/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
@@ -687,6 +687,12 @@ $(function () {
             }
         });
 
+        self.download = () => {
+            if (!self.enableDownload()) return;
+            const url = self.downloadUrl();
+            if (url) window.location.href = url;
+        };
+
         self.slice = () => {
             if (!self.enableSlicing()) return;
 

--- a/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
+++ b/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
@@ -249,13 +249,13 @@ $(function () {
         };
 
         self.foldersOnlyList = ko.dependentObservable(function () {
-            filter = function (data) {
+            var filter = function (data) {
                 return data["type"] && data["type"] == "folder";
             };
             return _.filter(self.listHelper.paginatedItems(), filter);
         });
         self.filesOnlyList = ko.dependentObservable(function () {
-            filter = function (data) {
+            var filter = function (data) {
                 return data["type"] && data["type"] != "folder";
             };
             return _.filter(self.listHelper.paginatedItems(), filter);

--- a/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
+++ b/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
@@ -596,11 +596,11 @@ $(function () {
                 (type == "folder" && capabilities.copy_folder);
             const crossStorageCopyPossible = _.any(
                 _.map(
+                    self.files.storageOptions(),
                     (storage) =>
                         storage.key !== data.origin &&
                         ((type === "folder" && storage.capabilities.add_folder) ||
-                            (type !== "folder" && storage.capabilities.upload_file)),
-                    self.files.storageOptions()
+                            (type !== "folder" && storage.capabilities.upload_file))
                 )
             );
 
@@ -627,12 +627,12 @@ $(function () {
                 (type == "folder" && capabilities.remove_folder);
             const crossStorageMovePossible = _.any(
                 _.map(
+                    self.files.storageOptions(),
                     (storage) =>
                         storage.key !== data.origin &&
                         ((type === "folder" && storage.capabilities.add_folder) ||
                             (type !== "folder" && storage.capabilities.upload_file)) &&
-                        inStorageRemovePossible,
-                    self.files.storageOptions()
+                        inStorageRemovePossible
                 )
             );
 
@@ -837,8 +837,8 @@ $(function () {
             const files = self.selectedFiles();
             if (files.length === 0) return;
 
-            const hasFiles = _.any(_.map((f) => f.type !== "folder", files));
-            const hasFolders = _.any(_.map((f) => f.type === "folder", files));
+            const hasFiles = _.any(_.map(files, (f) => f.type !== "folder"));
+            const hasFolders = _.any(_.map(files, (f) => f.type === "folder"));
 
             const location = files[0].origin;
             const capabilities = self.files.storageCapabilities(location);
@@ -882,14 +882,14 @@ $(function () {
             const storageOptions = self.files.storageOptions();
             selectStorageElement.empty();
             _.each(storageOptions, (storage) => {
-                if (storage === location && !inStorageActionPossible) {
+                if (storage.key === location && !inStorageActionPossible) {
                     // skip current storage if it doesn't support copy/move
                     return;
                 }
                 if (
-                    storage !== location &&
-                    ((hasFiles && !self.files.storageCanUpload(storage)) ||
-                        (hasFolders && !self.files.storageCanAddFolder(storage)))
+                    storage.key !== location &&
+                    ((hasFiles && !self.files.storageCanUpload(storage.key)) ||
+                        (hasFolders && !self.files.storageCanAddFolder(storage.key)))
                 ) {
                     // skip other storages that can't write files or add folders
                     return;

--- a/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
+++ b/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
@@ -737,7 +737,7 @@ $(function () {
                                     "Creating new folder %(filename)s failed: %(error)s"
                                 ),
                                 {
-                                    filename: _.escape(`local:${value}`),
+                                    filename: _.escape(`${storage}:${value}`),
                                     error: _.escape(_errorFromJqXHR(jqXHR))
                                 }
                             )
@@ -997,7 +997,7 @@ $(function () {
                 ),
                 _.sprintf(
                     gettext(
-                        "Copying %%(filename)s to %(storage)s:%(destination)s failed: %(error)s"
+                        "Copying %%(filename)s to %(storage)s:%(destination)s failed: %%(error)s"
                     ),
                     {storage, destination}
                 ),
@@ -1053,7 +1053,7 @@ $(function () {
                 ),
                 _.sprintf(
                     gettext(
-                        "Moving %%(filename)s to %(storage)s:%(destination)s failed: %(error)s"
+                        "Moving %%(filename)s to %(storage)s:%(destination)s failed: %%(error)s"
                     ),
                     {storage, destination}
                 ),

--- a/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
+++ b/src/octoprint/plugins/uploadmanager/static/js/uploadmanager.js
@@ -546,8 +546,9 @@ $(function () {
             if (!selected || selected.length !== 1) return false;
 
             const data = selected[0];
+            if (data.type !== "machinecode") return false;
 
-            return data.type == "machinecode" && printAfterLoad
+            return printAfterLoad
                 ? self.files.enableSelectAndPrint(data, printAfterLoad)
                 : self.files.enableSelect(data);
         };

--- a/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
+++ b/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
@@ -108,9 +108,11 @@
                 </div>
 
                 <div class="btn-group">
-                    <a class="btn btn-small"
-                       title="{{ _('Download') |edq }}"
-                       data-bind="attr: {href: $root.downloadUrl }, css: { disabled: !$root.enableDownload() }"><i class="fa-solid fa-cloud-arrow-down"></i></a>
+                    <button class="btn btn-small"
+                            title="{{ _('Download') |edq }}"
+                            data-bind="click: function() { $root.download(); }, css: { disabled: !$root.enableDownload() }">
+                        <i class="fa-solid fa-cloud-arrow-down"></i>
+                    </button>
                 </div>
 
                 <div class="btn-group">

--- a/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
+++ b/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
@@ -216,7 +216,7 @@
                         <!-- /ko -->
 
                         <!-- ko foreach: $root.filesAndFolders -->
-                        <tr data-bind="click.single: $root.handleSingleClick, click.double: $root.handleDoubleClick, event: { contextmenu: $root.handleContextMenu }, css: { 'info': $root.isSelected($data) }, template: { name: $root.templateFor($data), data: $data }, style: { 'font-weight': $root.listHelper.isSelected($data) ? 'bold' : 'normal' }">
+                        <tr data-bind="click.single: $root.handleSingleClick, click.double: $root.handleDoubleClick, css: { 'info': $root.isSelected($data) }, template: { name: $root.templateFor($data), data: $data }, style: { 'font-weight': $root.listHelper.isSelected($data) ? 'bold' : 'normal' }">
                         </tr>
                         <!-- /ko -->
                     </tbody>

--- a/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
+++ b/src/octoprint/plugins/uploadmanager/templates/uploadmanager.jinja2
@@ -61,7 +61,7 @@
                 <div class="btn-group">
                     <button class="btn btn-small"
                             title="{{ _('Create Folder') |edq }}"
-                            data-bind="click: $root.showAddFolderDialog, css: { disabled: !$root.loginState.isUser() }">
+                            data-bind="click: $root.showAddFolderDialog, css: { disabled: !$root.loginState.isUser() || !$root.currentStorageCanAddFolder() }">
                         <i class="fa-solid fa-folder-plus"></i>
                     </button>
                 </div>


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the following multiple bugs in the upload manager:
- Missing use of the `currentStorageCanAddFolder` variable in the Jinja template. The "Create Folder" button was always clickable even for storages that do not support folders (e.g., Printer).
- Use of `<a>` instead of `<button>` for the download button. Selecting a file in a storage that does not support downloads (e.g., Printer) and clicking the "Download" button, even though it appeared disabled due to styling, caused a page reload because `href` was empty.
- Inverted parameter order in `_.map()` calls. This bug caused disallowed storages to appear in the copy/move dialog for cross-storage operations. For example, selecting a folder in Local storage and trying to copy it would show Printer among the destination storages even though it does not support folders.
- Due to an incorrect check, the "Load" and "Load and Print" buttons were incorrectly enabled even for non-gcode files (e.g., STL models).
- Minor fixes (use `var` instead of declaring global functions, fix error messages, remove the `contextmenu` event binding that pointed to a non-existent function).

For review convenience, each bug is fixed in a separate commit.

These bugs affect only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Before the PR:
- The "Create Folder" button was clickable even in the Printer storage
- The "Download" button was clickable even when disabled and caused a page refresh
- Trying to copy/move a folder from Local storage showed Printer storage among the destinations
- Selecting a folder kept the "Load" and "Load and Print" buttons enabled

After applying the PR:
- The "Create Folder" button is no longer clickable in the Printer storage
- The "Download" button is no longer clickable when it should not be
- Trying to copy/move a folder from Local storage no longer shows Printer storage among the destinations
- Selecting a folder now correctly disables the "Load" and "Load and Print" buttons

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
