### PR TITLE
fix(printer): jog was always relative

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -663,7 +663,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             tags = set()
         tags |= {"trigger:printer.jog"}
 
-        self._connection.jog(axes, relative=True, speed=speed, tags=tags)
+        self._connection.jog(axes, relative=relative, speed=speed, tags=tags)
 
     def home(self, axes, tags=None, *args, **kwargs):
         if self._connection is None:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug that caused printer jog operations to be always relative, even if `printer.jog()` was called with `relative` parameter set to `False`.

This bug affects only the `dev` branch, since it has been introduced by the giant comm refactoring commit.

#### How was it tested? How can it be tested by the reviewer?

Call the following API and check the output in Terminal tab:
```bash
curl -X POST http://localhost:8081/api/printer/printhead \
-H "Content-Type: application/json" \
-H "X-Api-Key: YOUR_API_KEY" \
-d '{"command": "jog", "x": 100, "absolute": true}'
```

Before applying this PR:
```
>>> G91
<<< ok
>>> G0 X100 F6000
<<< ok
>>> G90
<<< ok
```
Please note that `G91 (Relative Positioning)` has been sent to the printer even if we specified `"absolute": true` in the API command.

After applying this PR:
```
>>> G90
<<< ok
>>> G0 X100 F6000
<<< ok
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
