### PR TITLE
fix(serial): supportResendsWithoutOk setting is a string

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -685,9 +685,7 @@ class MachineCom:
         self._busy_protocol_detected = False
         self._busy_protocol_support = False
 
-        self._trigger_ok_after_resend = self._settings.get_boolean(
-            ["supportResendsWithoutOk"]
-        )
+        self._trigger_ok_after_resend = self._settings.get(["supportResendsWithoutOk"])
         self._resend_ok_timer = None
 
         self._resendActive = False


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Per config schema`serial.supportResendsWithoutOk` setting is a string, not a boolean:

https://github.com/OctoPrint/OctoPrint/blob/82b1296f3db3604194eced01692d15db092001b8/src/octoprint/plugins/serial_connector/config_schema.py#L205-L206

https://github.com/OctoPrint/OctoPrint/blob/82b1296f3db3604194eced01692d15db092001b8/src/octoprint/plugins/serial_connector/config_schema.py#L7-L10

This PR fix a point of code in the new serial connector when it was loaded as a boolean. This bug affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Not really tested

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
