### PR TITLE
test: extend remote user header tests

### DIFF
--- a/tests/server/util/test_util.py
+++ b/tests/server/util/test_util.py
@@ -115,6 +115,22 @@ def test_validate_local_redirect(url, paths, expected):
             "user",
         ),  # lan via proxy, trusted auth proxy also trusted as reverse proxy
         (
+            "127.0.0.1",
+            "10.1.2.3",
+            "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1", "192.168.1.10"],
+            None,
+        ),  # lan via proxy, trusted auth proxy not in chain, ignored
+        (
+            "127.0.0.1",
+            "192.168.1.10, 10.1.2.3",
+            "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1", "192.168.1.10"],
+            None,
+        ),  # lan via proxy, spoofed auth proxy address in X-Forwarded-For, ignored
+        (
             "192.168.1.10",
             "127.0.0.1, 10.1.2.3",
             "user",
@@ -130,6 +146,14 @@ def test_validate_local_redirect(url, paths, expected):
             ["127.0.0.0/8", "::1", "192.168.1.10"],
             None,
         ),  # lan via trusted reverse proxy, not trusted as auth proxy though, spoofed remote address, ignored
+        (
+            "192.168.1.10",
+            "10.1.2.3",
+            "user",
+            ["192.168.1.10"],
+            ["127.0.0.0/8", "::1", "192.168.1.10"],
+            "user",
+        ),  # lan via auth proxy directly, no reverse proxies
     ],
 )
 def test_get_user_for_remote_user_header(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds additional test cases for the remote user header:

1. The first is the case where, in OctoPi, the attacker contacts haproxy directly, bypassing the authentication proxy. It must fail because the authentication proxy's IP is not in the `X-Forwarded-For` header.

2. The second is the same case as the first (in OctoPi, the attacker contacts haproxy directly, bypassing the authentication proxy), but additionally the attacker attempts to spoof the auth proxy's IP in the `X-Forwarded-For` header. It must fail because the attacker's IP appears to the right of the auth proxy's IP in the `X-Forwarded-For` header.

3. The third verifies that the auth proxy works correctly even when there are no additional reverse proxies in between.

#### How was it tested? How can it be tested by the reviewer?

```bash
python -m pytest tests/server/util/test_util.py -v
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
