### PR TITLE
fix: wrong FILE_SELECTED path on printer upload

### DIFF
--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -373,7 +373,7 @@ class PrinterFileStorage(StorageInterface):
 
         try:
             remote = self._connection.upload_printer_file(
-                temp.name, path, progress_callback=callback
+                temp.name, path, file_object.filename, progress_callback=callback
             )
             self._update_last_activity()
             return remote

--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -534,7 +534,13 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             return None
 
     def upload_printer_file(
-        self, source, target, progress_callback: callable = None, *args, **kwargs
+        self,
+        source,
+        target,
+        source_filename,
+        progress_callback: callable = None,
+        *args,
+        **kwargs,
     ) -> str:
         if progress_callback is not None:
             self._progress_callback = progress_callback
@@ -552,7 +558,8 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             tags = kwargs.get("tags", set()) | {"trigger:printer.add_sd_file"}
             return self._comm.startFileTransfer(
                 source,
-                target,
+                source_filename,
+                remote=target,
                 special=not valid_file_type(target, "gcode"),
                 tags=tags,
             )

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -645,6 +645,7 @@ class PrinterFilesMixin:
         self,
         path_or_file: Union[str, IO],
         path: str,
+        source_filename: str,
         progress_callback: callable,
         *args,
         **kwargs,

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1152,7 +1152,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         else:
             # no plugin feels responsible, use the default implementation
             local = self._file_manager.path_on_disk(FileDestinations.LOCAL, filename)
-            remote = connection.upload_printer_file(local, path)
+            remote = connection.upload_printer_file(local, path, filename)
             return remote
 
     @util.deprecated(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

While trying to copy the file "a.gcode" from Local to Printer storage, I got this stacktrace:

~~~stacktrace
2026-03-11 23:44:08,192 - octoprint.printer.standard.job - INFO - Print job selected - origin: local, path: a.gco, owner: None, user: None
2026-03-11 23:44:08,194 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Operational" to "Sending file to SD"
2026-03-11 23:44:08,198 - octoprint.plugins.serial_connector.serial_comm - INFO - Finished in 0.006 s. Approx. transfer rate of 164.314 lines/s or 6.086 ms per line
2026-03-11 23:44:08,199 - octoprint.plugins.file_check - WARNING - Error raised by native grep, falling back to python implementation: grep: /home/user/.octoprint/upload/a.gco: No such file or directory
2026-03-11 23:44:08,199 - octoprint.plugins.file_check - ERROR - Something unexpectedly went wrong while trying to search for {travel_speed} in /home/user/.octoprint/upload/a.gco
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/octoprint_file_check/__init__.py", line 376, in _search_through_file
    return self._search_through_file_python(path, compiled)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/octoprint_file_check/__init__.py", line 387, in _search_through_file_python
    with open(path, encoding="utf8", errors="replace") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.octoprint/upload/a.gco'
2026-03-11 23:44:08,200 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Printing" to "Operational"
2026-03-11 23:44:08,202 - octoprint.plugins.file_check - WARNING - Error raised by native grep, falling back to python implementation: grep: /home/user/.octoprint/upload/a.gco: No such file or directory
2026-03-11 23:44:08,203 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
2026-03-11 23:44:08,206 - octoprint.plugins.file_check - ERROR - Something unexpectedly went wrong while trying to search for ;\s+printhost_apikey\s+=\s+\S+ in /home/user/.octoprint/upload/a.gco
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/octoprint_file_check/__init__.py", line 376, in _search_through_file
    return self._search_through_file_python(path, compiled)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/octoprint_file_check/__init__.py", line 387, in _search_through_file_python
    with open(path, encoding="utf8", errors="replace") as f:
         ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
FileNotFoundError: [Errno 2] No such file or directory: '/home/user/.octoprint/upload/a.gco'
~~~

I immediately wondered why the stacktraces referenced the file `a.gco` instead of `a.gcode` when looking for it (and obviously not finding it) in Local storage.


I reconstructed the call flow that is triggered when performing a cross-storage copy:

1. In the filemanager, `_action_across_storage` calls:
https://github.com/OctoPrint/OctoPrint/blob/13ba11973e014c7f13396bde29d5eeecbc015254/src/octoprint/filemanager/__init__.py#L1259-L1266
Here the only reference to `a.gcode` is in `source_wrapper.filename`. `destination_in_storage` has already been shortened to `a.gco`, the name the file will have in the destination Printer storage.

2. `add_file(self, path, file_object, allow_overwrite=False, progress_callback=None, *args, **kwargs)` in printer.py creates a temporary file and calls:
https://github.com/OctoPrint/OctoPrint/blob/13ba11973e014c7f13396bde29d5eeecbc015254/src/octoprint/filemanager/storage/printer.py#L375-L377
Here `temp.name` is the random name of the temporary file and `path` is `a.gco`. Any reference to the original name, `a.gcode`, is no longer passed along the call chain from this point on.

3. connector.py receives the request in `upload_printer_file(self, source, target, progress_callback: callable = None, *args, **kwargs)` and calls:
https://github.com/OctoPrint/OctoPrint/blob/13ba11973e014c7f13396bde29d5eeecbc015254/src/octoprint/plugins/serial_connector/connector.py#L553-L558
Here `source` is the random name of the temporary file and `target` is `a.gco`.

4. serial_comm.py receives the request in `startFileTransfer(self, path_or_file, filename, remote=None, special=False, tags=None)` and calls:
https://github.com/OctoPrint/OctoPrint/blob/13ba11973e014c7f13396bde29d5eeecbc015254/src/octoprint/plugins/serial_connector/serial_comm.py#L1622-L1627
Here both `filename` and `remote` are `a.gco`.

5. connector.py receives the callback in `on_comm_file_transfer_started(self, local_filename, remote_filename, filesize, user=None)` and does:
https://github.com/OctoPrint/OctoPrint/blob/13ba11973e014c7f13396bde29d5eeecbc015254/src/octoprint/plugins/serial_connector/connector.py#L720-L728
Here `storage` is `LOCAL`, but `path` is `a.gco`, the one from the PRINTER storage!
The call to `set_job(job)` triggers `on_printer_job_changed()` in standard.py. `set_job` therefore fires `Events.FILE_SELECTED` with the wrong filename, causing both the incorrect logs (`Print job selected - origin: local, path: a.gco`) and the `octoprint_file_check` plugin being triggered on a file that does not exist.


This PR proposes adding the `source_filename` parameter to the `upload_printer_file()` function (step 3 of the reconstructed call flow) and updates all callers. This function only exists in the `dev` branch, so there are no backwards compatibility concerns with any plugins that might use it. The call to `startFileTransfer()` from the connector is also fixed, so that it uses `source_filename` as `target` and `target` as `remote`.

This whole bug exists only in `dev`branch.

#### How was it tested? How can it be tested by the reviewer?

I tested this PR both by uploading a file named `a.gcode` and by copying/moving it from Local to Printer storage.
The file is correctly uploaded/copied/moved and appears in Printer storage with the expected name `a.gco`.
I also verified that the "already existing" file detection still works, as well as the overwrite checkbox in the filemanager.
These are the logs after applying the PR. As shown, the logs now report the correct path and the file_check plugin no longer crashes:
~~~stacktrace
2026-03-12 00:06:28,234 - octoprint.printer.standard.job - INFO - Print job selected - origin: local, path: b.gcode, owner: None, user: None
2026-03-12 00:06:28,239 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Operational" to "Sending file to SD"
2026-03-12 00:06:28,241 - octoprint.plugins.serial_connector.serial_comm - INFO - Finished in 0.008 s. Approx. transfer rate of 131.066 lines/s or 7.630 ms per line
2026-03-12 00:06:28,242 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Printing" to "Operational"
2026-03-12 00:06:28,243 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
