### PR TITLE
fix(auth): create remote users w/o password

### DIFF
--- a/src/octoprint/access/users.py
+++ b/src/octoprint/access/users.py
@@ -19,6 +19,8 @@ from octoprint.settings import settings as s
 from octoprint.util import atomic_write, deprecated, generate_api_key, to_bytes, yaml
 from octoprint.util import get_fully_qualified_classname as fqcn
 
+NOLOGIN_PWHASH = "nologin"
+
 password_hashers = []
 
 try:
@@ -174,6 +176,8 @@ class UserManager(GroupChangeListener):
 
     @staticmethod
     def create_password_hash(password, *args, **kwargs):
+        if password is None:
+            return NOLOGIN_PWHASH
         return password_hashers[0].hash(password)
 
     @staticmethod
@@ -1226,6 +1230,9 @@ class User(UserMixin):
         }
 
     def check_password(self, password, legacy=False):
+        if self._passwordHash == NOLOGIN_PWHASH:
+            return False
+
         if legacy:
             return self._passwordHash == password
 

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -257,8 +257,8 @@ def get_user_for_remote_user_header(
 
     if user is None and settings().getBoolean(["accessControl", "addRemoteUsers"]):
         octoprint.server.userManager.add_user(
-            header, settings().generateApiKey(), active=True
-        )
+            header, None, active=True
+        )  # create new user with disabled password login
         user = octoprint.server.userManager.find_user(userid=header)
 
     if user and settings().getBoolean(["accessControl", "trustRemoteGroups"]):

--- a/tests/access/users/test_usermanager.py
+++ b/tests/access/users/test_usermanager.py
@@ -5,33 +5,44 @@ Unit tests for octoprint.access.users.UserManager
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
-import unittest
-
-import ddt
+import pytest
 
 import octoprint.access.users
 
 
-@ddt.ddt
-class UserManagerTest(unittest.TestCase):
-    def test_createPasswordHash_nonascii(self):
-        """Test for issue #1891"""
+def test_createPasswordHash_nonascii():
+    """Test for issue #1891"""
 
-        password = "password with ümläutß"
+    password = "password with ümläutß"
 
-        # should not throw an exception
-        octoprint.access.users.UserManager.create_password_hash(password)
+    # should not throw an exception
+    octoprint.access.users.UserManager.create_password_hash(password)
 
-    def test_createPasswordHash_is_valid(self):
-        password = "test1234"
-        password_hash = octoprint.access.users.UserManager.create_password_hash(password)
-        user = octoprint.access.users.User(
-            "username",
-            password_hash,
-            True,
-            permissions=[],
-            apikey="apikey",
-            settings={"key": "value"},
-        )
 
-        self.assertTrue(user.check_password(password))
+def test_createPasswordHash_is_valid():
+    password = "test1234"
+    password_hash = octoprint.access.users.UserManager.create_password_hash(password)
+    user = octoprint.access.users.User(
+        "username",
+        password_hash,
+        True,
+        permissions=[],
+        apikey="apikey",
+        settings={"key": "value"},
+    )
+
+    assert user.check_password(password)
+
+
+@pytest.mark.parametrize("password", [octoprint.access.users.NOLOGIN_PWHASH, "", None])
+def test_nologin_user_check_password_always_false(password):
+    user = octoprint.access.users.User(
+        "username",
+        octoprint.access.users.NOLOGIN_PWHASH,
+        True,
+        permissions=[],
+        apikey="apikey",
+        settings={"key": "value"},
+    )
+
+    assert not user.check_password(password)


### PR DESCRIPTION
Password can then be set by an admin if needed.

Fixes an issue discovered by @jacopotediosi: the previous code utilized the wrong method to create a password hash, basically generating a fresh global API key whenever a new remote user was added. Thankfully that feature is not much used. On the other side, if it was more used, we would have noticed this earlier for sure.

Quick and dirty PR to be able to tag something as possibly bugfix release relevant.