### PR TITLE
fix(api): connection api multiple fixes

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -650,6 +650,7 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         error_str = None
         if self._comm is not None:
             error_str = self._comm.getErrorString()
+            self._port, self._baudrate = self._comm.getConnection()
 
         self.set_state(state, error=error_str)  # this will call the listener
 

--- a/src/octoprint/server/api/connection.py
+++ b/src/octoprint/server/api/connection.py
@@ -125,7 +125,7 @@ def connectionState_1_12_0():  # 1.12.0+
             connector=connector,
             parameters=connection_state,
             capabilities=capabilities,
-            profile=profile.get("_id") if profile else None,
+            profile=profile.get("id") if profile else None,
         ),
         options=_get_options_1_12_0(),
     )

--- a/src/octoprint/server/api/connection.py
+++ b/src/octoprint/server/api/connection.py
@@ -100,8 +100,8 @@ def connectionState():  # pre 1.12.0
         current=CurrentConnectionState_pre_1_12_0(
             state=state,
             printerProfile=profile.get("id", None) if profile else None,
-            port=connection_state.get("port", ""),
-            baudrate=connection_state.get("baudrate", 0),
+            port=connection_state.get("port", None) or None,
+            baudrate=connection_state.get("baudrate", None) or None,
         ),
         options=_get_options(),
     )
@@ -296,8 +296,8 @@ def _get_options() -> ConnectionOptions_pre_1_12_0:  # pre 1.12.0
             for printer_profile in profile_options.values()
             if "id" in printer_profile
         ],
-        portPreference=preferred_connection_params.get("port"),
-        baudratePreference=preferred_connection_params.get("baudrate"),
+        portPreference=preferred_connection_params.get("port") or None,
+        baudratePreference=preferred_connection_params.get("baudrate") or None,
         printerProfilePreference=default_profile["id"]
         if "id" in default_profile
         else None,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR contains three fixes for the `/api/connection` API:

1. When connected to a printer with AUTO baud rate, the `baudrate` field was an empty string instead of the actual baudrate in both the 1.12.0 and pre-1.12.0 API versions (in the latter, it also caused a crash because Pydantic expected an integer or `None`, but not a string).
2. The `profile` field in the 1.12.0 API version was always `null`.
3. The pre-1.12.0 API version crashed if called while the printer was disconnected because `port`, `baudrate`, `portPreference`, and `baudratePreference` were empty strings, but Pydantic expected `None`. Please note that it's correct to return `None` (`null` in the actual API response) here because that's how the real API responds in OctoPrint 1.11.7.

These bugs affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

```bash
curl http://localhost:5000/api/connection -H "X-Api-Key: YOUR_API_KEY" -H "X-OctoPrint-Api-Version: 1.12.0"
```

and

```bash
curl http://localhost:5000/api/connection -H "X-Api-Key: YOUR_API_KEY" -H "X-OctoPrint-Api-Version: 1.11.0"
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
