### PR TITLE
fix(serial): fix crash on action disconnect

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -755,7 +755,7 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         )
 
     def on_comm_force_disconnect(self):
-        self._listener.on_printer_disconnected()
+        self._listener.on_printer_disconnect()
 
     def on_comm_record_fileposition(self, origin, name, pos):
         self._listener.on_printer_record_recovery_position(self.current_job, pos)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in serial connector that occured when OctoPrint received `// action:disconnect` from the printer.

The right name of the method to call on printer disconnection is `on_printer_disconnect()`, [defined by connection.py](https://github.com/OctoPrint/OctoPrint/blob/82b1296f3db3604194eced01692d15db092001b8/src/octoprint/printer/connection.py#L145), not `on_printer_disconnected()`.

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Connect to virtual printer and type the following command in the Terminal tab to simulate a printer-initiated disconnection: `M118 // action:disconnect`

Before this fix, it causes a crash:
~~~stacktrace
2026-03-13 17:16:03,716 - octoprint.plugins.serial_connector.serial_comm - INFO - Disconnecting on request of the printer...
2026-03-13 17:16:03,716 - octoprint.plugins.serial_connector.serial_comm - ERROR - Something crashed inside the serial connection loop, please report this in OctoPrint's bug tracker:
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 2491, in _monitor
    self._callback.on_comm_force_disconnect()
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/connector.py", line 758, in on_comm_force_disconnect
    self._listener.on_printer_disconnected()
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'Printer' object has no attribute 'on_printer_disconnected'. Did you mean: 'on_printer_disconnect'?
~~~

Logs after the fix (not crashing anymore):
~~~stacktrace
2026-03-13 17:17:24,508 - octoprint.plugins.serial_connector.serial_comm - INFO - Disconnecting on request of the printer...
2026-03-13 17:17:24,508 - octoprint.filemanager - INFO - Removed storage manager for printer
2026-03-13 17:17:24,510 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Operational" to "Offline"
2026-03-13 17:17:24,510 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
2026-03-13 17:17:24,512 - octoprint.server - INFO - Starting autorefresh of connection options
2026-03-13 17:17:24,512 - octoprint.plugins.action_command_notification - INFO - Notifications cleared
2026-03-13 17:17:24,514 - octoprint.server - INFO - Connection options were updated, refreshing the connection options in the frontend
2026-03-13 17:17:24,518 - octoprint.plugins.virtual_printer.VirtualPrinter - INFO - Closing down read loop
2026-03-13 17:17:24,773 - octoprint.plugins.virtual_printer.VirtualPrinter - INFO - Closing down buffer loop
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
