### PR TITLE
fix(coreui): use correct storage in rename check

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -2026,7 +2026,7 @@ $(function () {
             };
 
             // Collect an item from the queue that needs an overwrite dialog
-            const {data, response, path, fileSizeTooBig} =
+            const {data, response, path, storage, fileSizeTooBig} =
                 self._uploadExistsQueue.shift();
             const file = data.files[0];
 
@@ -2068,7 +2068,7 @@ $(function () {
 
                     if (!newName) return;
 
-                    OctoPrint.files.exists("local", path, newName).done(function (r) {
+                    OctoPrint.files.exists(storage, path, newName).done(function (r) {
                         if (r.exists) {
                             $(".control-group", self.uploadExistsDialog).addClass(
                                 "error"
@@ -2122,6 +2122,7 @@ $(function () {
                                 data,
                                 response,
                                 path,
+                                storage,
                                 fileSizeTooBig
                             };
                             self._uploadExistsQueue.push(queueEntry);


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [ ] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR replaces the hardcoded "local" storage with the actual selected storage when checking file existence in the rename dialog.

This bug caused the existence check to always be performed on local storage, even when the rename dialog appeared for an upload operation targeting the printer storage.

Reproduction steps:
1. Upload a file called `b.gcode` to local storage.
2. Upload a file called `a.gcode` to printer storage.
3. Try uploading a file called `a.gcode` again to printer storage. The `File already exists: a.gcode` dialog will appear. Enter `b.gcode` as the new filename and click the `upload(rename)` button. The error `File already exists` will appear because the existence of `b.gcode` is erroneously checked in local storage instead of printer storage.

#### How was it tested? How can it be tested by the reviewer?

See above steps to reproduce.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
