### PR TITLE
fix(storage): fix wrong storage on UploadJob

### DIFF
--- a/docs/events/index.rst
+++ b/docs/events/index.rst
@@ -415,7 +415,7 @@ FileSelected
 
    * ``name``: the file's name
    * ``path``: the file's path within its storage location
-   * ``origin``: the origin storage location of the file, either ``local`` or ``sdcard``
+   * ``origin``: the origin storage location of the file, either ``local`` or ``printer``
 
    .. versionchanged:: 1.4.0
 
@@ -423,25 +423,31 @@ FileDeselected
    No file is selected any more for printing.
 
 TransferStarted
-   A file transfer to the printer's SD has started.
+   A file transfer to the printer's storage has started.
 
    Payload:
 
-   * ``local``: the file's name as stored locally
-   * ``remote``: the file's name as stored on SD
+   * ``remote``: the file's name as stored on the printer
 
    **Note:** Name changed in version 1.1.0
 
    .. versionchanged:: 1.1.0
 
+   .. versionchanged:: 2.0.0
+
+      Deprecated ``local`` payload, it's always the same as ``remote``.
+
 TransferDone
-   A file transfer to the printer's SD has finished.
+   A file transfer to the printer's storage has finished.
 
    Payload:
 
    * ``time``: the time it took for the transfer to complete in seconds
-   * ``local``: the file's name as stored locally
-   * ``remote``: the file's name as stored on SD
+   * ``remote``: the file's name as stored on the printer
+
+   .. versionchanged:: 2.0.0
+
+      Deprecated ``local`` payload, it's always the same as ``remote``.
 
 .. _sec-events-available_events-printing:
 

--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -724,12 +724,11 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         self, local_filename, remote_filename, filesize, user=None
     ):
         job = UploadJob(
-            storage=FileDestinations.LOCAL,
-            path=local_filename,
+            storage=FileDestinations.PRINTER,
+            path=remote_filename,
             display=local_filename,
             size=filesize,
             owner=user,
-            remote_path=remote_filename,
         )
         super().set_job(job)
         self._listener.on_printer_files_upload_start(job)

--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -726,7 +726,7 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         job = UploadJob(
             storage=FileDestinations.PRINTER,
             path=remote_filename,
-            display=local_filename,
+            display=remote_filename,
             size=filesize,
             owner=user,
         )

--- a/src/octoprint/printer/job.py
+++ b/src/octoprint/printer/job.py
@@ -40,7 +40,7 @@ class PrintJob(BaseModel):
 
 
 class UploadJob(PrintJob):
-    remote_path: Optional[str] = None
+    pass
 
 
 class JobProgress(BaseModel):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1825,6 +1825,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                             origin=None,
                             size=None,
                             date=None,
+                            upload=None,
                         ),
                         estimatedPrintTime=None,
                         filament=None,
@@ -1863,6 +1864,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                         date=int(job.date.astimezone(None).timestamp())
                         if job.date
                         else None,
+                        upload=isinstance(job, UploadJob),
                     ),
                     estimatedPrintTime=estimatedPrintTime,
                     filament=filament,

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1584,7 +1584,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
     def on_printer_files_upload_start(self, job: UploadJob):
         eventManager().fire(
             Events.TRANSFER_STARTED,
-            {"local": job.path, "remote": job.remote_path},
+            {"local": job.path, "remote": job.path},  # local is deprecated as of 2.0.0
         )
 
         self._sdStreaming = True
@@ -1604,20 +1604,26 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
     ):
         self._sdStreaming = False
 
-        payload = {"local": job.path, "remote": job.remote_path, "time": elapsed}
+        payload = {
+            "local": job.path,
+            "remote": job.path,
+            "time": elapsed,
+        }  # local is deprecated as of 2.0.0
 
         if failed:
             eventManager().fire(Events.TRANSFER_FAILED, payload)
             if callable(self._streamingFailedCallback):
                 self._streamingFailedCallback(
-                    job.path, job.remote_path, FileDestinations.PRINTER
+                    job.path, job.path, FileDestinations.PRINTER
                 )
+                self._streamingFailedCallback = self._streamingFinishedCallback = None
         else:
             eventManager().fire(Events.TRANSFER_DONE, payload)
             if callable(self._streamingFinishedCallback):
                 self._streamingFinishedCallback(
-                    job.path, job.remote_path, FileDestinations.PRINTER
+                    job.path, job.path, FileDestinations.PRINTER
                 )
+                self._streamingFailedCallback = self._streamingFinishedCallback = None
 
         self._set_job_data(None)
         self._update_progress_data()

--- a/src/octoprint/schema/api/job.py
+++ b/src/octoprint/schema/api/job.py
@@ -16,6 +16,8 @@ class ApiJobFile(BaseModel):
     """Size of the file being printed in bytes"""
     date: Optional[int] = None
     """Last modification date of the file being printed as timestamp"""
+    upload: Optional[bool] = None
+    """Whether this file is currently being uploaded (true) or already available on the storage (false)"""
 
 
 class ApiJobInfo(BaseModel):

--- a/src/octoprint/server/api/job.py
+++ b/src/octoprint/server/api/job.py
@@ -116,6 +116,7 @@ def _get_api_job_response() -> apischema.ApiJobResponse:
         origin=file_data.get("origin"),
         size=file_data.get("size"),
         date=file_data.get("date"),
+        upload=file_data.get("upload"),
     )
 
     job_data = current_data["job"]

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1929,10 +1929,9 @@ $(function () {
                 title: gettext("Streaming done"),
                 text: _.sprintf(
                     gettext(
-                        "Streamed %(local)s to %(remote)s on SD, took %(time).2f seconds"
+                        "Streamed %(remote)s to printer storage, took %(time).2f seconds"
                     ),
                     {
-                        local: _.escape(payload.local),
                         remote: _.escape(payload.remote),
                         time: payload.time
                     }
@@ -1951,8 +1950,8 @@ $(function () {
             new PNotify({
                 title: gettext("Streaming failed"),
                 text: _.sprintf(
-                    gettext("Did not finish streaming %(local)s to %(remote)s on SD"),
-                    {local: _.escape(payload.local), remote: _.escape(payload.remote)}
+                    gettext("Did not finish streaming %(remote)s to printer storage"),
+                    {remote: _.escape(payload.remote)}
                 ),
                 type: "error"
             });

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -412,7 +412,7 @@ $(function () {
 
         self._cachedFileKey = undefined;
         self._syncMetadata = (data) => {
-            if (data.file && data.file.origin && data.file.path) {
+            if (data.file && data.file.origin && data.file.path && !data.file.upload) {
                 const futureFileKey = self.calcFileKey(data.file);
                 if (futureFileKey !== self._cachedFileKey) {
                     const currentFileKey = self.calcFileKey();


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Changes the `UploadJob`'s storage to `printer` when uploading to the printer's SD card, deprecates `local` key on related event payloads and adjusts frontend accordingly.

#### How was it tested? How can it be tested by the reviewer?

Uploading files to the printer from the UI.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

Hahahaha... no.

#### Any background context you want to provide?

As discussed in #5294

#### What are the relevant tickets if any?

#5294

#### Screenshots (if appropriate)

#### Further notes

Draft for now as dinner's ready and I can't wait for tests, CI, do your thing.