### PR TITLE
fix(serial): PrintingGcodeFileInformation._size was wrong

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -6027,7 +6027,7 @@ class PrintingGcodeFileInformation(PrintingFileInformation):
         if self._handle:
             self._start_pos = self._pos = self._handle.tell()
 
-            self._handle.seek(os.SEEK_END)
+            self._handle.seek(0, whence=os.SEEK_END)
             self._size = self._handle.tell()
             self._handle.seek(self._pos)
         else:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug in [`PrintingGcodeFileInformation`](https://github.com/OctoPrint/OctoPrint/blob/82b1296f3db3604194eced01692d15db092001b8/src/octoprint/plugins/serial_connector/serial_comm.py#L5993).

The `_size` property was always calculated as `2` (the value of `os.SEEK_END`) due to a typo: `seek(os.SEEK_END)` instead of `seek(0, os.SEEK_END)`.

This had no real impact on the current core code, since files always arrived in this class passed by path.

#### How was it tested? How can it be tested by the reviewer?

Place the following file in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import io

import octoprint.plugin


class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
):
    def on_after_startup(self):
        self._trigger_bug()

    def _trigger_bug(self):
        gcode_content = b"G28\nG1 X10 Y10 Z0.2 F3000\n" * 1000
        file_obj = io.BytesIO(gcode_content)

        from octoprint.plugins.serial_connector.serial_comm import (
            PrintingGcodeFileInformation,
        )

        info = PrintingGcodeFileInformation(file_obj)

        self._logger.info(
            "=== BUG REPRO RESULTS ===\n"
            "  Real gcode size: %d bytes\n"
            "  Reported size: %d bytes\n",
            len(gcode_content),
            info._size,
        )


__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Look at OctoPrint logs.

Before this fix:
```stacktrace
2026-03-13 15:35:11,651 - octoprint.plugins.bug_repro - INFO - === BUG REPRO RESULTS ===
  Real gcode size: 26000 bytes
  Reported size: 2 bytes
```

After this fix:
```stacktrace
  
2026-03-13 15:40:44,300 - octoprint.plugins.bug_repro - INFO - === BUG REPRO RESULTS ===
  Real gcode size: 26000 bytes
  Reported size: 26000 bytes
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

Yep, I let Claude Opus 4.6 generate the above test plugin.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
