### PR TITLE
fix(access): disallow cyclic subgrouping

### DIFF
--- a/src/octoprint/access/groups.py
+++ b/src/octoprint/access/groups.py
@@ -516,6 +516,16 @@ class GroupCantBeChanged(Exception):
         Exception.__init__(self, "Group can't be changed: %s" % key)
 
 
+class CyclicSubgroupReference(Exception):
+    def __init__(self, key, subgroup_key):
+        Exception.__init__(
+            self,
+            "Adding subgroup {} to group {} would create a cycle".format(
+                subgroup_key, key
+            ),
+        )
+
+
 class Group:
     def __init__(
         self,
@@ -636,6 +646,18 @@ class Group:
 
         return dirty
 
+    def has_subgroup_transitive(self, key, seen=None):
+        """Check if key appears in this group's transitive subgroup chain."""
+        if seen is None:
+            seen = set()
+        if self._key in seen:
+            return False
+        seen.add(self._key)
+        for subgroup in self._subgroups:
+            if subgroup._key == key or subgroup.has_subgroup_transitive(key, seen):
+                return True
+        return False
+
     def add_subgroups_to_group(self, subgroups):
         """Adds a list of subgroups to a group"""
         if not self.is_changeable():
@@ -653,6 +675,8 @@ class Group:
 
         dirty = False
         for group in subgroups:
+            if group._key == self._key or group.has_subgroup_transitive(self._key):
+                raise CyclicSubgroupReference(self._key, group._key)
             if group.is_toggleable() and group not in self._subgroups:
                 self._subgroups.append(group)
                 dirty = True

--- a/src/octoprint/server/api/access.py
+++ b/src/octoprint/server/api/access.py
@@ -69,6 +69,8 @@ def add_group():
         )
     except groups.GroupAlreadyExists:
         abort(409)
+    except groups.CyclicSubgroupReference:
+        abort(409)
     return get_groups()
 
 
@@ -112,6 +114,8 @@ def update_group(key):
         abort(403)
     except groups.UnknownGroup:
         abort(404)
+    except groups.CyclicSubgroupReference:
+        abort(409)
 
 
 @api.route("/access/groups/<key>", methods=["DELETE"])

--- a/src/octoprint/static/js/app/viewmodels/access.js
+++ b/src/octoprint/static/js/app/viewmodels/access.js
@@ -568,12 +568,49 @@ $(function () {
                     }
                     self.editor.permissions(permissions);
                 },
+                subgroupUnselectableReason: function (subgroup) {
+                    if (!subgroup.toggleable)
+                        return gettext(
+                            "Fixed groups can't be added to or removed from other groups."
+                        );
+
+                    var key = self.editor.key();
+                    if (!key) return "";
+
+                    if (key === subgroup.key)
+                        return gettext("A group cannot be its own subgroup.");
+                    if (key === GROUP_GUESTS && subgroup.dangerous)
+                        return gettext(
+                            "Dangerous subgroups cannot be added to the guests group."
+                        );
+
+                    // check if adding this subgroup would create a cycle
+                    var hasSubgroupTransitive = function (groupKey, seen) {
+                        if (!seen) seen = {};
+                        if (groupKey in seen) return false;
+                        seen[groupKey] = true;
+                        var group = self.lookup[groupKey];
+                        if (!group) return false;
+                        for (var i = 0; i < group.subgroups.length; i++) {
+                            var subgroupKey = group.subgroups[i];
+                            if (
+                                subgroupKey === key ||
+                                hasSubgroupTransitive(subgroupKey, seen)
+                            )
+                                return true;
+                        }
+                        return false;
+                    };
+                    if (hasSubgroupTransitive(subgroup.key)) {
+                        return gettext(
+                            "Adding this subgroup would create a circular reference."
+                        );
+                    }
+
+                    return "";
+                },
                 subgroupSelectable: function (subgroup) {
-                    // guests may not get dangerous subgroups
-                    return (
-                        self.editor.key() !== subgroup.key &&
-                        (self.editor.key() !== GROUP_GUESTS || !subgroup.dangerous)
-                    );
+                    return !self.editor.subgroupUnselectableReason(subgroup);
                 },
                 subgroupSelected: function (subgroup) {
                     var index = self.editor.subgroups().indexOf(subgroup);

--- a/src/octoprint/templates/snippets/settings/accesscontrol/subgroup_list.jinja2
+++ b/src/octoprint/templates/snippets/settings/accesscontrol/subgroup_list.jinja2
@@ -5,11 +5,11 @@
         <tr>
             <td class="settings_accesscontrol_subgroups_list_checkbox">
                 <input type="checkbox"
-                       data-bind="checkedValue: key, checked: $parents[1].editor.subgroups, enable: toggleable && $parents[1].editor.subgroupSelectable($data)">
+                       data-bind="checkedValue: key, checked: $parents[1].editor.subgroups, enable: toggleable && $parents[1].editor.subgroupSelectable($data), attr: {title: $parents[1].editor.subgroupUnselectableReason($data)}">
             </td>
             <td class="settings_accesscontrol_subgroups_list_name"
                 style="cursor: pointer"
-                data-bind="click: function() { if ($data.toggleable && $parents[1].editor.subgroupSelectable($data)) { $parents[1].editor.toggleSubgroup($data.key) } }, attr: {title: description}">
+                data-bind="click: function() { if ($data.toggleable && $parents[1].editor.subgroupSelectable($data)) { $parents[1].editor.toggleSubgroup($data.key) } }, attr: {title: $parents[1].editor.subgroupUnselectableReason($data) || description}">
                 <span class="name"
                       data-bind="text: name, style: { fontWeight: ($parents[1].editor.subgroupSelected($data.name)) ? 'bold' : 'normal' }"></span> <small class="label label-info"
         data-bind="visible: !$data.toggleable"

--- a/tests/access/groups/test_groupmanager.py
+++ b/tests/access/groups/test_groupmanager.py
@@ -45,3 +45,37 @@ class GroupManagerTestCase(unittest.TestCase):
 
             group_manager.remove_group("fancy")
             self.assertIsNone(group_manager.find_group("fancy"))
+
+    def test_cyclic_subgroup_self_reference(self):
+        with group_manager_with_temp_file() as group_manager:
+            group_manager.add_group(
+                "alpha",
+                "Alpha",
+                "Alpha group",
+                permissions=[],
+                subgroups=[],
+                save=False,
+            )
+            with self.assertRaises(octoprint.access.groups.CyclicSubgroupReference):
+                group_manager.update_group("alpha", subgroups=["alpha"], save=False)
+
+    def test_cyclic_subgroup_indirect(self):
+        with group_manager_with_temp_file() as group_manager:
+            group_manager.add_group(
+                "alpha",
+                "Alpha",
+                "Alpha group",
+                permissions=[],
+                subgroups=[],
+                save=False,
+            )
+            group_manager.add_group(
+                "beta",
+                "Beta",
+                "Beta group",
+                permissions=[],
+                subgroups=["alpha"],
+                save=False,
+            )
+            with self.assertRaises(octoprint.access.groups.CyclicSubgroupReference):
+                group_manager.update_group("alpha", subgroups=["beta"], save=False)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds backend and frontend checks to prevent cyclic references when configuring access subgroups.

Without these, circular references between subgroups could persistently crash OctoPrint, surviving restarts and needing manually fixing the configuration file. The following video demonstrates how it was possible:

https://github.com/user-attachments/assets/d6cc837a-ce57-42ff-83a4-418b6e450f02

This PR is bugfix release relevant.

#### How was it tested? How can it be tested by the reviewer?

See above video. Also, this PR adds two new unit tests to check that cycle detection is working correctly.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

A useful addition introduced by this PR is that by hovering the mouse over the checkboxes of the non-selectable subgroups, you get a tooltip with the reason:

<img height="400" alt="2026-03-16_23-09" src="https://github.com/user-attachments/assets/c92e8b8a-89e6-4c66-95d0-8e933b5cac9d" />
<img height="400" alt="2026-03-16_23-09_1" src="https://github.com/user-attachments/assets/ff051bad-e84f-4b0b-afc0-89600e08f7e9" />
<img height="400" alt="image" src="https://github.com/user-attachments/assets/40bc60ed-5b82-4817-b51f-5a2dbf143e53" />


#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
