### PR TITLE
test: fix race condition in test_handle_system_commands

### DIFF
--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -71,7 +71,29 @@ def test_handle_system_commands(mocked_printer, param, shell, expected_call):
         mocked_printer, "test123 {a}", shell=shell
     )
 
-    with mock.patch("subprocess.check_call") as mcc:
+    class MockThread:
+        def __init__(self):
+            self.target = None
+            self.args = None
+            self.mock = None
+
+        def constructor(self, target=None, args=None):
+            self.target = target
+            self.args = args or ()
+            self.mock = mock.MagicMock()
+            self.mock.start.side_effect = self.start
+            return self.mock
+
+        def start(self):
+            self.target(*self.args)
+
+    mock_thread = MockThread()
+
+    with (
+        mock.patch("subprocess.check_call") as mcc,
+        mock.patch("threading.Thread") as mocked_thread,
+    ):
+        mocked_thread.side_effect = mock_thread.constructor
         sub.handle("Test", {"a": param})
 
         mcc.assert_called_once_with(f"test123 {expected_call}", shell=shell, cwd=None)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the following unit test:

https://github.com/OctoPrint/OctoPrint/blob/fe8d4a7df536cee21706a20859d7fa854e68c5fe/tests/test_events.py#L69-L77

The test was sometimes failing randomly, since `sub.handle()` is asynchronous (uses `threading.Thread`) and `mcc.assert_called_once_with()` could be called before the thread had finished.

This PR fixes the race condition by mocking the `Thread` class, as was already done in [this other unit test](https://github.com/OctoPrint/OctoPrint/blob/fe8d4a7df536cee21706a20859d7fa854e68c5fe/tests/slicing/test_slicingmanager.py#L119).

#### How was it tested? How can it be tested by the reviewer?

Run the following command:
```bash
python -m pytest tests/test_events.py::test_handle_system_commands -v
```

Before this fix, the test was sometimes failing randomly, as happened [here](https://github.com/OctoPrint/OctoPrint/actions/runs/23349682215/job/67924617078):
```stacktrace
=================================== FAILURES ===================================
_ test_handle_system_commands[test.gcode;rm -rf /;#.gcode-False-test.gcode;rm -rf /;#.gcode] _

mocked_printer = <Mock id='140346623856656'>
param = 'test.gcode;rm -rf /;#.gcode', shell = False
expected_call = 'test.gcode;rm -rf /;#.gcode'

    @pytest.mark.parametrize(
        "param, shell, expected_call",
        (
            ("a", True, "a"),
            ("a", False, "a"),
            ("a;b", True, "'a;b'"),
            ("a;b", False, "a;b"),
            ("test.gcode;rm -rf /;#.gcode", True, "'test.gcode;rm -rf /;#.gcode'"),
            ("test.gcode;rm -rf /;#.gcode", False, "test.gcode;rm -rf /;#.gcode"),
        ),
    )
    def test_handle_system_commands(mocked_printer, param, shell, expected_call):
        sub = octoprint.events.SystemEventSubscription(
            mocked_printer, "test123 {a}", shell=shell
        )

        with mock.patch("subprocess.check_call") as mcc:
            sub.handle("Test", {"a": param})

>           mcc.assert_called_once_with(f"test123 {expected_call}", shell=shell, cwd=None)

tests/test_events.py:77:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

self = <MagicMock name='check_call' id='140346623857328'>
args = ('test123 test.gcode;rm -rf /;#.gcode',)
kwargs = {'cwd': None, 'shell': False}
msg = "Expected 'check_call' to be called once. Called 0 times."

    def assert_called_once_with(self, /, *args, **kwargs):
        """assert that the mock was called exactly once and that that call was
        with the specified arguments."""
        if not self.call_count == 1:
            msg = ("Expected '%s' to be called once. Called %s times.%s"
                   % (self._mock_name or 'mock',
                      self.call_count,
                      self._calls_repr()))
>           raise AssertionError(msg)
E           AssertionError: Expected 'check_call' to be called once. Called 0 times.

/opt/hostedtoolcache/Python/3.14.3/x64/lib/python3.14/unittest/mock.py:996: AssertionError
=========================== short test summary info ============================
FAILED tests/test_events.py::test_handle_system_commands[test.gcode;rm -rf /;#.gcode-False-test.gcode;rm -rf /;#.gcode] - AssertionError: Expected 'check_call' to be called once. Called 0 times.
================== 1 failed, 1123 passed in 73.79s (0:01:13) ===================
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
