### PR TITLE
fix(coreui): reset cached file key on job unselect

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -430,6 +430,7 @@ $(function () {
                 }
             } else {
                 self.filedata(undefined);
+                self._cachedFileKey = undefined;
             }
         };
 


### PR DESCRIPTION
### Please review this PR after merging #5294, because that bug masks this one.

<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that when copying a file from Local to Printer Storage, deleting it in the Printer storage, and copying it again, during the second copy the State sidebar remained unpopulated (`File` empty, `Uploaded` unknown, no preview, etc).

This happens because the cached file key is not reset on job unselect, and therefore on the second copy, since `futureFileKey`===`self._cachedFileKey`, `self._loadFileData()` was not being called.

This PR fixes this bug by resetting the cached file key on job unselect.

This bug was introduced by commit 50c784ac9 and is therefore present since OctoPrint 1.11.4 (I think it is therefore bugfix release relevant).

#### How was it tested? How can it be tested by the reviewer?

The bug described in this PR is reproducible only after merging #5294, since the bug fixed by that PR always caused the file not to be selected in the State sidebar during cross-storage operations.

Steps to reproduce:
1. Copy a file from Local to Printer storage via the filemanager plugin
2. At the end of the copy, delete the file in the Printer storage
3. Copy the same file again

Before the PR: the State sidebar remains empty during the second copy.

After applying the PR: the State sidebar is correctly populated for both copies.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
