### PR TITLE
fix(printer): add connection guard to change_tool and set_temperature

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -701,6 +701,9 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         self._connection.extrude(amount, speed=speed, tags=tags)
 
     def change_tool(self, tool, tags=None, *args, **kwargs):
+        if self._connection is None:
+            return
+
         if not PrinterMixin.valid_tool_regex.match(tool):
             raise ValueError(f'tool must match "tool[0-9]+": {tool}')
 
@@ -711,6 +714,9 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         self._connection.change_tool(tool, tags=tags)
 
     def set_temperature(self, heater, value, tags=None, *args, **kwargs):
+        if self._connection is None:
+            return
+
         if not PrinterMixin.valid_heater_regex.match(heater):
             raise ValueError(
                 'heater must match "tool", "tool([0-9])", "bed" or "chamber": {heater}'.format(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I found that `change_tool()` and `set_temperature()` were the only two functions in `Printer` class that required a printer connection and that forgot to check whether one actually existed. This PR adds checks to ensure that `_connection` is not `None`, thus preventing crashes if third-party plugins call these two functions.

This bug affects only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Place the following script in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import octoprint.plugin

class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.SimpleApiPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")

    def get_api_commands(self):
        return {}

    def on_api_get(self, request):
        action = request.args.get("action")

        # /api/plugin/bug_repro?action=change_tool
        if action == "change_tool":
            self._printer.change_tool("tool0")

        # /api/plugin/bug_repro?action=set_temperature
        elif action == "set_temperature":
            self._printer.set_temperature("tool0", 200)

__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Disconnect the printer and curl `/api/plugin/bug_repro?action=change_tool` and `/api/plugin/bug_repro?action=set_temperature`.

Before the fixes contained in this PR, the following crashes occur:
~~~stacktrace
2026-03-14 00:21:39,250 - octoprint.server.api - ERROR - Error calling SimpleApiPlugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/__init__.py", line 103, in pluginData
    response = api_plugin.on_api_get(request)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 18, in on_api_get
    self._printer.change_tool("tool0")
    ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/__init__.py", line 460, in wrapper
    return f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/standard.py", line 711, in change_tool
    self._connection.change_tool(tool, tags=tags)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'change_tool'
2026-03-14 00:21:39,254 - tornado.access - ERROR - 500 GET /api/plugin/bug_repro?action=change_tool (127.0.0.1) 4.99ms
~~~

~~~stacktrace
2026-03-14 00:22:14,749 - octoprint.server.api - ERROR - Error calling SimpleApiPlugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/__init__.py", line 103, in pluginData
    response = api_plugin.on_api_get(request)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 22, in on_api_get
    self._printer.set_temperature("tool0", 200)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/__init__.py", line 460, in wrapper
    return f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/standard.py", line 728, in set_temperature
    self._connection.set_temperature(heater, value, tags=tags)
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'set_temperature'
2026-03-14 00:22:14,752 - tornado.access - ERROR - 500 GET /api/plugin/bug_repro?action=set_temperature (127.0.0.1) 5.44ms
~~~

I verified that they don't occur anymore after applying this PR.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

Yes, I asked Claude Opus 4.6 to generate the above test plugin file.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
