### PR TITLE
fix: PRINT_FAILED event not fired on connection fails

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -655,6 +655,8 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             ConnectedPrinterState.CLOSED,
             ConnectedPrinterState.CLOSED_WITH_ERROR,
         }:
+            self.set_state(state, error=error_str)  # this will call the listener
+
             if self._comm is not None:
                 self._comm = None
 
@@ -662,6 +664,7 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             self.error_info = None
 
             super().set_job(None)
+            return
 
         self.set_state(state, error=error_str)  # this will call the listener
 

--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -651,12 +651,12 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         if self._comm is not None:
             error_str = self._comm.getErrorString()
 
+        self.set_state(state, error=error_str)  # this will call the listener
+
         if state in {
             ConnectedPrinterState.CLOSED,
             ConnectedPrinterState.CLOSED_WITH_ERROR,
         }:
-            self.set_state(state, error=error_str)  # this will call the listener
-
             if self._comm is not None:
                 self._comm = None
 
@@ -664,9 +664,6 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
             self.error_info = None
 
             super().set_job(None)
-            return
-
-        self.set_state(state, error=error_str)  # this will call the listener
 
     def on_comm_error(self, error, reason, consequence=None, faq=None, logs=None):
         self.error_info = ErrorInformation(

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -31,6 +31,7 @@ from octoprint.printer import (
     PrinterMixin,
 )
 from octoprint.printer.connection import (
+    PRINTING_STATES,
     ConnectedPrinter,
     ConnectedPrinterListenerMixin,
     ConnectedPrinterState,
@@ -1194,10 +1195,8 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
     ):
         old_state = self._state
 
-        if old_state in {
-            ConnectedPrinterState.PRINTING,
-        }:
-            # if we were still printing and went into an error state, mark the print as failed
+        if old_state in PRINTING_STATES:
+            # if we were in any print-related state and went into an error state, mark the print as failed
             if state in {
                 ConnectedPrinterState.CLOSED,
                 ConnectedPrinterState.ERROR,
@@ -1253,11 +1252,6 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             if self._connection is not None:
                 self._connection = None
 
-            with self._selected_job_mutex:
-                if self._selected_job is not None:
-                    eventManager().fire(Events.FILE_DESELECTED)
-                self._set_job_data(None)
-
             self._update_progress_data()
             self._set_offsets(None)
             self._add_temperature_data()
@@ -1283,10 +1277,12 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                 )
             )
         else:
-            eventManager().fire(Events.FILE_DESELECTED)
-            self._logger_job.info(
-                "Print job deselected - user: {}".format(user if user else "n/a")
-            )
+            with self._selected_job_mutex:
+                if self._selected_job is not None:
+                    eventManager().fire(Events.FILE_DESELECTED)
+                    self._logger_job.info(
+                        "Print job deselected - user: {}".format(user if user else "n/a")
+                    )
 
         self._set_job_data(
             job,

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1252,6 +1252,8 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             if self._connection is not None:
                 self._connection = None
 
+            self.on_printer_job_changed(None)
+
             self._update_progress_data()
             self._set_offsets(None)
             self._add_temperature_data()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes two bugs that caused the `PRINT_FAILED` event to never fire on connection errors (`M112`, USB disconnect, etc.):

1. In `connector.py`, `on_comm_state_change()` cleared the job (`set_job(None)`) before changing state (`set_state()`), so `_selected_job` was already `None` when `on_printer_state_changed()` checked it. Fixed by moving cleanup after `set_state()`.

2. In `standard.py`, `on_printer_state_changed()` only checked for `PRINTING` state, missing `PAUSED`, `PAUSING`, `RESUMING`, `STARTING`, `CANCELLING` and `FINISHING`. Fixed by using `PRINTING_STATES`.

Also removed `FILE_DESELECTED` event firing from `on_printer_state_changed()` to avoid double emission: both `on_printer_state_changed()` and `on_printer_job_changed()` (called via `set_job(None)`) were firing the event independently. Job deselection is now handled entirely by `on_printer_job_changed()`.

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Place the following file in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import octoprint.plugin

class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.EventHandlerPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")

    def on_event(self, event, payload): 
        self._logger.info(f"Received event {event} with payload {payload}")

__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Run a print on the virtual printer, go to the terminal and send `M112` command. Check OctoPrint logs.

Before this PR, sending M112 while printing, `PRINT_FAILED` was not fired:
~~~stacktrace
2026-03-16 15:57:55,487 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'PRINTING', 'state_string': 'Printing'}
[...]
2026-03-16 15:58:03,100 - octoprint.plugins.serial_connector.serial_comm - INFO - Force-sending M112 to the printer
2026-03-16 15:58:03,102 - octoprint.plugins.bug_repro - INFO - Received event UpdatedFiles with payload {'type': 'printables'}
2026-03-16 15:58:03,103 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Printing" to "Offline after error"
2026-03-16 15:58:03,103 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
2026-03-16 15:58:03,104 - octoprint.plugins.bug_repro - INFO - Received event FileDeselected with payload None
[...]
2026-03-16 15:58:03,106 - octoprint.plugins.bug_repro - INFO - Received event Disconnected with payload None
2026-03-16 15:58:03,106 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'CLOSED_WITH_ERROR', 'state_string': 'Offline'}
2026-03-16 15:58:03,107 - octoprint.plugins.bug_repro - INFO - Received event EStop with payload None
2026-03-16 15:58:03,109 - octoprint.server - INFO - Connection options were updated, refreshing the connection options in the frontend
2026-03-16 15:58:03,110 - octoprint.plugins.bug_repro - INFO - Received event PrintFailed with payload {'name': '3DBenchy_150um_MINI_PLA_2h.gcode', 'path': '3DBenchy_150um_MINI_PLA_2h.gcode', 'origin': 'local', 'size': 4593839, 'reason': 'error', 'error': 'unknown', 'time': 5.685002303998772, 'progress': 0.0}
2026-03-16 16:22:12,951 - octoprint.server - INFO - Connection options were updated, refreshing the connection options in the frontend
~~~

Before this PR, sending M112 while print is paused, `PRINT_FAILED` was not fired:
~~~stacktrace
2026-03-16 16:32:46,661 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'PAUSED', 'state_string': 'Paused'}
2026-03-16 16:32:54,529 - octoprint.plugins.serial_connector.serial_comm - INFO - Force-sending M112 to the printer
2026-03-16 16:32:54,531 - octoprint.plugins.virtual_printer.VirtualPrinter - INFO - Closing down read loop
2026-03-16 16:32:54,532 - octoprint.plugins.bug_repro - INFO - Received event UpdatedFiles with payload {'type': 'printables'}
2026-03-16 16:32:54,532 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Paused" to "Offline after error"
2026-03-16 16:32:54,532 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
2026-03-16 16:32:54,534 - octoprint.server - INFO - Starting autorefresh of connection options
2026-03-16 16:32:54,535 - octoprint.plugins.action_command_notification - INFO - Notifications cleared
2026-03-16 16:32:54,535 - octoprint.plugins.bug_repro - INFO - Received event Disconnected with payload None
2026-03-16 16:32:54,536 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'CLOSED_WITH_ERROR', 'state_string': 'Offline'}
2026-03-16 16:32:54,536 - octoprint.plugins.bug_repro - INFO - Received event FileDeselected with payload None
2026-03-16 16:32:54,536 - octoprint.plugins.bug_repro - INFO - Received event EStop with payload None
2026-03-16 16:32:54,759 - octoprint.plugins.virtual_printer.VirtualPrinter - INFO - Closing down buffer loop
~~~


After this PR, sending M112 while printing, `PRINT_FAILED` is correctly fired:
~~~stacktrace
2026-03-16 16:22:07,562 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'PRINTING', 'state_string': 'Printing'}
[...]
2026-03-16 16:22:12,938 - octoprint.plugins.serial_connector.serial_comm - INFO - Force-sending M112 to the printer
2026-03-16 16:22:12,940 - octoprint.plugins.bug_repro - INFO - Received event UpdatedFiles with payload {'type': 'printables'}
2026-03-16 16:22:12,941 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Printing" to "Offline after error"
2026-03-16 16:22:12,941 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
[...]
2026-03-16 16:22:12,944 - octoprint.plugins.bug_repro - INFO - Received event Disconnected with payload None
2026-03-16 16:22:12,944 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'CLOSED_WITH_ERROR', 'state_string': 'Offline'}
2026-03-16 16:22:12,945 - octoprint.plugins.bug_repro - INFO - Received event FileDeselected with payload None
2026-03-16 16:22:12,945 - octoprint.plugins.bug_repro - INFO - Received event EStop with payload None
2026-03-16 16:22:12,948 - octoprint.plugins.bug_repro - INFO - Received event MetadataStatisticsUpdated with payload {'storage': 'local', 'path': '3DBenchy_150um_MINI_PLA_2h.gcode'}
2026-03-16 16:22:12,948 - octoprint.timelapse - INFO - Enabled rendering queue processing
2026-03-16 16:22:12,950 - octoprint.plugins.bug_repro - INFO - Received event PrintFailed with payload {'name': '3DBenchy_150um_MINI_PLA_2h.gcode', 'path': '3DBenchy_150um_MINI_PLA_2h.gcode', 'origin': 'local', 'size': 4593839, 'reason': 'error', 'error': 'unknown', 'time': 5.407658370997524, 'progress': 0.0}
2026-03-16 16:22:12,951 - octoprint.server - INFO - Connection options were updated, refreshing the connection options in the frontend
~~~

After this PR, sending M112 while print is paused, `PRINT_FAILED` is correctly fired:
~~~stacktrace
2026-03-16 16:37:31,726 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'PAUSED', 'state_string': 'Paused'}
2026-03-16 16:37:36,296 - octoprint.plugins.serial_connector.serial_comm - INFO - Force-sending M112 to the printer
2026-03-16 16:37:36,298 - octoprint.plugins.bug_repro - INFO - Received event UpdatedFiles with payload {'type': 'printables'}
2026-03-16 16:37:36,299 - octoprint.plugins.virtual_printer.VirtualPrinter - INFO - Closing down read loop
2026-03-16 16:37:36,299 - octoprint.plugins.serial_connector.serial_comm - INFO - Changing monitoring state from "Paused" to "Offline after error"
2026-03-16 16:37:36,300 - octoprint.printer.standard.job - INFO - Print job deselected - user: n/a
2026-03-16 16:37:36,300 - octoprint.server - INFO - Starting autorefresh of connection options
2026-03-16 16:37:36,306 - octoprint.plugins.action_command_notification - INFO - Notifications cleared
2026-03-16 16:37:36,306 - octoprint.plugins.bug_repro - INFO - Received event Disconnected with payload None
2026-03-16 16:37:36,306 - octoprint.plugins.bug_repro - INFO - Received event PrinterStateChanged with payload {'state_id': 'CLOSED_WITH_ERROR', 'state_string': 'Offline'}
2026-03-16 16:37:36,307 - octoprint.plugins.bug_repro - INFO - Received event FileDeselected with payload None
2026-03-16 16:37:36,307 - octoprint.plugins.bug_repro - INFO - Received event EStop with payload None
2026-03-16 16:37:36,307 - octoprint.plugins.bug_repro - INFO - Received event MetadataStatisticsUpdated with payload {'storage': 'local', 'path': '3DBenchy_150um_MINI_PLA_2h.gcode'}
2026-03-16 16:37:36,307 - octoprint.timelapse - INFO - Enabled rendering queue processing
2026-03-16 16:37:36,313 - octoprint.plugins.bug_repro - INFO - Received event PrintFailed with payload {'name': '3DBenchy_150um_MINI_PLA_2h.gcode', 'path': '3DBenchy_150um_MINI_PLA_2h.gcode', 'origin': 'local', 'size': 4593839, 'reason': 'error', 'error': 'unknown', 'time': 21.66119983400131, 'progress': 0.0}
2026-03-16 16:37:36,319 - octoprint.server - INFO - Connection options were updated, refreshing the connection options in the frontend
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
