### PR TITLE
feat(auth): add optional trusted auth proxy config

### DIFF
--- a/src/octoprint/schema/config/access_control.py
+++ b/src/octoprint/schema/config/access_control.py
@@ -62,6 +62,18 @@ class AccessControlConfig(BaseModel):
     **ONLY ENABLE THIS** if your OctoPrint instance is only accessible through a connection locked down through an authenticating reverse proxy!
     """
 
+    trustedAuthProxies: Optional[list[str]] = None
+    """
+    Only trust the remote user header if the request came via one of these configured (trusted!) reverse proxies.
+
+    **Unset by default, meaning this will NOT be checked!** If you plan to use an auth proxy with OctoPrint,
+    be sure to also set it's IP address (or a CIDR range covering it) here!
+
+    Please note that only your **trusted reverse proxies** as defined via `server.reverseProxy.trustedProxies` and
+    `server.reverseProxy.trustLocalhostProxies` will be used for a check, so if your trusted auth proxy address
+    isn't part of your trusted reverse proxies, this check will always fail, causing remote user headers to not work!
+    """
+
     remoteUserHeader: str = "REMOTE_USER"
     """Header used by the reverse proxy to convey the authenticated user."""
 

--- a/src/octoprint/schema/config/access_control.py
+++ b/src/octoprint/schema/config/access_control.py
@@ -66,12 +66,8 @@ class AccessControlConfig(BaseModel):
     """
     Only trust the remote user header if the request came via one of these configured (trusted!) reverse proxies.
 
-    **Unset by default, meaning this will NOT be checked!** If you plan to use an auth proxy with OctoPrint,
-    be sure to also set it's IP address (or a CIDR range covering it) here!
-
-    Please note that only your **trusted reverse proxies** as defined via `server.reverseProxy.trustedProxies` and
-    `server.reverseProxy.trustLocalhostProxies` will be used for a check, so if your trusted auth proxy address
-    isn't part of your trusted reverse proxies, this check will always fail, causing remote user headers to not work!
+    If left unset, the configured trusted reverse proxies from `server.reverseProxy.trustedProxies` and `server.reverseProxy.trustLocalhostProxies`
+    will be used. Make sure this includes your auth proxy or set it explicitly here!
     """
 
     remoteUserHeader: str = "REMOTE_USER"

--- a/src/octoprint/schema/config/access_control.py
+++ b/src/octoprint/schema/config/access_control.py
@@ -59,15 +59,36 @@ class AccessControlConfig(BaseModel):
     Whether to trust remote user headers. If you have setup authentication in front of OctoPrint and the user names you use there match OctoPrint
     accounts, by setting this to true users will be logged into OctoPrint as the user provided in the header.
 
-    **ONLY ENABLE THIS** if your OctoPrint instance is only accessible through a connection locked down through an authenticating reverse proxy!
+    Make sure to add your auth proxy address(es) to `trustedAuthProxies` as well, see below!
     """
 
-    trustedAuthProxies: Optional[list[str]] = None
+    trustedAuthProxies: list[str] = []
     """
-    Only trust the remote user header if the request came via one of these configured (trusted!) reverse proxies.
+    Only trust the remote user header if the request came via one of these configured (trusted!) reverse proxie addresses or CIDR ranges.
 
-    If left unset, the configured trusted reverse proxies from `server.reverseProxy.trustedProxies` and `server.reverseProxy.trustLocalhostProxies`
-    will be used. Make sure this includes your auth proxy or set it explicitly here!
+    Must either be included in the set of trusted reverse proxies (see `server.reverseProxy.trustedProxies` and `server.reverseProxy.trustLocalhostProxies`)
+    or directly connect to OctoPrint!
+
+    **WARNING**: If left unset, the remote user header won't ever be trusted!
+
+    Examples:
+
+    ``` yaml
+    accessControl:
+      trustedAuthProxies:
+        - 127.0.0.0/8
+        - ::1
+    ```
+
+    to trust localhost.
+
+    ``` yaml
+    accessControl:
+      trustedAuthProxies:
+        - 192.168.1.128
+    ```
+
+    to trust 192.168.1.128
     """
 
     remoteUserHeader: str = "REMOTE_USER"

--- a/src/octoprint/schema/config/access_control.py
+++ b/src/octoprint/schema/config/access_control.py
@@ -54,41 +54,18 @@ class AccessControlConfig(BaseModel):
     checkBasicAuthenticationPassword: bool = True
     """Whether to also check the password provided through Basic Authentication, if the Basic Authentication header is to be trusted. Disabling this will only match the user name in the Basic Authentication header and login the user without further checks, thus disable with caution."""
 
-    trustRemoteUser: bool = False
-    """
-    Whether to trust remote user headers. If you have setup authentication in front of OctoPrint and the user names you use there match OctoPrint
-    accounts, by setting this to true users will be logged into OctoPrint as the user provided in the header.
-
-    Make sure to add your auth proxy address(es) to `trustedAuthProxies` as well, see below!
-    """
-
     trustedAuthProxies: list[str] = []
     """
-    Only trust the remote user header if the request came via one of these configured (trusted!) reverse proxie addresses or CIDR ranges.
+    If you want to setup a authenticating reverse proxy in front of OctoPrint, add its address (or CIDR range) here to enable trusting
+    the remote user header defined in ``remoteUserHeader``.
 
-    Must either be included in the set of trusted reverse proxies (see `server.reverseProxy.trustedProxies` and `server.reverseProxy.trustLocalhostProxies`)
-    or directly connect to OctoPrint!
+    Please note that your auth proxy must either also be included in the set of trusted reverse proxies (see ``server.reverseProxy.trustedProxies`` and ``server.reverseProxy.trustLocalhostProxies``)
+    or *directly* connect to OctoPrint!
 
-    **WARNING**: If left unset, the remote user header won't ever be trusted!
+    If left unset (the default), the remote user header defined in ``remoteUserHeader`` won't ever be trusted!
 
-    Examples:
-
-    ``` yaml
-    accessControl:
-      trustedAuthProxies:
-        - 127.0.0.0/8
-        - ::1
-    ```
-
-    to trust localhost.
-
-    ``` yaml
-    accessControl:
-      trustedAuthProxies:
-        - 192.168.1.128
-    ```
-
-    to trust 192.168.1.128
+    **Please note:** If you are coming from a previous version of OctoPrint that still supported the ``trustRemoteUser`` setting and you had that set to ``true``,
+    this setting will be prepopulated with your trusted reverse proxies for you during settings migration. You definitely should give this a sanity check however!
     """
 
     remoteUserHeader: str = "REMOTE_USER"

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -260,7 +260,7 @@ def load_user_from_request(request):
             return user
 
     # Remote User Header?
-    if settings().getBoolean(["accessControl", "trustRemoteUser"]):
+    if settings().get(["accessControl", "trustedAuthProxies"]):
         user = util.get_user_for_remote_user_header(request)
         if user:
             return user

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -250,19 +250,17 @@ def get_user_for_remote_user_header(
     """
     Tries to find a user based on the configured remote user request header.
 
-    Will only perform any action if the trustRemoteUser setting is enabled.
+    Will only perform any action if one or more trusted authentication proxies
+    are configured.
     """
     s = settings()
 
-    if not s.getBoolean(["accessControl", "trustRemoteUser"]):
+    trusted_auth_proxies = s.get(["accessControl", "trustedAuthProxies"])
+    if not trusted_auth_proxies:
         return None
 
     header = request.headers.get(s.get(["accessControl", "remoteUserHeader"]))
     if header is None:
-        return None
-
-    trusted_auth_proxies = s.get(["accessControl", "trustedAuthProxies"])
-    if not trusted_auth_proxies:
         return None
 
     trusted_auth_proxies = get_ipset_from_list(

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -21,7 +21,9 @@ from octoprint.settings import settings
 from octoprint.util import to_unicode
 from octoprint.util.net import (
     contains_trusted_source,
+    get_ipset_from_list,
     is_loopback_address,
+    usable_trusted_proxies,
     usable_trusted_proxies_from_settings,
 )
 
@@ -259,14 +261,30 @@ def get_user_for_remote_user_header(
     if header is None:
         return None
 
-    trusted_auth_proxy = s.get(["accessControl", "trustedAuthProxies"])
-    if trusted_auth_proxy:
-        if not contains_trusted_source(
-            trusted_auth_proxy,
-            request.headers.get("X-Forwarded-For"),
-            usable_trusted_proxies_from_settings(s),
-        ):
-            return None  # don't eval the header if this request is not coming from our trusted auth proxy
+    trusted_proxies = get_ipset_from_list(usable_trusted_proxies_from_settings(s))
+
+    trusted_auth_proxies_config = s.get(["accessControl", "trustedAuthProxies"])
+    if trusted_auth_proxies_config:
+        trusted_auth_proxies = get_ipset_from_list(
+            usable_trusted_proxies(trusted_auth_proxies_config)
+        )
+    else:
+        trusted_auth_proxies = trusted_proxies
+
+    orig_remote_addr = request.environ.get("ORIG_REMOTE_ADDR")
+    forwarded_for = request.headers.get("X-Forwarded-For")
+
+    request_via_trusted_proxy_chain_incl_auth_proxy = (
+        orig_remote_addr in trusted_proxies
+        and contains_trusted_source(trusted_auth_proxies, forwarded_for, trusted_proxies)
+    )
+    request_directly_from_auth_proxy = orig_remote_addr in trusted_auth_proxies
+
+    if not (
+        request_via_trusted_proxy_chain_incl_auth_proxy
+        or request_directly_from_auth_proxy
+    ):
+        return None  # don't eval the header if this request is not coming from our trusted auth proxy
 
     user = octoprint.server.userManager.find_user(userid=header)
 

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -261,15 +261,14 @@ def get_user_for_remote_user_header(
     if header is None:
         return None
 
-    trusted_proxies = get_ipset_from_list(usable_trusted_proxies_from_settings(s))
+    trusted_auth_proxies = s.get(["accessControl", "trustedAuthProxies"])
+    if not trusted_auth_proxies:
+        return None
 
-    trusted_auth_proxies_config = s.get(["accessControl", "trustedAuthProxies"])
-    if trusted_auth_proxies_config:
-        trusted_auth_proxies = get_ipset_from_list(
-            usable_trusted_proxies(trusted_auth_proxies_config)
-        )
-    else:
-        trusted_auth_proxies = trusted_proxies
+    trusted_auth_proxies = get_ipset_from_list(
+        usable_trusted_proxies(trusted_auth_proxies, add_localhost=False)
+    )
+    trusted_proxies = get_ipset_from_list(usable_trusted_proxies_from_settings(s))
 
     orig_remote_addr = request.environ.get("ORIG_REMOTE_ADDR")
     forwarded_for = request.headers.get("X-Forwarded-For")

--- a/src/octoprint/server/util/__init__.py
+++ b/src/octoprint/server/util/__init__.py
@@ -19,7 +19,11 @@ import octoprint.timelapse
 from octoprint.plugin import plugin_manager
 from octoprint.settings import settings
 from octoprint.util import to_unicode
-from octoprint.util.net import is_loopback_address
+from octoprint.util.net import (
+    contains_trusted_source,
+    is_loopback_address,
+    usable_trusted_proxies_from_settings,
+)
 
 from . import flask, sockjs, tornado, watchdog  # noqa: F401
 
@@ -246,28 +250,37 @@ def get_user_for_remote_user_header(
 
     Will only perform any action if the trustRemoteUser setting is enabled.
     """
-    if not settings().getBoolean(["accessControl", "trustRemoteUser"]):
+    s = settings()
+
+    if not s.getBoolean(["accessControl", "trustRemoteUser"]):
         return None
 
-    header = request.headers.get(settings().get(["accessControl", "remoteUserHeader"]))
+    header = request.headers.get(s.get(["accessControl", "remoteUserHeader"]))
     if header is None:
         return None
 
+    trusted_auth_proxy = s.get(["accessControl", "trustedAuthProxies"])
+    if trusted_auth_proxy:
+        if not contains_trusted_source(
+            trusted_auth_proxy,
+            request.headers.get("X-Forwarded-For"),
+            usable_trusted_proxies_from_settings(s),
+        ):
+            return None  # don't eval the header if this request is not coming from our trusted auth proxy
+
     user = octoprint.server.userManager.find_user(userid=header)
 
-    if user is None and settings().getBoolean(["accessControl", "addRemoteUsers"]):
+    if user is None and s.getBoolean(["accessControl", "addRemoteUsers"]):
         octoprint.server.userManager.add_user(
             header, None, active=True
         )  # create new user with disabled password login
         user = octoprint.server.userManager.find_user(userid=header)
 
-    if user and settings().getBoolean(["accessControl", "trustRemoteGroups"]):
-        groupHeader = request.headers.get(
-            settings().get(["accessControl", "remoteGroupsHeader"])
-        )
+    if user and s.getBoolean(["accessControl", "trustRemoteGroups"]):
+        groupHeader = request.headers.get(s.get(["accessControl", "remoteGroupsHeader"]))
         if groupHeader:
             groups = groupHeader.split(",")
-            mapping = settings().get(["accessControl", "remoteGroupsMapping"])
+            mapping = s.get(["accessControl", "remoteGroupsMapping"])
             if mapping:
                 groups = [mapping.get(group, group) for group in groups]
             octoprint.server.userManager.change_user_groups(header, groups)

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -904,6 +904,7 @@ class WsgiInputContainer:
             ),
             "QUERY_STRING": request.query,
             "REMOTE_ADDR": request.remote_ip,
+            "ORIG_REMOTE_ADDR": request.connection.context._orig_remote_ip,
             "SERVER_NAME": host,
             "SERVER_PORT": str(port),
             "SERVER_PROTOCOL": request.version,

--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -1238,6 +1238,7 @@ class Settings:
             self._migrate_trusted_proxies,
             self._migrate_allowlists_and_blocklists,
             self._migrate_notify_suppressed_commands,
+            self._migrate_trusted_auth_proxies,
         )
 
         for migrate in migrators:
@@ -1826,6 +1827,28 @@ class Settings:
             if "feature" not in config:
                 config["feature"] = {}
             config["feature"][key] = value
+
+        return modified
+
+    def _migrate_trusted_auth_proxies(self, config):
+        modified = False
+
+        if "accessControl" in config and "trustRemoteUser" in config["accessControl"]:
+            value = config["accessControl"].pop("trustRemoteUser")
+
+            if value and "trustedAuthProxies" not in config["accessControl"]:
+                from octoprint.util.net import usable_trusted_proxies_from_settings
+
+                trusted_proxies = usable_trusted_proxies_from_settings(self)
+                config["accessControl"]["trustedAuthProxies"] = trusted_proxies
+
+            modified = True
+
+        if modified:
+            backup_path = self.backup("trusted_auth_proxies_migration")
+            self._logger.info(
+                f"Made a copy of the current config at {backup_path} to allow recovery of trustRemoteUser"
+            )
 
         return modified
 

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -6,7 +6,7 @@ import os
 import socket
 import sys
 from collections.abc import Generator
-from typing import Optional
+from typing import Optional, Union
 
 import ifaddr
 import netaddr
@@ -372,40 +372,49 @@ def get_ipset_from_list(addresses) -> netaddr.IPSet:
     return ip_set
 
 
-def get_forwarded_for_addresses(forwarded_for):
+def get_forwarded_for_addresses(forwarded_for: str) -> list[str]:
     if forwarded_for is None:
         return []
     return [sanitize_address(addr.strip()) for addr in reversed(forwarded_for.split(","))]
 
 
-def get_trusted_forwarded_for_addresses(forwarded_for, trusted_proxies):
-    trusted_ip_set = get_ipset_from_list(trusted_proxies)
-    return [
-        addr
-        for addr in get_forwarded_for_addresses(forwarded_for)
-        if addr in trusted_ip_set
-    ]
+def get_trusted_forwarded_for_addresses(
+    forwarded_for: str, trusted_proxies: Union[list[str], netaddr.IPSet]
+) -> list[str]:
+    if not isinstance(trusted_proxies, netaddr.IPSet):
+        trusted_proxies = get_ipset_from_list(trusted_proxies)
+
+    trusted_ff = []
+    for addr in get_forwarded_for_addresses(forwarded_for):
+        if addr not in trusted_proxies:
+            break
+        trusted_ff.append(addr)
+    return trusted_ff
 
 
-def get_http_client_ip(remote_addr, forwarded_for, trusted_proxies):
-    trusted_ip_set = get_ipset_from_list(trusted_proxies)
+def get_http_client_ip(
+    remote_addr: str, forwarded_for: str, trusted_proxies: Union[list[str], netaddr.IPSet]
+) -> str:
+    if not isinstance(trusted_proxies, netaddr.IPSet):
+        trusted_proxies = get_ipset_from_list(trusted_proxies)
 
-    if sanitize_address(remote_addr) in trusted_ip_set:
+    if sanitize_address(remote_addr) in trusted_proxies:
         for addr in get_forwarded_for_addresses(forwarded_for):
-            if addr not in trusted_ip_set:
+            if addr not in trusted_proxies:
                 return addr
     return sanitize_address(remote_addr)
 
 
-def contains_trusted_source(trusted, forwarded_for, trusted_proxies):
+def contains_trusted_source(
+    trusted: netaddr.IPSet, forwarded_for: str, trusted_proxies: netaddr.IPSet
+) -> bool:
     if not trusted:
         return False
-    if not isinstance(trusted, list):
-        trusted = [trusted]
 
     trusted_forward_for = get_trusted_forwarded_for_addresses(
         forwarded_for, trusted_proxies
     )
-    trusted_set = get_ipset_from_list(trusted)
+    if not trusted_forward_for:
+        return False
 
-    return any(source in trusted_set for source in trusted_forward_for)
+    return any(source in trusted for source in trusted_forward_for)

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -373,7 +373,7 @@ def get_ipset_from_list(addresses) -> netaddr.IPSet:
 
 
 def get_forwarded_for_addresses(forwarded_for: str) -> list[str]:
-    if forwarded_for is None:
+    if forwarded_for is None or len(forwarded_for) == 0:
         return []
     return [sanitize_address(addr.strip()) for addr in reversed(forwarded_for.split(","))]
 

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -351,6 +351,11 @@ def download_file(url, folder, max_length=None, connect_timeout=3.05, read_timeo
 
 
 def get_ipset_from_list(addresses) -> netaddr.IPSet:
+    if not addresses:
+        return netaddr.IPSet()
+
+    addresses = [x for x in addresses if x]
+
     try:
         ip_set = netaddr.IPSet(addresses)
     except netaddr.AddrFormatError:
@@ -367,13 +372,40 @@ def get_ipset_from_list(addresses) -> netaddr.IPSet:
     return ip_set
 
 
+def get_forwarded_for_addresses(forwarded_for):
+    if forwarded_for is None:
+        return []
+    return [sanitize_address(addr.strip()) for addr in reversed(forwarded_for.split(","))]
+
+
+def get_trusted_forwarded_for_addresses(forwarded_for, trusted_proxies):
+    trusted_ip_set = get_ipset_from_list(trusted_proxies)
+    return [
+        addr
+        for addr in get_forwarded_for_addresses(forwarded_for)
+        if addr in trusted_ip_set
+    ]
+
+
 def get_http_client_ip(remote_addr, forwarded_for, trusted_proxies):
     trusted_ip_set = get_ipset_from_list(trusted_proxies)
 
-    if forwarded_for is not None and sanitize_address(remote_addr) in trusted_ip_set:
-        for addr in (
-            sanitize_address(addr.strip()) for addr in reversed(forwarded_for.split(","))
-        ):
+    if sanitize_address(remote_addr) in trusted_ip_set:
+        for addr in get_forwarded_for_addresses(forwarded_for):
             if addr not in trusted_ip_set:
                 return addr
     return sanitize_address(remote_addr)
+
+
+def contains_trusted_source(trusted, forwarded_for, trusted_proxies):
+    if not trusted:
+        return False
+    if not isinstance(trusted, list):
+        trusted = [trusted]
+
+    trusted_forward_for = get_trusted_forwarded_for_addresses(
+        forwarded_for, trusted_proxies
+    )
+    trusted_set = get_ipset_from_list(trusted)
+
+    return any(source in trusted_set for source in trusted_forward_for)

--- a/src/octoprint/util/net.py
+++ b/src/octoprint/util/net.py
@@ -350,19 +350,25 @@ def download_file(url, folder, max_length=None, connect_timeout=3.05, read_timeo
     return path
 
 
-def get_http_client_ip(remote_addr, forwarded_for, trusted_proxies):
+def get_ipset_from_list(addresses) -> netaddr.IPSet:
     try:
-        trusted_ip_set = netaddr.IPSet(trusted_proxies)
+        ip_set = netaddr.IPSet(addresses)
     except netaddr.AddrFormatError:
         # something's wrong with one of these addresses, let's add them one by one
-        trusted_ip_set = netaddr.IPSet()
-        for trusted_proxy in trusted_proxies:
+        ip_set = netaddr.IPSet()
+        for addr in addresses:
             try:
-                trusted_ip_set.add(trusted_proxy)
+                ip_set.add(addr)
             except netaddr.AddrFormatError:
                 logging.getLogger(__name__).error(
-                    f"Trusted proxy {trusted_proxy} is not a correctly formatted IP address or subnet"
+                    f"Address {addr} is not a correctly formatted IP address or subnet"
                 )
+
+    return ip_set
+
+
+def get_http_client_ip(remote_addr, forwarded_for, trusted_proxies):
+    trusted_ip_set = get_ipset_from_list(trusted_proxies)
 
     if forwarded_for is not None and sanitize_address(remote_addr) in trusted_ip_set:
         for addr in (

--- a/tests/server/util/test_util.py
+++ b/tests/server/util/test_util.py
@@ -69,6 +69,14 @@ def test_validate_local_redirect(url, paths, expected):
             "127.0.0.1",
             "",
             "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1"],
+            None,
+        ),  # direct from localhost, trusted auth proxy but not trusted reverse proxy (localhost not automatically added)
+        (
+            "127.0.0.1",
+            "",
+            "user",
             ["127.0.0.0/8", "::1"],
             ["127.0.0.0/8", "::1"],
             "user",

--- a/tests/server/util/test_util.py
+++ b/tests/server/util/test_util.py
@@ -1,6 +1,8 @@
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2022 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
+from unittest.mock import MagicMock, patch
+
 import pytest
 
 DEFAULT_ALLOWED_PATHS = ["/", "/recovery/", "/plugin/appkeys/auth/*"]
@@ -49,3 +51,137 @@ def test_validate_local_redirect(url, paths, expected):
     from octoprint.server.util import validate_local_redirect
 
     assert validate_local_redirect(url, paths) == expected
+
+
+@pytest.mark.parametrize(
+    "remote_addr, ff_header, remote_user_header, trusted_auth_proxies, trusted_reverse_proxies, expected",
+    [
+        ("127.0.0.1", "", "user", [], [], None),  # localhost, nothing trusted
+        (
+            "127.0.0.1",
+            "",
+            "user",
+            [],
+            ["127.0.0.0/8", "::1"],
+            None,
+        ),  # direct from localhost, no trusted auth proxy
+        (
+            "127.0.0.1",
+            "",
+            "user",
+            ["127.0.0.0/8", "::1"],
+            ["127.0.0.0/8", "::1"],
+            "user",
+        ),  # direct from localhost, trusted auth proxy
+        (
+            "192.168.1.10",
+            "",
+            "user",
+            ["127.0.0.0/8", "::1"],
+            ["127.0.0.0/8", "::1"],
+            None,
+        ),  # direct from lan, no match against trusted proxy
+        (
+            "127.0.0.1",
+            "192.168.1.10",
+            "user",
+            ["127.0.0.0/8", "::1"],
+            ["127.0.0.0/8", "::1"],
+            "user",
+        ),  # lan via proxy, trusted auth proxy
+        (
+            "127.0.0.1",
+            "10.1.2.3, 192.168.1.10",
+            "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1"],
+            None,
+            # lan via proxy, trusted auth proxy not among trusted reverse proxies
+        ),
+        (
+            "127.0.0.1",
+            "10.1.2.3, 192.168.1.10",
+            "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1", "192.168.1.10"],
+            "user",
+        ),  # lan via proxy, trusted auth proxy also trusted as reverse proxy
+        (
+            "192.168.1.10",
+            "127.0.0.1, 10.1.2.3",
+            "user",
+            ["127.0.0.0/8", "::1"],
+            ["127.0.0.0/8", "::1"],
+            None,
+        ),  # lan via untrusted reverse proxy, spoofed remote address, ignored
+        (
+            "192.168.1.10",
+            "127.0.0.1, 10.1.2.3",
+            "user",
+            ["127.0.0.0/8", "::1"],
+            ["127.0.0.0/8", "::1", "192.168.1.10"],
+            None,
+        ),  # lan via trusted reverse proxy, not trusted as auth proxy though, spoofed remote address, ignored
+    ],
+)
+def test_get_user_for_remote_user_header(
+    remote_addr,
+    ff_header,
+    remote_user_header,
+    trusted_auth_proxies,
+    trusted_reverse_proxies,
+    expected,
+):
+    from octoprint.server.util import LoginMechanism, get_user_for_remote_user_header
+    from octoprint.settings import Settings
+
+    def settings_get(path, *args, **kwargs):
+        if path == ["accessControl", "remoteUserHeader"]:
+            return "X-Remote-User"
+        elif path == ["accessControl", "trustedAuthProxies"]:
+            return trusted_auth_proxies
+        else:
+            return None
+
+    settings = MagicMock(spec=Settings)
+    settings.get.side_effect = settings_get
+
+    # mock settings
+    with patch("octoprint.server.util.settings") as settings_mock:
+        settings_mock.return_value = settings
+
+        # mock usable_trusted_proxies_from_settings
+        with patch(
+            "octoprint.server.util.usable_trusted_proxies_from_settings"
+        ) as trusted_proxies_mock:
+            trusted_proxies_mock.side_effect = (
+                lambda *args, **kwargs: trusted_reverse_proxies
+            )
+
+            # mock request
+            mocked_environ = {"ORIG_REMOTE_ADDR": remote_addr}
+            mocked_headers = {
+                "X-Forwarded-For": ff_header,
+                "X-Remote-User": remote_user_header,
+            }
+            mocked_request = MagicMock()
+            mocked_request.environ = mocked_environ
+            mocked_request.headers = mocked_headers
+
+            # mock user manager
+            with patch("octoprint.server.userManager") as user_manager_mock:
+                user_manager_mock.find_user.return_value = remote_user_header
+
+                with patch("octoprint.server.util._flask") as flask_mock:
+                    flask_mock.session = dict()
+
+                    # call function
+                    returned_user = get_user_for_remote_user_header(mocked_request)
+
+                    assert returned_user == expected
+                    if expected is not None:
+                        assert (
+                            flask_mock.session["login_mechanism"]
+                            == LoginMechanism.REMOTE_USER
+                        )
+                        assert flask_mock.session["credentials_seen"]

--- a/tests/util/test_net.py
+++ b/tests/util/test_net.py
@@ -4,6 +4,7 @@ __copyright__ = "Copyright (C) 2017 The OctoPrint Project - Released under terms
 from unittest import mock
 
 import ifaddr
+import netaddr
 import pytest
 
 import octoprint.util.net
@@ -176,6 +177,12 @@ def test_get_netmask_broken_address():
             "127.100.100.1",
         ),  # everything is trusted (BAD IDEA!)
         (
+            "127.100.100.1",
+            "10.1.2.3, 192.168.1.10",
+            netaddr.IPSet(["0.0.0.0/0"]),
+            "127.100.100.1",
+        ),  # everything is trusted (BAD IDEA!) and already an IPSet
+        (
             "192.168.1.10",
             "127.0.0.1",
             ["127.0.0.1", "::1"],
@@ -313,6 +320,26 @@ def test_get_forwarded_for_addresses(forwarded_for, expected):
             ["0.0.0.0/0"],
             ["192.168.1.10", "10.1.2.3"],
         ),  # everything is trusted (BAD IDEA!)
+        (
+            "127.0.0.1, 192.168.1.10",
+            ["127.0.0.1", "::1"],
+            [],
+        ),  # ipv4 before true lan ip
+        (
+            "::1, ::ffff:192.168.1.10",
+            ["127.0.0.1", "::1"],
+            [],
+        ),  # ipv6 before true lan ip
+        (
+            "127.0.0.1, 10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.10"],
+            ["192.168.1.10"],
+        ),  # access through trusted reverse proxies on 127.0.0.1 and 192.168.1.10, real ip 10.1.2.3, spoofed to 127.0.0.1
+        (
+            "::1, fd12:3456:789a:2::1, fd12:3456:789a:1::1",
+            ["127.0.0.1", "::1", "fd12:3456:789a:1::/64"],
+            ["fd12:3456:789a:1::1"],
+        ),  # access through trusted reverse proxies on ::1 and something on fd12:3456:789a:1::/64, spoofed to ::1
     ],
 )
 def test_get_trusted_forwarded_for_addresses(forwarded_for, trusted_proxies, expected):
@@ -330,51 +357,45 @@ def test_get_trusted_forwarded_for_addresses(forwarded_for, trusted_proxies, exp
         (
             None,
             "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             False,
         ),  # nothing is trusted
         (
-            ["192.168.1.10"],
+            netaddr.IPSet(["192.168.1.10"]),
             "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             True,
         ),  # trusted is contained in forward_for and trusted proxies
         (
-            ["127.0.0.1", "::1"],
+            netaddr.IPSet(["127.0.0.1", "::1"]),
             "10.1.2.3, 192.168.1.10, ::1",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             True,
         ),  # trusted is contained in forward_for and trusted proxies
         (
-            ["127.0.0.1", "::1"],
+            netaddr.IPSet(["127.0.0.1", "::1"]),
             "10.1.2.3, 192.168.1.10, 127.0.0.1",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             True,
         ),  # trusted is contained in forward_for and trusted proxies
         (
-            ["192.168.1.1"],
+            netaddr.IPSet(["192.168.1.1"]),
             "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             False,
         ),  # trusted is not contained in forward_for
         (
-            ["10.1.2.3"],
+            netaddr.IPSet(["10.1.2.3"]),
             "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             False,
         ),  # trusted is contained in forward_for but not trusted proxies
         (
-            ["192.168.1.0/24"],
+            netaddr.IPSet(["192.168.1.0/24"]),
             "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            netaddr.IPSet(["127.0.0.1", "::1", "192.168.1.0/24"]),
             True,
         ),  # trusted range matches ip in forward_for and in trusted proxies
-        (
-            "192.168.1.0/24",
-            "10.1.2.3, 192.168.1.10",
-            ["127.0.0.1", "::1", "192.168.1.0/24"],
-            True,
-        ),  # trusted range matches ip in forward_for and in trusted proxies, single auth proxy
     ],
 )
 def test_contains_trusted_source(trusted, forwarded_for, trusted_proxies, expected):

--- a/tests/util/test_net.py
+++ b/tests/util/test_net.py
@@ -275,6 +275,7 @@ def test_get_ipset_from_list(addresses, expected):
     [
         ("127.0.0.1, 10.1.2.3, 192.168.1.10", ["192.168.1.10", "10.1.2.3", "127.0.0.1"]),
         (None, []),
+        ("", []),
     ],
 )
 def test_get_forwarded_for_addresses(forwarded_for, expected):

--- a/tests/util/test_net.py
+++ b/tests/util/test_net.py
@@ -247,3 +247,140 @@ def test_usable_trusted_proxies_from_settings():
             ["server", "reverseProxy", "trustLocalhostProxies"]
         )
         patched.assert_called_once_with(["10.0.0.1"], add_localhost=True)
+
+
+@pytest.mark.parametrize(
+    "addresses,expected",
+    [
+        (["10.0.0.1"], ["10.0.0.1"]),
+        (["10.0.0.1", "murks"], ["10.0.0.1"]),
+        (None, []),
+        ([None], []),
+    ],
+)
+def test_get_ipset_from_list(addresses, expected):
+    actual = [str(x) for x in octoprint.util.net.get_ipset_from_list(addresses)]
+    assert actual == expected
+
+
+@pytest.mark.parametrize(
+    "forwarded_for,expected",
+    [
+        ("127.0.0.1, 10.1.2.3, 192.168.1.10", ["192.168.1.10", "10.1.2.3", "127.0.0.1"]),
+        (None, []),
+    ],
+)
+def test_get_forwarded_for_addresses(forwarded_for, expected):
+    assert octoprint.util.net.get_forwarded_for_addresses(forwarded_for) == expected
+
+
+@pytest.mark.parametrize(
+    "forwarded_for,trusted_proxies,expected",
+    [
+        (
+            None,
+            ["127.0.0.1", "::1"],
+            [],
+        ),  # direct connection
+        (
+            "192.168.1.10",
+            ["127.0.0.1", "::1"],
+            [],
+            # only untrusted proxy
+        ),
+        (
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.10"],
+            ["192.168.1.10"],
+        ),  # untrusted proxy in front
+        (
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            ["192.168.1.10"],
+        ),  # ipv4 range w/ untrusted proxy in front
+        (
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "unknown", "192.168.1.0/24"],
+            ["192.168.1.10"],
+        ),  # ipv4 range w/ garbage entry and untrusted proxy in front
+        (
+            "fd12:3456:789a:2::1, fd12:3456:789a:1::1",
+            ["127.0.0.1", "::1", "fd12:3456:789a:1::/64"],
+            ["fd12:3456:789a:1::1"],
+        ),  # ipv6 range w/ untrusted proxy in front
+        (
+            "10.1.2.3, 192.168.1.10",
+            ["0.0.0.0/0"],
+            ["192.168.1.10", "10.1.2.3"],
+        ),  # everything is trusted (BAD IDEA!)
+    ],
+)
+def test_get_trusted_forwarded_for_addresses(forwarded_for, trusted_proxies, expected):
+    assert (
+        octoprint.util.net.get_trusted_forwarded_for_addresses(
+            forwarded_for, trusted_proxies
+        )
+        == expected
+    )
+
+
+@pytest.mark.parametrize(
+    "trusted,forwarded_for,trusted_proxies,expected",
+    [
+        (
+            None,
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            False,
+        ),  # nothing is trusted
+        (
+            ["192.168.1.10"],
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            True,
+        ),  # trusted is contained in forward_for and trusted proxies
+        (
+            ["127.0.0.1", "::1"],
+            "10.1.2.3, 192.168.1.10, ::1",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            True,
+        ),  # trusted is contained in forward_for and trusted proxies
+        (
+            ["127.0.0.1", "::1"],
+            "10.1.2.3, 192.168.1.10, 127.0.0.1",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            True,
+        ),  # trusted is contained in forward_for and trusted proxies
+        (
+            ["192.168.1.1"],
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            False,
+        ),  # trusted is not contained in forward_for
+        (
+            ["10.1.2.3"],
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            False,
+        ),  # trusted is contained in forward_for but not trusted proxies
+        (
+            ["192.168.1.0/24"],
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            True,
+        ),  # trusted range matches ip in forward_for and in trusted proxies
+        (
+            "192.168.1.0/24",
+            "10.1.2.3, 192.168.1.10",
+            ["127.0.0.1", "::1", "192.168.1.0/24"],
+            True,
+        ),  # trusted range matches ip in forward_for and in trusted proxies, single auth proxy
+    ],
+)
+def test_contains_trusted_source(trusted, forwarded_for, trusted_proxies, expected):
+    assert (
+        octoprint.util.net.contains_trusted_source(
+            trusted, forwarded_for, trusted_proxies
+        )
+        == expected
+    )


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

If trusted auth proxies (address or range) are configured, the chain of
trusted involved reverse proxies will be checked for any the auth proxies.

Only if an auth proxy was involved in the request will the remote user
header then be evaluated.

Additional security option.

#### How was it tested? How can it be tested by the reviewer?

```
mitmdump --mode reverse:http://localhost:5000@5555 --modify-headers "/X-Remote-User/admin" --modify-headers "/X-Forwarded-For/127.0.0.1"
```

with

- default config: login via header
- `accessControl.trustedAuthProxies=["127.0.0.1"]`: login via header
- `accessControl.trustedAuthProxies=["192.168.1.10"]`: no login

and 

```
mitmdump --mode reverse:http://localhost:5000@5555 --modify-headers "/X-Remote-User/admin" --modify-headers "/X-Forwarded-For/192.168.1.10"
```

with

- default config: login via header
- `accessControl.trustedAuthProxies=["127.0.0.1"]`: no login
- `accessControl.trustedAuthProxies=["192.168.1.0/24"]`: login

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

As suggested by @jacopotediosi 

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
