### PR TITLE
fix(coreui): fix connection profiles API fields

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -153,9 +153,9 @@ $(function () {
 
             // printer profile
 
-            const printerProfiles = response.options.printerProfiles;
+            const printerProfiles = response.options.profiles;
             const preferredProfile = response.options.preferredProfile;
-            const currentProfile = response.current.printerProfile;
+            const currentProfile = response.current.profile;
 
             if (!self.currentProfile() && printerProfiles) {
                 if (printerProfiles.indexOf(currentProfile) >= 0) {


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Version 1.12.0 of the /api/connection API changed the names of some fields: `options.printerProfiles` -> `options.profiles` and `current.printerProfile` -> `current.profile`. This PR updates two lines of code in the `ConnectionViewModel` where the old field name was still being used.

Below I reference the current schemes of connection API to speed up your review :)

https://github.com/OctoPrint/OctoPrint/blob/5d7a2f541fb3eaaa6507f944b507f118dc250849/src/octoprint/server/api/connection.py#L49-L54

https://github.com/OctoPrint/OctoPrint/blob/5d7a2f541fb3eaaa6507f944b507f118dc250849/src/octoprint/server/api/connection.py#L25-L30

This bug affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

I think this bug was masked by the fact that another knockout subscriber asynchronously updates the Connection sidebar with the correct data.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
