### PR TITLE
test: actually verify fired events

### DIFF
--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -215,7 +215,7 @@ class FileManagerTest(unittest.TestCase):
     def test_add_file(self):
         wrapper = object()
 
-        self.local_storage.add_file.return_value = ("", "test.gcode")
+        self.local_storage.add_file.return_value = "test.gcode"
         self.local_storage.path_in_storage.return_value = "test.gcode"
         self.local_storage.path_on_disk.return_value = "prefix/test.gcode"
         self.local_storage.split_path.return_value = ("", "test.gcode")
@@ -227,7 +227,7 @@ class FileManagerTest(unittest.TestCase):
             octoprint.filemanager.FileDestinations.LOCAL, "test.gcode", wrapper
         )
 
-        self.assertEqual(("", "test.gcode"), file_path)
+        self.assertEqual("test.gcode", file_path)
         self.local_storage.add_file.assert_called_once_with(
             "test.gcode",
             wrapper,
@@ -245,16 +245,23 @@ class FileManagerTest(unittest.TestCase):
                     "name": "test.gcode",
                     "path": "test.gcode",
                     "type": ["machinecode", "gcode"],
+                    "operation": "add",
                 },
             ),
-            mock.call(octoprint.filemanager.Events.UPDATED_FILES, {"type": "printables"}),
+            mock.call(
+                octoprint.filemanager.Events.UPDATED_FILES,
+                {
+                    "type": "printables",
+                    "storage": octoprint.filemanager.FileDestinations.LOCAL,
+                },
+            ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
     def test_add_file_display(self):
         wrapper = object()
 
-        self.local_storage.add_file.return_value = ("", "test.gcode")
+        self.local_storage.add_file.return_value = "test.gcode"
         self.local_storage.path_in_storage.return_value = "test.gcode"
         self.local_storage.path_on_disk.return_value = "prefix/test.gcode"
         self.local_storage.split_path.return_value = ("", "test.gcode")
@@ -269,7 +276,7 @@ class FileManagerTest(unittest.TestCase):
             display="täst.gcode",
         )
 
-        self.assertEqual(("", "test.gcode"), file_path)
+        self.assertEqual("test.gcode", file_path)
         self.local_storage.add_file.assert_called_once_with(
             "test.gcode",
             wrapper,
@@ -285,7 +292,7 @@ class FileManagerTest(unittest.TestCase):
         test_profile = {"id": "_default", "name": "My Default Profile"}
         self.printer_profile_manager.get_current_or_default.return_value = test_profile
 
-        self.local_storage.add_file.return_value = ("", "test.gcode")
+        self.local_storage.add_file.return_value = "test.gcode"
         self.local_storage.path_in_storage.return_value = "test.gcode"
         self.local_storage.path_on_disk.return_value = "prefix/test.gcode"
         self.local_storage.split_path.return_value = ("", "test.gcode")
@@ -297,7 +304,7 @@ class FileManagerTest(unittest.TestCase):
             user="user",
         )
 
-        self.assertEqual(("", "test.gcode"), file_path)
+        self.assertEqual("test.gcode", file_path)
         self.local_storage.add_file.assert_called_once_with(
             "test.gcode",
             wrapper,
@@ -326,21 +333,28 @@ class FileManagerTest(unittest.TestCase):
                     "name": "test.gcode",
                     "path": "test.gcode",
                     "type": ["machinecode", "gcode"],
+                    "operation": "remove",
                 },
             ),
-            mock.call(octoprint.filemanager.Events.UPDATED_FILES, {"type": "printables"}),
+            mock.call(
+                octoprint.filemanager.Events.UPDATED_FILES,
+                {
+                    "type": "printables",
+                    "storage": octoprint.filemanager.FileDestinations.LOCAL,
+                },
+            ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
     def test_add_folder(self):
-        self.local_storage.add_folder.return_value = ("", "test_folder")
+        self.local_storage.add_folder.return_value = "test_folder"
         self.local_storage.split_path.return_value = ("", "test_folder")
 
         folder_path = self.file_manager.add_folder(
             octoprint.filemanager.FileDestinations.LOCAL, "test_folder"
         )
 
-        self.assertEqual(("", "test_folder"), folder_path)
+        self.assertEqual("test_folder", folder_path)
         self.local_storage.add_folder.assert_called_once_with(
             "test_folder", ignore_existing=True, display=None, user=None
         )
@@ -354,9 +368,15 @@ class FileManagerTest(unittest.TestCase):
                     "path": "test_folder",
                 },
             ),
-            mock.call(octoprint.filemanager.Events.UPDATED_FILES, {"type": "printables"}),
+            mock.call(
+                octoprint.filemanager.Events.UPDATED_FILES,
+                {
+                    "type": "printables",
+                    "storage": octoprint.filemanager.FileDestinations.LOCAL,
+                },
+            ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
     def test_add_folder_not_ignoring_existing(self):
         self.local_storage.add_folder.side_effect = RuntimeError("already there")
@@ -421,9 +441,15 @@ class FileManagerTest(unittest.TestCase):
                     "path": "test_folder",
                 },
             ),
-            mock.call(octoprint.filemanager.Events.UPDATED_FILES, {"type": "printables"}),
+            mock.call(
+                octoprint.filemanager.Events.UPDATED_FILES,
+                {
+                    "type": "printables",
+                    "storage": octoprint.filemanager.FileDestinations.LOCAL,
+                },
+            ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
     def test_remove_folder_nonrecursive(self):
         self.local_storage.path_in_storage.return_value = "test_folder"
@@ -716,11 +742,14 @@ class FileManagerTest(unittest.TestCase):
         expected_events = [
             mock.call(
                 octoprint.filemanager.Events.SLICING_STARTED,
-                {"stl": "source.file", "gcode": "dest.file", "progressAvailable": False},
-            ),
-            mock.call(
-                octoprint.filemanager.Events.SLICING_DONE,
-                {"stl": "source.file", "gcode": "dest.file", "time": 15.694000005722046},
+                {
+                    "slicer": "some_slicer",
+                    "stl": "source.file",
+                    "stl_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "gcode": "dest.file",
+                    "gcode_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "progressAvailable": mock.ANY,
+                },
             ),
             mock.call(
                 octoprint.filemanager.Events.FILE_ADDED,
@@ -729,10 +758,29 @@ class FileManagerTest(unittest.TestCase):
                     "name": "dest.file",
                     "path": "dest.file",
                     "type": None,
+                    "operation": "add",
+                },
+            ),
+            mock.call(
+                octoprint.filemanager.Events.UPDATED_FILES,
+                {
+                    "type": "printables",
+                    "storage": octoprint.filemanager.FileDestinations.LOCAL,
+                },
+            ),
+            mock.call(
+                octoprint.filemanager.Events.SLICING_DONE,
+                {
+                    "slicer": "some_slicer",
+                    "stl": "source.file",
+                    "stl_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "gcode": "dest.file",
+                    "gcode_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "time": mock.ANY,
                 },
             ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
         # assert that model links were added
         self.local_storage.add_file.assert_called_once_with(
@@ -840,18 +888,28 @@ class FileManagerTest(unittest.TestCase):
         expected_events = [
             mock.call(
                 octoprint.filemanager.Events.SLICING_STARTED,
-                {"stl": "source.file", "gcode": "dest.file"},
+                {
+                    "slicer": "some_slicer",
+                    "stl": "source.file",
+                    "stl_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "gcode": "dest.file",
+                    "gcode_location": octoprint.filemanager.FileDestinations.LOCAL,
+                    "progressAvailable": mock.ANY,
+                },
             ),
             mock.call(
                 octoprint.filemanager.Events.SLICING_FAILED,
                 {
+                    "slicer": "some_slicer",
                     "stl": "source.file",
+                    "stl_location": octoprint.filemanager.FileDestinations.LOCAL,
                     "gcode": "dest.file",
+                    "gcode_location": octoprint.filemanager.FileDestinations.LOCAL,
                     "reason": "Something went wrong",
                 },
             ),
         ]
-        self.fire_event.call_args_list = expected_events
+        self.assertEqual(self.fire_event.call_args_list, expected_events)
 
         # assert that the temporary file was deleted
         mocked_os.assert_called_once_with("tmp.file")


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

While reviewing unit tests, I found that in six instances in `test_filemanager.py`, event assertions used `=` (assignment) instead of `assertEqual`, never actually verifying the fired events.

An example below:
https://github.com/OctoPrint/OctoPrint/blob/fe8d4a7df536cee21706a20859d7fa854e68c5fe/tests/filemanager/test_filemanager.py#L252

This PR fixes these six instances, ensuring that the tests actually check that events are fired. Since these unit tests passed without actually verifying the events for years, the expected event payloads also needed to be updated.

#### How was it tested? How can it be tested by the reviewer?

```bash
python -m pytest tests/filemanager/test_filemanager.py -v
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
