### PR TITLE
fix: fix terminal suppression

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -4278,10 +4278,10 @@ class MachineCom:
 
         if ret != "":
             try:
-                self._log(f"<<< {sanitize_ascii(ret)}")
+                self._log(f"Recv: {sanitize_ascii(ret)}")
             except ValueError as e:
                 self._log(f"WARN: While reading last line: {e}")
-                self._log(f"<<< {ret!r}")
+                self._log(f"Recv: {ret!r}")
 
             if null_pos >= 0:
                 self._logger.warning("Received line:")
@@ -5116,7 +5116,7 @@ class MachineCom:
             return
 
         if log:
-            self._log(">>> " + cmd.decode(self._serial_encoding))
+            self._log("Send: " + cmd.decode(self._serial_encoding))
 
         cmd += b"\n"
         written = 0


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Suppression checkboxes in Terminal tab were not working anymore because regexes were looking for `Recv:` and `Send:` but since 0b12b9494 the serial connector was logging `<<<` and `>>>`.
This PR proposes to revert to `Recv:` and `Send:` to fix this bug.

To be honest, I preferred `<<<` and `>>>` myself, because they were shorter and not language (English) dependent. However, I did a quick `grep` and found out that some known plugins (`atxpihat`, `bettergrblsupport`, `prettygcode`, `terminalmessaging`) actually read theese logs and look for the old format. So, if we want to keep the new format, I think it should be warned as a breaking change. Also we'll need to update multiple residues in the codebase and documentation that still references `Recv:` and `Send:`.

This bug affected only the `dev` branch. 

#### How was it tested? How can it be tested by the reviewer?

Connect to the virtual printer, go to the Terminal tab and check all the suppression checkboxes. Before this fix they don't work. After this fix they work.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
