### PR TITLE
fix(coreui): always re-query uploadButton from DOM

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1750,9 +1750,9 @@ $(function () {
                 self.loginState.hasPermission(self.access.permissions.FILES_UPLOAD) &&
                 self.currentStorageCanUpload()
             ) {
-                self.uploadButton.fileupload("enable");
+                self.uploadButton().fileupload("enable");
             } else {
-                self.uploadButton.fileupload("disable");
+                self.uploadButton().fileupload("disable");
             }
         };
 
@@ -1810,7 +1810,9 @@ $(function () {
 
             //~~ Gcode upload
 
-            self.uploadButton = $("#gcode_upload");
+            // Must re-query the DOM element on each call because jQuery File Upload
+            // clones and replaces the file input after every file selection.
+            self.uploadButton = () => $("#gcode_upload");
 
             self.dropOverlay = $("#drop_overlay");
             self.dropZone = $("#drop");
@@ -1961,7 +1963,7 @@ $(function () {
         };
 
         self._setDropzone = (enable) => {
-            const button = self.uploadButton;
+            const button = self.uploadButton();
             const url = API_BASEURL + "files/" + self.currentStorage();
 
             if (button === undefined) return;

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -1811,7 +1811,9 @@ $(function () {
             //~~ Gcode upload
 
             // Must re-query the DOM element on each call because jQuery File Upload
-            // clones and replaces the file input after every file selection.
+            // clones and replaces the file input after every file selection
+            //
+            // See https://github.com/blueimp/jQuery-File-Upload/wiki/Frequently-Asked-Questions#why-is-the-file-input-field-cloned-and-replaced-after-each-selection
             self.uploadButton = () => $("#gcode_upload");
 
             self.dropOverlay = $("#drop_overlay");


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug in the frontend.

Reproduction steps:
1. Upload a `a.gcode` file to local storage by clicking the upload button in the sidebar (no drag-and-drop).
2. Switch to printer storage via the sidebar and upload a `b.gcode` file, again using the upload button (no drag-and-drop).
3. The `b.gcode` file is incorrectly uploaded to local storage instead of printer storage.

This happens because `onStartup()` sets `self.uploadButton = $("#gcode_upload")`, but when the upload button is clicked, the jQuery File Upload plugin [replaces it with a clone](https://github.com/blueimp/jQuery-File-Upload/wiki/Frequently-Asked-Questions#why-is-the-file-input-field-cloned-and-replaced-after-each-selection), and the reference is lost. When the user subsequently select the printer storage (point 2 in the flow described above), `_setDropzone()` sets the `url` property to the broken reference and not to the newly cloned button.

#### How was it tested? How can it be tested by the reviewer?

See above steps to reproduce.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
