### PR TITLE
chore: remove Repetier settings leftovers

### DIFF
--- a/src/octoprint/plugins/serial_connector/config_schema.py
+++ b/src/octoprint/plugins/serial_connector/config_schema.py
@@ -260,12 +260,6 @@ class SerialConfig(BaseModel):
     supportWait: bool = True
     """Whether to support ``wait`` responses from the printer and interpret them as a call to send more commands."""
 
-    ignoreIdenticalResends: bool = False
-    """Whether to ignore identical resends from the printer (``true``, repetier) or not (``false``)."""
-
-    identicalResendsCountdown: int = 7
-    """If ``ignoreIdenticalResends`` is true, how many consecutive identical resends to ignore."""
-
     supportFAsCommand: bool = False
     """Whether to support ``F`` on its own as a valid GCODE command (``true``) or not (``false``)."""
 

--- a/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
+++ b/src/octoprint/plugins/serial_connector/templates/serial_connector_settings.jinja2
@@ -472,16 +472,6 @@
                         <div class="controls">
                             <label class="checkbox">
                                 <input type="checkbox"
-                                       data-bind="checked: settings.settings.plugins.serial_connector.ignoreIdenticalResends"
-                                       id="settings-serialIgnoreIdenticalResends">
-                                {{ _("Ignore consecutive resend requests for the same line") }} <span class="label">{{ _("Repetier") }}</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="control-group">
-                        <div class="controls">
-                            <label class="checkbox">
-                                <input type="checkbox"
                                        data-bind="checked: settings.settings.plugins.serial_connector.repetierTargetTemp"
                                        id="settings-serialRepetierTargetTemp">
                                 {{ _("Support <code>TargetExtr%%n</code>/<code>TargetBed</code> target temperature format") }} <span class="label">{{ _("Repetier") }}</span>

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -1136,9 +1136,6 @@ def _get_serial_settings():
         "externalHeatupDetection": s.getBoolean(
             ["plugins", "serial_connector", "externalHeatupDetection"]
         ),
-        "ignoreIdenticalResends": s.getBoolean(
-            ["plugins", "serial_connector", "ignoreIdenticalResends"]
-        ),
         "firmwareDetection": s.getBoolean(
             ["plugins", "serial_connector", "firmwareDetection"]
         ),
@@ -1419,11 +1416,6 @@ def _set_serial_settings(data: dict[str, Any]):
         s.setBoolean(
             ["plugins", "serial_connector", "externalHeatupDetection"],
             data["externalHeatupDetection"],
-        )
-    if "ignoreIdenticalResends" in data:
-        s.setBoolean(
-            ["plugins", "serial_connector", "ignoreIdenticalResends"],
-            data["ignoreIdenticalResends"],
         )
     if "firmwareDetection" in data:
         s.setBoolean(

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -1127,9 +1127,6 @@ def _get_serial_settings():
             ["plugins", "serial_connector", "sdAlwaysAvailable"]
         ),
         "sdLowerCase": s.getBoolean(["plugins", "serial_connector", "sdLowerCase"]),
-        "swallowOkAfterResend": s.getBoolean(
-            ["plugins", "serial_connector", "swallowOkAfterResend"]
-        ),
         "repetierTargetTemp": s.getBoolean(
             ["plugins", "serial_connector", "repetierTargetTemp"]
         ),
@@ -1402,11 +1399,6 @@ def _set_serial_settings(data: dict[str, Any]):
         )
     if "sdLowerCase" in data:
         s.setBoolean(["plugins", "serial_connector", "sdLowerCase"], data["sdLowerCase"])
-    if "swallowOkAfterResend" in data:
-        s.setBoolean(
-            ["plugins", "serial_connector", "swallowOkAfterResend"],
-            data["swallowOkAfterResend"],
-        )
     if "repetierTargetTemp" in data:
         s.setBoolean(
             ["plugins", "serial_connector", "repetierTargetTemp"],

--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -1604,7 +1604,6 @@ class Settings:
             "unknownCommandsNeedAck",
             "sdRelativePath",
             "sdAlwaysAvailable",
-            "swallowOkAfterResend",
             "repetierTargetTemp",
             "externalHeatupDetection",
             "supportWait",

--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -1608,8 +1608,6 @@ class Settings:
             "repetierTargetTemp",
             "externalHeatupDetection",
             "supportWait",
-            "ignoreIdenticalResends",
-            "identicalResendsCountdown",
             "supportFAsCommand",
             "firmwareDetection",
             "blockWhileDwelling",


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

1. Remove `ignoreIdenticalResends` and `identicalResendsCountdown` settings leftovers from config schema, Settings API, and UI. They were removed by 86b886e in 2018.
2. Remove `swallowOkAfterResend` setting leftover from Settings API.  It was introduced in 2013 by d12da2548, and later removed in 2015 by 116a540ab.

This was dead code since years, so of course it's bugfix release relevant.

#### How was it tested? How can it be tested by the reviewer?

No need to test, this was all dead code.
Edit: CI here failed because of a bug in unit tests (see #5332). Actually, `pytest` passes on my laptop.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
