### PR TITLE
fix(printer): fix ErrorInformation field types

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -82,9 +82,9 @@ ERROR_FAQS = {
 class ErrorInformation(BaseModel):
     error: str
     reason: str
-    consequence: str = None
-    faq: str = Optional[None]
-    logs: list[str] = Optional[None]
+    consequence: Optional[str] = None
+    faq: Optional[str] = None
+    logs: Optional[list[str]] = None
 
 
 class FirmwareInformation(BaseModel):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the invalid `ErrorInformation` pydantic schema, which caused a crash when any communication error occurred in the connector.

The schema is set correctly in the `main` branch:

https://github.com/OctoPrint/OctoPrint/blob/4bef84e2966fc2eee8c8e7eed2c4f21be6a9c159/src/octoprint/printer/standard.py#L38-L43

It was somehow broken in the `dev` branch:

https://github.com/OctoPrint/OctoPrint/blob/82b1296f3db3604194eced01692d15db092001b8/src/octoprint/printer/__init__.py#L82-L87

#### How was it tested? How can it be tested by the reviewer?

Try connecting to a serial port which is not a printer, e.g., in my case `/dev/ttyS31`.

Before this fix:
- The pnotify notification "Could not autodetect your printer" doesn't appear
- Logs show the following stacktrace:
~~~stacktrace
2026-03-15 23:37:28,383 - octoprint.plugins.serial_connector.serial_comm - INFO - Failed to connect: Port /dev/ttyS31 is busy or does not exist
2026-03-15 23:37:28,383 - octoprint.plugins.serial_connector.serial_comm - INFO - Serial detection: Could not open port /dev/ttyS31, baudrate 19200, skipping
2026-03-15 23:37:28,383 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Detecting serial connection" to "Error"
Traceback (most recent call last):
  File "/usr/lib/python3.14/threading.py", line 1082, in _bootstrap_inner
    self._context.run(self.run)
    ~~~~~~~~~~~~~~~~~^^^^^^^^^^
  File "/usr/lib/python3.14/threading.py", line 1024, in run
    self._target(*self._args, **self._kwargs)
    ~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 2334, in _monitor
    self._perform_detection_step(init=True)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 3606, in _perform_detection_step
    self._trigger_error(error_text, "autodetect")
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 4214, in _trigger_error
    self._callback.on_comm_error(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        text,
        ^^^^^
    ...<3 lines>...
        logs=payload.get("logs"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/connector.py", line 669, in on_comm_error
    self.error_info = ErrorInformation(
                      ~~~~~~~~~~~~~~~~^
        error=error, reason=reason, consequence=consequence, faq=faq, logs=logs
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )  # this will call the listener
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 2 validation errors for ErrorInformation
faq
  Input should be a valid string [type=string_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
logs
  Input should be a valid list [type=list_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/list_type
~~~

After this fix:
- The pnotify notification "Could not autodetect your printer" correctly appears
- Logs are as follow (no more crashes):
~~~stacktrace
2026-03-15 23:48:56,508 - octoprint.plugins.serial_connector.serial_comm - INFO - Failed to connect: Port /dev/ttyS31 is busy or does not exist
2026-03-15 23:48:56,508 - octoprint.plugins.serial_connector.serial_comm - INFO - Serial detection: Could not open port /dev/ttyS31, baudrate 19200, skipping
2026-03-15 23:48:56,508 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Detecting serial connection" to "Error"
2026-03-15 23:48:56,509 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Error" to "Offline after error"
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
