### PR TITLE
fix(printer): fix crash in printer.get_connection_options()

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -840,7 +840,7 @@ class PrinterMixin(CommonPrinterMixin):
         message="get_connection_option has been deprecated and will be removed in a future version. Please use ConnectedPrinter.all() in combination with get_connection_option on the returned ConnectPrinter instances instead.",
         since="1.12.0",
     )
-    def get_connection_options(cls):
+    def get_connection_options(cls, *args, **kwargs):
         from .connection import ConnectedPrinter
 
         serial_connector = ConnectedPrinter.find("serial")
@@ -857,7 +857,7 @@ class PrinterMixin(CommonPrinterMixin):
         if settings().get(["printerConnection", "preferred", "connector"]) == "serial":
             preferred = settings().get(["printerConnection", "preferred", "parameters"])
 
-        connection_options = serial_connector.get_connection_options()
+        connection_options = serial_connector.connection_options()
         ports = connection_options.get("port", [])
         baudrates = connection_options.get("baudrate", [])
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash that occured when a plugin calls the deprecated `self._printer.get_connection_options()` method.
This affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Place the following script in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import octoprint.plugin

class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
):
    def on_after_startup(self):
        print("=== BUG REPRO ===")

        connection_options = octoprint.printer.get_connection_options()
        print(connection_options)

__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Before the fix of this PR, this appears in logs:
~~~stacktrace
=== BUG REPRO ===
2026-03-13 20:03:21,893 - octoprint.plugin - ERROR - Error while calling plugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 9, in on_after_startup
    connection_options = octoprint.printer.get_connection_options()
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: module 'octoprint.printer' has no attribute 'get_connection_options'
~~~

After this PR:
~~~stacktrace
=== BUG REPRO ===
{'ports': ['/dev/ttyS0', '/dev/ttyS1', '/dev/ttyS2', '/dev/ttyS3', '/dev/ttyS4', '/dev/ttyS5', '/dev/ttyS6', '/dev/ttyS7', '/dev/ttyS8', '/dev/ttyS9', '/dev/ttyS10', '/dev/ttyS11', '/dev/ttyS12', '/dev/ttyS13', '/dev/ttyS14', '/dev/ttyS15', '/dev/ttyS16', '/dev/ttyS17', '/dev/ttyS18', '/dev/ttyS19', '/dev/ttyS20', '/dev/ttyS21', '/dev/ttyS22', '/dev/ttyS23', '/dev/ttyS24', '/dev/ttyS25', '/dev/ttyS26', '/dev/ttyS27', '/dev/ttyS28', '/dev/ttyS29', '/dev/ttyS30', '/dev/ttyS31', 'VIRTUAL'], 'baudrates': [250000, 230400, 115200, 57600, 38400, 19200], 'portPreference': 'VIRTUAL', 'baudratePreference': '', 'autoconnect': True}
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
