### PR TITLE
fix(auth): revalidate that remote header still matches session

### DIFF
--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -48,6 +48,7 @@ import octoprint.filemanager
 import octoprint.util
 import octoprint.util.net
 from octoprint.server import util
+from octoprint.server.util.flask import server_side_logout
 from octoprint.systemcommands import system_command_manager
 from octoprint.util.json import JsonEncoding
 from octoprint.vendor.flask_principal import (  # noqa: F401
@@ -206,15 +207,21 @@ def load_user(id):
     if id == "_internal":
         return userManager.internal_user_factory()
 
-    if session and "usersession.id" in session:
-        sessionid = session["usersession.id"]
-    else:
-        sessionid = None
+    sessionid = None
+    sessionsig = ""
+    if session:
+        sessionid = session.get("usersession.id")
+        sessionsig = session.get("usersession.signature", "")
 
-    if session and "usersession.signature" in session:
-        sessionsig = session["usersession.signature"]
-    else:
-        sessionsig = ""
+        login_mechanism = session.get("login_mechanism")
+        if (
+            login_mechanism == util.LoginMechanism.REMOTE_USER
+            and id
+            != request.headers.get(settings().get(["accessControl", "remoteUserHeader"]))
+        ):
+            # remote user header doesn't match anymore, we interpret that as a logout, see #5279
+            server_side_logout(id, sessionid=sessionid)
+            return None
 
     if sessionid:
         # session["_fresh"] is False if the session comes from a remember me cookie,
@@ -1718,6 +1725,8 @@ class Server:
                 and not current_user.is_anonymous
             ):
                 return Identity(current_user.get_id())
+            else:
+                return OctoPrintAnonymousIdentity()
 
         principals.identity_loader(current_user_identity_loader)
 

--- a/src/octoprint/server/api/__init__.py
+++ b/src/octoprint/server/api/__init__.py
@@ -16,7 +16,7 @@ from flask import (
     request,
     session,
 )
-from flask_login import current_user, login_user, logout_user
+from flask_login import current_user, login_user
 from werkzeug.exceptions import HTTPException
 
 import octoprint.access.users
@@ -41,6 +41,7 @@ from octoprint.server.util.flask import (
     limit,
     no_firstrun_access,
     passive_login,
+    server_side_logout,
     session_signature,
     to_api_credentials_seen,
 )
@@ -335,7 +336,7 @@ def login():
         reauthenticate = current_user and current_user.get_id() == username
 
         if "usersession.id" in session and not reauthenticate:
-            _logout(current_user)
+            server_side_logout(current_user.get_id(), sessionid=session["usersession.id"])
 
         user = octoprint.server.userManager.find_user(username)
         if user is not None:
@@ -473,14 +474,9 @@ def logout():
     username = None
     if current_user:
         username = current_user.get_id()
+        server_side_logout(username, sessionid=session.get("usersession.id"))
 
-    # logout from user manager...
-    _logout(current_user)
-
-    # ... and from flask login (and principal)
-    logout_user()
-
-    # ... and send an active logout session cookie
+    # send an active logout session cookie
     r = make_response(jsonify(octoprint.server.userManager.anonymous_user_factory()))
     r.set_cookie("active_logout", "true")
 
@@ -489,14 +485,6 @@ def logout():
         auth_log(f"Logging out user {username} from {request.remote_addr}")
 
     return r
-
-
-def _logout(user):
-    if "usersession.id" in session:
-        del session["usersession.id"]
-    if "login_mechanism" in session:
-        del session["login_mechanism"]
-    octoprint.server.userManager.logout_user(user)
 
 
 @api.route("/currentuser", methods=["GET"])

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -664,6 +664,24 @@ def _local_networks():
     return _cached_local_networks
 
 
+def server_side_logout(userid, sessionid=None):
+    from flask import session
+    from flask_login import logout_user
+
+    # log out from user manager...
+    user = octoprint.server.userManager.find_user(userid=userid, session=sessionid)
+    if user:
+        octoprint.server.userManager.logout_user(user)
+
+    # ... clear login related stuff from session...
+    session.pop("usersession.id", None)
+    session.pop("usersession.signature", None)
+    session.pop("login_mechanism", None)
+
+    # ... and log out from flask login (and principal)
+    logout_user()
+
+
 def passive_login():
     logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Checks whether the remote user header still matches the existing session user, and if not resets the session to the anonymous user.

#### How was it tested? How can it be tested by the reviewer?

I could only test with `mitmproxy`: 
- set the remote user header to one of my users: `mitmdump --mode reverse:http://localhost:5000@5555 --modify-headers "/X-Remote-User/admin"`
- checked that it got logged in when using the proxy address
- set the remote user header to a not existing user: `mitmdump --mode reverse:http://localhost:5000@5555 --modify-headers "/X-Remote-User/other"`
- checked the user was logged out

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

HELL NO

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#5279 

#### Screenshots (if appropriate)

#### Further notes

~~Still needs testing:~~
~~- other *existing* user in the header: should invalidate the existing session *but create a new one*~~

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
