### PR TITLE
fix(printer): forward job params in toggle_pause_print

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -400,9 +400,9 @@ class CommonPrinterMixin:
             tags (set of str): An optional set of tags to attach to the command(s) throughout their lifecycle
         """
         if self.is_printing():
-            self.pause_print(*args, tags=tags, **kwargs)
+            self.pause_print(*args, tags=tags, params=params, **kwargs)
         elif self.is_paused():
-            self.resume_print(*args, tags=tags, **kwargs)
+            self.resume_print(*args, tags=tags, params=params, **kwargs)
 
     def cancel_print(self, tags: set[str] = None, params: dict = None, *args, **kwargs):
         """


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Job params were added in 39d4d73 to provide printer connector  specific additional parameters. However, they were being lost in `toggle_pause_print()` and never reached the printer connector in case of toggle pause operations.  Since `params` is a named parameter in the signature of `toggle_pause_print()`, it is captured there and excluded from `**kwargs`, so the internal calls  to `pause_print()`/`resume_print()` - which only forwarded `*args`, `tags` and `**kwargs` - silently dropped it.

This bug affected only `dev` branch.


#### How was it tested? How can it be tested by the reviewer?

Since the only built-in connector, the serial connector, doesn't use job parameters, I don't know how to test them. Perhaps this bug impacted custom connectors, e.g., Bambu or Klipper, but I've never looked at their code. The pytests all pass both before and after this PR.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

This bug was caught while reviewing commits history.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
