### PR TITLE
fix(printer): set "offline after error" state when printer fails

### DIFF
--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -954,6 +954,8 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
 
     def get_state_string(self, state=None, *args, **kwargs):
         if self._connection is None:
+            if state is not None:
+                return state.value
             return "Offline"
         else:
             return self._connection.get_state_string(state=state)
@@ -1293,7 +1295,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         )
         self._stateMonitor.set_state(
             self._dict(
-                text=self.get_state_string(),
+                text=self.get_state_string(state=self._state),
                 flags=self._get_state_flags(),
                 error=self.get_error(),
             )
@@ -1671,7 +1673,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
 
     def _set_state(self, state, state_string=None, error_string=None):
         if state_string is None:
-            state_string = self.get_state_string()
+            state_string = self.get_state_string(state=state)
         if error_string is None:
             error_string = self.get_error()
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -953,12 +953,9 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         self._connection.cancel_print(user=user, tags=tags, params=params)
 
     def get_state_string(self, state=None, *args, **kwargs):
-        if self._connection is None:
-            if state is not None:
-                return state.value
-            return "Offline"
-        else:
-            return self._connection.get_state_string(state=state)
+        if state is None:
+            state = self._state
+        return state.value
 
     def get_state_id(self, state=None, *args, **kwargs):
         if state is None:
@@ -1672,12 +1669,13 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         self._stateMonitor.set_temp_offsets(offsets)
 
     def _set_state(self, state, state_string=None, error_string=None):
+        self._state = state
+
         if state_string is None:
-            state_string = self.get_state_string(state=state)
+            state_string = self.get_state_string()
         if error_string is None:
             error_string = self.get_error()
 
-        self._state = state
         self._stateMonitor.set_state(
             self._dict(
                 text=state_string, flags=self._get_state_flags(), error=error_string
@@ -1685,8 +1683,8 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         )
 
         payload = {
-            "state_id": self.get_state_id(self._state),
-            "state_string": self.get_state_string(self._state),
+            "state_id": self.get_state_id(),
+            "state_string": state_string,
         }
         eventManager().fire(Events.PRINTER_STATE_CHANGED, payload)
 

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1292,7 +1292,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         )
         self._stateMonitor.set_state(
             self._dict(
-                text=self.get_state_string(state=self._state),
+                text=self.get_state_string(),
                 flags=self._get_state_flags(),
                 error=self.get_error(),
             )


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the state string, so that when the printer disconnects with an error, the State in the sidebar is set to `State: Offline after error` instead of `State: Offline`.

This bug affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Connect to the virtual printer, then send `M112` via Terminal tab.
Before this PR, the State sidebar shows `State: Offline`.
After this PR, the State sidebar shows `State: Offline after error`.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

To be honest, the state string lifecycle in the `standard.py` file confuses me. The fix I propose in this PR just works, but I'm not sure if it's the best good design possible.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
