### PR TITLE
fix(serial): chamber/custom temps were None in gcode scripts

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -382,6 +382,8 @@ class TemperatureRecord:
     def copy_from(self, other):
         self._tools = other.tools
         self._bed = other.bed
+        self._chamber = other.chamber
+        self._custom = other.custom
 
     def set_tool(self, tool, actual=None, target=None):
         current = self._tools.get(tool, (None, None))


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that the gcode scripts `afterPrintPaused` and `afterPrintCancelled` were getting `None` when trying to access the chamber temperature (actual or target).

This was due to a bug that is fixed by this PR. The bug was also present in `main`, but in `util/comm.py` instead of `plugins/serial_connector/serial_comm.py`, so this PR is not backportable as a bugfix.

#### How was it tested? How can it be tested by the reviewer?

1. Enable the chamber in the virtual printer settings:
```yaml
  virtual_printer:
    _config_version: 1
    enabled: true
    hasChamber: true
```

2. Go to *OctoPrint Settings -> GCODE Scripts -> After print job is paused* and set the following script:
```
M117 pauseStart
M117 bed_actual={{ pause_temperature.b.actual }}
M117 bed_target={{ pause_temperature.b.target }}
M117 chamber_actual={{ pause_temperature.c.actual }}
M117 chamber_target={{ pause_temperature.c.target }}
M117 pauseEnd
```

3. Start a print, pause it and look at the Terminal tab.

Output in the Terminal tab before this PR:
```
>>> M117 pauseStart
<<< echo:pauseStart
<<< ok
>>> M117 bed_actual=60.0
<<< echo:bed_actual=60.0
<<< ok
>>> M117 bed_target=60.0
<<< echo:bed_target=60.0
<<< ok
>>> M117 chamber_actual=None
<<< echo:chamber_actual=None
<<< ok
>>> M117 chamber_target=None
<<< echo:chamber_target=None
<<< ok
>>> M117 pauseEnd
<<< echo:pauseEnd
```

After this PR:
```
>>> M117 pauseStart
<<< echo:pauseStart
<<< ok
>>> M117 bed_actual=60.0
<<< echo:bed_actual=60.0
<<< ok
>>> M117 bed_target=60.0
<<< echo:bed_target=60.0
<<< ok
>>> M117 chamber_actual=30.0
<<< echo:chamber_actual=30.0
<<< ok
>>> M117 chamber_target=30.0
<<< echo:chamber_target=30.0
<<< ok
>>> M117 pauseEnd
<<< echo:pauseEnd
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
