### PR TITLE
fix(pmgr): fix python mismatch

### DIFF
--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -1151,7 +1151,7 @@ class PluginManagerPlugin(
             return result
 
         if is_python_mismatch(stderr):
-            return self.handle_python_mismatch(source, source_type, partial=partial)
+            return self._handle_python_mismatch(source, source_type, partial=partial)
 
         if force:
             # We don't use --upgrade here because that will also happily update all our dependencies - we'd rather
@@ -1174,7 +1174,7 @@ class PluginManagerPlugin(
                 return result
 
             if is_python_mismatch(stderr):
-                return self.handle_python_mismatch(source, source_type)
+                return self._handle_python_mismatch(source, source_type, partial=partial)
 
         result_line = get_result_line(stdout)
         if not result_line:

--- a/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
+++ b/src/octoprint/plugins/pluginmanager/static/js/pluginmanager.js
@@ -1701,7 +1701,7 @@ $(function () {
                                 gettext(
                                     "You can find more info on this issue in the FAQ at %(url)s"
                                 ),
-                                {url: faq}
+                                {url: response.faq}
                             ),
                             stream: "error"
                         });
@@ -1836,7 +1836,9 @@ $(function () {
                             : '<i class="fa fa-remove"></i>'
                     }) +
                     (step.result === false && step.faq
-                        ? ' (<a href="" target="_blank" rel="noopener noreferrer">' +
+                        ? ' (<a href="' +
+                          encodeURI(step.faq) +
+                          '" target="_blank" rel="noopener noreferrer">' +
                           gettext("Why?") +
                           "</a>)"
                         : "") +


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes two bugs that occurred when installing a plugin with a mismatching Python version.
A crash would occur due to calls with the wrong name of the `_handle_python_mismatch` method, and the FAQ links in the pnotify notification would remain empty.

These bugs are also present in `main` (bugfix release relevant).

#### How was it tested? How can it be tested by the reviewer?

Install via the Upload Manager file upload a plugin with the following `setup.py`:
```py
from setuptools import setup
setup(
    name="OctoPrint-python_mismatch",
    version="0.1.0",
    packages=["octoprint_python_mismatch"],
    python_requires=">=4.0",
    entry_points={
        "octoprint.plugin": [
            "python_mismatch = octoprint_python_mismatch"
        ]
    },
)
```
For convenience, I have prepared the following zip ready to upload&install: [python_mismatch.zip](https://github.com/user-attachments/files/25981743/python_mismatch.zip)

Before the fix:

~~~stacktrace
2026-03-13 20:29:34,300 - octoprint.plugins.pluginmanager - ERROR - Unexpected error while trying to install plugin from /tmp/tmpog_39o4c/python_mismatch.zip
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/pluginmanager/__init__.py", line 979, in command_install
    result = self._command_install_archive(
        path,
    ...<7 lines>...
        from_repo=from_repo,
    )
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/pluginmanager/__init__.py", line 1154, in _command_install_archive
    return self.handle_python_mismatch(source, source_type, partial=partial)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'PluginManagerPlugin' object has no attribute 'handle_python_mismatch'. Did you mean: '_handle_python_mismatch'?
~~~

And the pnotify error notification contained a "Why?" link with no href.

After the fix:

~~~stacktrace
2026-03-13 21:22:53,157 - octoprint.plugins.pluginmanager - ERROR - Installing the plugin from /tmp/tmpt05i4pwx/python_mismatch.zip failed, pip reported a Python version mismatch
~~~

And the "Why?" link in the pnotify error notification has the correct href.


#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
