### PR TITLE
fix: fix variable name shadowing builtin type()

### DIFF
--- a/src/octoprint/util/json/encoding.py
+++ b/src/octoprint/util/json/encoding.py
@@ -51,8 +51,8 @@ class JsonEncoding:
 
     @classmethod
     def encode(cls, obj):
-        for type, encoder in cls.encoders.items():
-            if isinstance(obj, type):
+        for typ, encoder in cls.encoders.items():
+            if isinstance(obj, typ):
                 return encoder(obj)
         raise TypeError(f"Unserializable type {type(obj)}")
 

--- a/tests/util/test_json.py
+++ b/tests/util/test_json.py
@@ -44,7 +44,7 @@ def test_encoding_loads():
 
 
 def test_encoding_dumps_typeerror():
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError, match="Unserializable type"):
         json.encoding.dumps(SomeClass())
 
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [ x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug in `JsonEncoding.encode()`.

The for-loop variable `type` overwrote the builtin `type()`. When no encoder matched, the f-string in the raise called `bytes(obj)` instead of `type(obj)`, which threw its own `TypeError` (not the custom one). This commit also tightens the unit test to only accept the custom `TypeError`.

#### How was it tested? How can it be tested by the reviewer?

```bash
python -m pytest tests/util/test_json.py -v
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

I renamed `type` to `typ` following the same convention used for the `add_encoder()` method.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
