### PR TITLE
fix(api): fix crash while saving notifySuppressedCommands

### DIFF
--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -769,7 +769,7 @@ def _saveSettings(data):
             )
 
         if "notifySuppressedCommands" in data["feature"]:
-            value = data["notifySuppressedCommands"]
+            value = data["feature"]["notifySuppressedCommands"]
             if value in ("info", "warn", "never"):
                 s.set(["feature", "notifySuppressedCommands"], value)
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

Commit fe8d4a7df536cee21706a20859d7fa854e68c5fe moved the `notifySuppressedCommands` setting but broke its saving. This PR fixes it.

This bug affected only `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

Go to *OctoPrint Settings -> Features -> Display notifications for suppressed commands* -> set any setting different from the current one and save the setting.

Stacktrace before the fix of this PR:
~~~stacktrace
2026-03-20 01:28:54,205 - octoprint - ERROR - Exception on /api/settings [POST]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 1658, in decorated_view
    return func(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/vendor/flask_principal.py", line 196, in _decorated
    rv = f(*args, **kw)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/settings.py", line 403, in setSettings
    response = _saveSettings(data)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/settings.py", line 772, in _saveSettings
    value = data["notifySuppressedCommands"]
            ~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
KeyError: 'notifySuppressedCommands'
2026-03-20 01:28:54,213 - tornado.access - ERROR - 500 POST /api/settings (127.0.0.1) 10.27ms
~~~

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
