### PR TITLE
Fix `autoconnect` related backwards compatibility and UX issues

### DIFF
--- a/src/octoprint/plugins/serial_connector/__init__.py
+++ b/src/octoprint/plugins/serial_connector/__init__.py
@@ -62,6 +62,26 @@ class SerialConnectorPlugin(
                         except KeyError:
                             pass
 
+                autoconnect = config.pop("autoconnect", False)
+
+                parameters = {}
+                if "port" in config:
+                    parameters["port"] = config.pop("port")
+                if "baudrate" in config:
+                    parameters["baudrate"] = config.pop("baudrate")
+
+                preferred_connector = self._settings.global_get(
+                    ["printerConnection", "preferred", "connector"]
+                )
+                if preferred_connector is None or preferred_connector == "serial":
+                    self._settings.global_set_boolean(
+                        ["printerConnection", "autoconnect"], autoconnect
+                    )
+                    self._settings.global_set(
+                        ["printerConnection", "preferred", "parameters"],
+                        parameters,
+                    )
+
                 self._settings.global_set(
                     ["plugins", "serial_connector"], config, force=True
                 )

--- a/src/octoprint/plugins/serial_connector/__init__.py
+++ b/src/octoprint/plugins/serial_connector/__init__.py
@@ -62,13 +62,22 @@ class SerialConnectorPlugin(
                         except KeyError:
                             pass
 
+                if "autorefresh" in config:
+                    self._settings.global_set_boolean(
+                        ["printerConnection", "autorefresh"], config.pop("autorefresh")
+                    )
+                if "autorefreshInterval" in config:
+                    self._settings.global_set_int(
+                        ["printerConnection", "autorefreshInterval"],
+                        config.pop("autorefreshInterval"),
+                    )
+
                 autoconnect = config.pop("autoconnect", False)
 
-                parameters = {}
-                if "port" in config:
-                    parameters["port"] = config.pop("port")
-                if "baudrate" in config:
-                    parameters["baudrate"] = config.pop("baudrate")
+                parameters = {
+                    "port": config.pop("port", None),
+                    "baudrate": config.pop("baudrate", None),
+                }
 
                 preferred_connector = self._settings.global_get(
                     ["printerConnection", "preferred", "connector"]

--- a/src/octoprint/plugins/serial_connector/config_schema.py
+++ b/src/octoprint/plugins/serial_connector/config_schema.py
@@ -112,12 +112,6 @@ class SerialConfig(BaseModel):
     lowLatency: bool = False
     """Whether to request low latency mode on the serial port."""
 
-    autorefresh: bool = True
-    """Whether to automatically refresh the port list while no connection is established."""
-
-    autorefreshInterval: int = 1
-    """Interval in seconds at which to refresh the port list while no connection is established."""
-
     log: bool = False
     """Whether to log whole communication to ``serial.log`` (warning: might decrease performance)."""
 

--- a/src/octoprint/plugins/serial_connector/config_schema.py
+++ b/src/octoprint/plugins/serial_connector/config_schema.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from typing import Optional
 
 from octoprint.schema import BaseModel
 
@@ -107,20 +106,11 @@ class SerialCapabilities(BaseModel):
 
 
 class SerialConfig(BaseModel):
-    port: Optional[str] = None
-    """The default port to use to connect to the printer. If unset or set to ``AUTO``, the port will be auto-detected."""
-
-    baudrate: Optional[int] = None
-    """The default baudrate to use to connect to the printer. If unset or set to 0, the baudrate will be auto-detected."""
-
     exclusive: bool = True
     """Whether to request exclusive access to the serial port."""
 
     lowLatency: bool = False
     """Whether to request low latency mode on the serial port."""
-
-    autoconnect: bool = False
-    """Whether to try to automatically connect to the printer on startup."""
 
     autorefresh: bool = True
     """Whether to automatically refresh the port list while no connection is established."""

--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -218,10 +218,9 @@ def serialList():
     else:
         candidates = []
         try:
-            with os.scandir("/dev") as it:
-                for entry in it:
-                    if regex_serial_devices.match(entry.name):
-                        candidates.append(entry.path)
+            for entry in os.scandir("/dev"):
+                if regex_serial_devices.match(entry.name):
+                    candidates.append(entry.path)
         except Exception:
             _logger.exception("Could not scan /dev for serial ports on the system")
 

--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -189,7 +189,7 @@ PORT_AUTO = "AUTO"
 BAUDRATE_AUTO = 0
 
 STANDARD_BAUDRATES = [115200, 250000, 230400, 57600, 38400, 19200, 9600]
-
+# standard baudrates, sorted by likelihood
 
 SDFileData = namedtuple("SDFileData", ["name", "size", "timestamp", "longname"])
 
@@ -269,8 +269,7 @@ def serialList():
 
 def baudrateList(candidates=None):
     if candidates is None:
-        # sorted by likelihood
-        candidates = STANDARD_BAUDRATES
+        candidates = STANDARD_BAUDRATES[:]
 
     # additional baudrates prepended, sorted descending
     additionalBaudrates = settings().get(

--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -188,6 +188,8 @@ MINIMAL_SD_TIMESTAMP = 1212012000
 PORT_AUTO = "AUTO"
 BAUDRATE_AUTO = 0
 
+STANDARD_BAUDRATES = [115200, 250000, 230400, 57600, 38400, 19200, 9600]
+
 
 SDFileData = namedtuple("SDFileData", ["name", "size", "timestamp", "longname"])
 
@@ -251,11 +253,16 @@ def serialList():
                 filter(lambda x: not fnmatch.fnmatch(x, pattern), candidates)
             )
 
-    # last used port = first to try, move to start
-    prev = settings().get(["plugins", "serial_connector", "port"])
-    if prev in candidates:
-        candidates.remove(prev)
-        candidates.insert(0, prev)
+    # preferred port = first to try, move to start
+    preferred_connector = settings().get(["printerConnection", "preferred", "connector"])
+    if preferred_connector == "serial":
+        preferred_params = settings().get(
+            ["printerConnection", "preferred", "parameters"]
+        )
+        preferred = preferred_params.get("port")
+        if preferred in candidates:
+            candidates.remove(preferred)
+            candidates.insert(0, preferred)
 
     return candidates
 
@@ -263,7 +270,7 @@ def serialList():
 def baudrateList(candidates=None):
     if candidates is None:
         # sorted by likelihood
-        candidates = [115200, 250000, 230400, 57600, 38400, 19200, 9600]
+        candidates = STANDARD_BAUDRATES
 
     # additional baudrates prepended, sorted descending
     additionalBaudrates = settings().get(
@@ -288,11 +295,16 @@ def baudrateList(candidates=None):
             except ValueError:
                 pass
 
-    # last used baudrate = first to try, move to start
-    prev = settings().getInt(["plugins", "serial_connector", "baudrate"])
-    if prev in candidates:
-        candidates.remove(prev)
-        candidates.insert(0, prev)
+    # preferred baudrate = first to try, move to start
+    preferred_connector = settings().get(["printerConnection", "preferred", "connector"])
+    if preferred_connector == "serial":
+        preferred_params = settings().get(
+            ["printerConnection", "preferred", "parameters"]
+        )
+        preferred = preferred_params.get("baudrate")
+        if preferred in candidates:
+            candidates.remove(preferred)
+            candidates.insert(0, preferred)
 
     return candidates
 

--- a/src/octoprint/plugins/serial_connector/static/js/serial_connector.js
+++ b/src/octoprint/plugins/serial_connector/static/js/serial_connector.js
@@ -84,6 +84,21 @@ $(function () {
             self.lastUpdated(new Date().getTime());
         };
 
+        self.onRenderParametersForConnector = (connector, parameters) => {
+            if (connector !== "serial") return false;
+
+            return [
+                {
+                    name: gettext("Port"),
+                    value: !parameters.port ? "AUTO" : parameters.port
+                },
+                {
+                    name: gettext("Baudrate"),
+                    value: !parameters.baudrate ? "AUTO" : parameters.baudrate
+                }
+            ];
+        };
+
         //~~ Settings related
 
         const get_config_item = (item, defaultValue) => {

--- a/src/octoprint/schema/config/appearance.py
+++ b/src/octoprint/schema/config/appearance.py
@@ -49,6 +49,7 @@ class ComponentOrderConfig(BaseModel):
 
     settings: list[str] = [
         "section_printer",
+        "printerconnection",
         "plugin_serial_connector",
         "printerprofiles",
         "temperatures",

--- a/src/octoprint/server/api/connection.py
+++ b/src/octoprint/server/api/connection.py
@@ -78,6 +78,8 @@ class ConnectionOptions_pre_2_0_0(BaseModel):
     baudratePreference: Optional[int]
     printerProfilePreference: Optional[str]
 
+    autoconnect: bool
+
 
 class ConnectionStateResponse_pre_2_0_0(BaseModel):
     current: CurrentConnectionState_pre_2_0_0
@@ -285,6 +287,9 @@ def _get_options() -> ConnectionOptions_pre_2_0_0:  # pre 2.0.0
             ["printerConnection", "preferred", "parameters"]
         )
 
+    # autoconnect
+    autoconnect = settings().getBoolean(["printerConnection", "autoconnect"])
+
     return ConnectionOptions_pre_2_0_0(
         ports=connection_options.get("port", []),
         baudrates=connection_options.get("baudrate", []),
@@ -301,4 +306,5 @@ def _get_options() -> ConnectionOptions_pre_2_0_0:  # pre 2.0.0
         printerProfilePreference=default_profile["id"]
         if "id" in default_profile
         else None,
+        autoconnect=autoconnect,
     )

--- a/src/octoprint/server/api/connection.py
+++ b/src/octoprint/server/api/connection.py
@@ -204,12 +204,12 @@ def connectionCommand():
             )
             settings().set(["printerConnection", "preferred", "parameters"], parameters)
             printerProfileManager.set_default(printerProfile)
-            settings_dirty = True
 
-        if "autoconnect" in data:
-            settings().setBoolean(
-                ["printerConnection", "autoconnect"], data["autoconnect"]
-            )
+            if "autoconnect" in data:
+                settings().setBoolean(
+                    ["printerConnection", "autoconnect"], data["autoconnect"]
+                )
+
             settings_dirty = True
 
         if settings_dirty:

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -272,7 +272,11 @@ def getSettings():
     if len(plugin_settings):
         data["plugins"] = plugin_settings
 
-    if not api_version_matches(">=2.0.0"):
+    if api_version_matches(">=2.0.0"):
+        data["printerConnection"] = {
+            "autoconnect": s.getBoolean(["printerConnection", "autoconnect"])
+        }
+    else:
         data["serial"] = _get_serial_settings()
         data["feature"]["autoUppercaseBlacklist"] = data["feature"].pop(
             "autoUppercaseBlocklist"
@@ -628,6 +632,13 @@ def _saveSettings(data):
             s.setInt(
                 ["printerParameters", "defaultExtrusionLength"],
                 data["printer"]["defaultExtrusionLength"],
+            )
+
+    if "printerConnection" in data:
+        if "autoconnect" in data["printerConnection"]:
+            s.setBoolean(
+                ["printerConnection", "autoconnect"],
+                data["printerConnection"]["autoconnect"],
             )
 
     if "webcam" in data:
@@ -1028,7 +1039,7 @@ def _get_serial_settings():
         "lowLatency": s.getBoolean(["plugins", "serial_connector", "lowLatency"]),
         "portOptions": connection_options.get("port", []),
         "baudrateOptions": connection_options.get("baudrate", []),
-        "autoconnect": s.getBoolean(["plugins", "serial_connector", "autoconnect"]),
+        "autoconnect": s.getBoolean(["printerConnection", "autoconnect"]),
         "timeoutConnection": s.getFloat(
             ["plugins", "serial_connector", "timeout", "connection"]
         ),

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -1151,6 +1151,14 @@ def fetch_template_data(refresh=False):
 
     templates["settings"]["entries"] = {
         "section_printer": (gettext("Printer"), None),
+        "printerconnection": (
+            gettext("Printer Connection"),
+            {
+                "template": "dialogs/settings/printerconnection.jinja2",
+                "_div": "settings_printerconnection",
+                "custom_bindings": True,
+            },
+        ),
         "printerprofiles": (
             gettext("Printer Profiles"),
             {

--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -227,6 +227,7 @@ $(function () {
             }
 
             self.saveSettings(false);
+            self.autoconnect(false);
             self.connectionOptionsLastUpdated(new Date().getTime());
         };
 

--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -206,7 +206,7 @@ $(function () {
                 connectorParameters,
                 response.current,
                 {connector: self.lastConnector, parameters: self.lastConnectorParameters},
-                preferredConnector
+                response.options.preferredConnector
             ]);
 
             // printer profile

--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -79,7 +79,7 @@ $(function () {
         });
 
         self.enableAutoConnect = ko.pureComputed(function () {
-            return self.enableConnect() && self.isErrorOrClosed();
+            return self.enableSaveSettings() && self.saveSettings();
         });
 
         self.previousIsOperational = undefined;

--- a/src/octoprint/static/js/app/viewmodels/connection.js
+++ b/src/octoprint/static/js/app/viewmodels/connection.js
@@ -41,8 +41,10 @@ $(function () {
         };
 
         self.currentConnector = ko.observable(undefined);
-        self.currentConnectorParameters = {};
         self.currentConnectorCapabilities = ko.observable({});
+
+        self.preferredConnectorName = ko.observable("-");
+        self.preferredConnectorParameters = ko.observableArray([]);
 
         self.lastConnector = undefined;
         self.lastConnectorParameters = {};
@@ -95,7 +97,61 @@ $(function () {
         self.fromResponse = function (response) {
             const connectors = response.options.connectors;
             const currentConnector = response.current.connector;
+
+            // preferred connection
+
             const preferredConnector = response.options.preferredConnector.connector;
+            const preferredConnectorParameters =
+                response.options.preferredConnector.parameters;
+            const preferredConnectorData = connectors.find(
+                (c) => c.connector === preferredConnector
+            );
+
+            if (preferredConnectorData) {
+                self.preferredConnectorName(preferredConnectorData.name);
+            } else {
+                // fallback
+                self.preferredConnectorName(`<code>${preferredConnector}</code>`);
+            }
+
+            let preferredConnectorParametersRendered = false;
+            callViewModels(
+                self.allViewModels,
+                "onRenderParametersForConnector",
+                (method) => {
+                    if (preferredConnectorParametersRendered) return;
+
+                    const result = method(
+                        preferredConnector,
+                        preferredConnectorParameters
+                    );
+                    if (result === false || !Array.isArray(result)) return;
+
+                    preferredConnectorParametersRendered = true;
+                    self.preferredConnectorParameters(
+                        result
+                            .filter(
+                                // make sure everything has name & value
+                                (item) =>
+                                    item.name !== undefined && item.value !== undefined
+                            )
+                            .map((item) => `${item.name}: ${item.value}`)
+                    );
+                }
+            );
+
+            if (!preferredConnectorParametersRendered) {
+                // fallback
+                const params = [];
+                for (const key in preferredConnectorParameters) {
+                    params.push(
+                        `<code>${key}</code>: <code>${JSON.stringify(preferredConnectorParameters[key])}</code>`
+                    );
+                }
+                self.preferredConnectorParameters(params);
+            }
+
+            // available connectors, parameters & capabilities
 
             self.connectorOptions(connectors);
 
@@ -106,6 +162,8 @@ $(function () {
             self.connectorParameters = connectorParameters;
 
             self.currentConnectorCapabilities(response.current.capabilities);
+
+            // determine active parameters
 
             let activeParameters;
             if (currentConnector && connectorParameters[currentConnector]) {
@@ -120,13 +178,13 @@ $(function () {
                 activeParameters = self.lastConnectorParameters;
             } else if (preferredConnector && connectorParameters[preferredConnector]) {
                 self.selectedConnector(preferredConnector);
-                activeParameters = response.options.preferredConnector.parameters;
+                activeParameters = preferredConnectorParameters;
             } else {
                 self.selectedConnector(connectors[0].connector);
                 activeParameters = undefined;
             }
 
-            // connectors
+            // set parameters on connection form & inform viewmodels of received data
 
             if (activeParameters) {
                 const container = $(`#connection_options_${self.selectedConnector()}`);
@@ -148,7 +206,7 @@ $(function () {
                 connectorParameters,
                 response.current,
                 {connector: self.lastConnector, parameters: self.lastConnectorParameters},
-                response.options.preferredConnector
+                preferredConnector
             ]);
 
             // printer profile
@@ -237,6 +295,9 @@ $(function () {
 
                 if (self.saveSettings()) data["save"] = true;
 
+                self.autoconnect(false);
+                self.saveSettings(false);
+
                 OctoPrint.connection.connect(data).done(function () {
                     self.settings.requestData();
                     self.settings.printerProfiles.requestData();
@@ -312,6 +373,6 @@ $(function () {
             "printerProfilesViewModel",
             "accessViewModel"
         ],
-        elements: ["#connection_wrapper"]
+        elements: ["#connection_wrapper", "#settings_printerconnection"]
     });
 });

--- a/src/octoprint/templates/dialogs/settings/printerconnection.jinja2
+++ b/src/octoprint/templates/dialogs/settings/printerconnection.jinja2
@@ -1,0 +1,41 @@
+<h3>{{ _("Printer Connection") }}</h3>
+
+<h4>{{ _("Default Connection Settings") }}</h4>
+
+<p>
+    {% trans %}
+    The following settings are the current connection defaults:
+{% endtrans %}
+</p>
+
+<dl>
+    <dt>{{ _("Connection Type") }}</dt>
+    <dd>
+        <span data-bind="text: preferredConnectorName"></span>
+    </dd>
+
+    <dt>{{ _("Connection Parameters") }}</dt>
+    <dd data-bind="foreach: preferredConnectorParameters">
+        <span data-bind="html: $data"></span>
+        <br />
+    </dd>
+</dl>
+
+<p>
+    {% trans %}
+    If you want to try to automatically connect with these settings on server startup,
+    check the following checkbox:
+{% endtrans %}
+</p>
+
+<form class="form-horizontal" onsubmit="return false;">
+    <div class="control-group">
+        <div class="controls">
+            <label class="checkbox">
+                <input type="checkbox"
+                       data-bind="checked: settings.settings.printerConnection.autoconnect">
+                {{ _("Attempt to autoconnect on startup with these settings") }}
+            </label>
+        </div>
+    </div>
+</form>

--- a/src/octoprint/templates/dialogs/settings/printerconnection.jinja2
+++ b/src/octoprint/templates/dialogs/settings/printerconnection.jinja2
@@ -11,7 +11,7 @@
 <dl>
     <dt>{{ _("Connection Type") }}</dt>
     <dd>
-        <span data-bind="text: preferredConnectorName"></span>
+        <span data-bind="html: preferredConnectorName"></span>
     </dd>
 
     <dt>{{ _("Connection Parameters") }}</dt>

--- a/src/octoprint/templates/sidebar/connection/connection.jinja2
+++ b/src/octoprint/templates/sidebar/connection/connection.jinja2
@@ -33,7 +33,7 @@
     <input type="checkbox"
            id="connection_save"
            data-bind="checked: saveSettings, enable: enableSaveSettings()">
-    {{ _("Save connection settings") }}
+    {{ _("Set as default connection settings") }}
 </label>
 
 <label class="checkbox" data-bind="css: {muted: !enableAutoConnect()}">

--- a/tests/plugins/serial_connector/test_serial_baudrate_lists.py
+++ b/tests/plugins/serial_connector/test_serial_baudrate_lists.py
@@ -297,3 +297,34 @@ def test_baudrate_list(
 
         # verify
         assert result == expected
+
+
+def test_baudrate_list_copied():
+    additional = [300000]
+
+    def settings_get(path):
+        if path == ["plugins", "serial_connector", "additionalBaudrates"]:
+            return additional
+        elif path == ["plugins", "serial_connector", "blocklistedBaudrates"]:
+            return []
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        elif path == ["printerConnection", "preferred", "parameters"]:
+            return {}
+        return None
+
+    with mock.patch(
+        "octoprint.plugins.serial_connector.serial_comm.settings"
+    ) as settings_getter:
+        patched_settings = mock.MagicMock()
+        patched_settings.get.side_effect = settings_get
+        settings_getter.return_value = patched_settings
+
+        expected = additional + STANDARD_BAUDRATES
+
+        # test & verify
+        result = baudrateList()  # first call
+        assert result == expected
+
+        result = baudrateList()  # second call
+        assert result == expected  # should not have additional in there twice now

--- a/tests/plugins/serial_connector/test_serial_baudrate_lists.py
+++ b/tests/plugins/serial_connector/test_serial_baudrate_lists.py
@@ -1,0 +1,299 @@
+import sys
+from unittest import mock
+
+import pytest
+
+from octoprint.plugins.serial_connector.serial_comm import (
+    STANDARD_BAUDRATES,
+    baudrateList,
+    serialList,
+)
+
+
+@pytest.mark.parametrize(
+    "ports, additional, hooks, blocklisted, connector, params, expected",
+    [
+        pytest.param(
+            ["ttyUSB0"], [], [], [], "other", {}, ["/dev/ttyUSB0"], id="most basic case"
+        ),
+        pytest.param(
+            ["ttyUSB0", "ttyUSB1", "ttyUSB2"],
+            [],
+            [],
+            [],
+            "serial",
+            {"port": "/dev/ttyUSB2"},
+            ["/dev/ttyUSB2", "/dev/ttyUSB0", "/dev/ttyUSB1"],
+            id="sorting changed by preferred connection",
+        ),
+        pytest.param(
+            ["ttyUSB0", "ttyUSB1", "ttyUSB2"],
+            [],
+            [],
+            [],
+            "serial",
+            {"port": "/dev/ttyUSB4"},
+            ["/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyUSB2"],
+            id="preferred connection not in found candidates",
+        ),
+        pytest.param(
+            ["ttyUSB0", "ttyUSB1", "ttyUSB2"],
+            [],
+            [],
+            [],
+            "serial",
+            {},
+            ["/dev/ttyUSB0", "/dev/ttyUSB1", "/dev/ttyUSB2"],
+            id="preferred connection but no preferred port",
+        ),
+        pytest.param(
+            ["ttyUSB0"],
+            ["/foo/bar"],
+            [],
+            [],
+            "other",
+            {},
+            ["/dev/ttyUSB0", "/foo/bar"],
+            id="additional port",
+        ),
+        pytest.param(
+            ["ttyUSB0"],
+            [],
+            ["VIRTUAL1", "VIRTUAL2"],
+            [],
+            "other",
+            {},
+            ["/dev/ttyUSB0", "VIRTUAL1", "VIRTUAL2"],
+            id="ports from a hook",
+        ),
+        pytest.param(
+            ["ttyUSB0", "ttyS0", "ttyS1"],
+            [],
+            [],
+            ["/dev/ttyS*"],
+            "other",
+            {},
+            ["/dev/ttyUSB0"],
+            id="blocklisted ports",
+        ),
+        pytest.param(
+            ["ttyUSB0"],
+            ["/foo/bar"],
+            [],
+            ["/f*"],
+            "other",
+            {},
+            ["/dev/ttyUSB0"],
+            id="blocklist used *after* additional ports get added",
+        ),
+        pytest.param(
+            ["ttyUSB0"],
+            [],
+            ["/foo/bar"],
+            ["/f*"],
+            "other",
+            {},
+            ["/dev/ttyUSB0"],
+            id="blocklist used *after* hook results get added",
+        ),
+    ],
+)
+def test_serial_list(
+    ports,
+    additional,
+    hooks,
+    blocklisted,
+    connector,
+    params,
+    expected,
+):
+    def settings_get(path):
+        if path == ["plugins", "serial_connector", "additionalPorts"]:
+            return additional
+        elif path == ["plugins", "serial_connector", "blocklistedPorts"]:
+            return blocklisted
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return connector
+        elif path == ["printerConnection", "preferred", "parameters"]:
+            return params
+        return None
+
+    with mock.patch(
+        "octoprint.plugins.serial_connector.serial_comm.settings"
+    ) as settings_getter:
+        patched_settings = mock.MagicMock()
+        patched_settings.get.side_effect = settings_get
+        settings_getter.return_value = patched_settings
+
+        with mock.patch("octoprint.plugin.plugin_manager") as pmgr_getter:
+            patched_pmgr = mock.MagicMock()
+            if hooks:
+
+                def hook(candidates):
+                    return hooks
+
+                patched_pmgr.get_hooks.return_value = {"some_plugin": hook}
+            else:
+                patched_pmgr.get_hooks.return_value = {}
+            pmgr_getter.return_value = patched_pmgr
+
+            with mock.patch(
+                "octoprint.plugins.serial_connector.serial_comm.os"
+            ) as patched_os:
+                scandir_result = []
+                for port in ports:
+                    d = mock.MagicMock()
+                    d.name = port
+                    d.path = f"/dev/{port}"
+                    scandir_result.append(d)
+
+                patched_os.name = "linux"
+                patched_os.scandir.return_value = scandir_result
+
+                with mock.patch("glob.glob") as patched_glob:
+                    patched_glob.return_value = additional
+
+                    # test
+                    result = serialList()
+
+                    # verify
+                    assert result == expected
+
+                    patched_glob.assert_has_calls(
+                        [mock.call(port) for port in additional]
+                    )
+
+
+def test_serial_list_windows():
+    with mock.patch(
+        "octoprint.plugins.serial_connector.serial_comm.settings"
+    ) as settings_getter:
+        patched_settings = mock.MagicMock()
+        patched_settings.get.return_value = None
+        settings_getter.return_value = patched_settings
+
+        with mock.patch("octoprint.plugin.plugin_manager") as pmgr_getter:
+            patched_pmgr = mock.MagicMock()
+            patched_pmgr.get_hooks.return_value = {}
+            pmgr_getter.return_value = patched_pmgr
+
+            with mock.patch(
+                "octoprint.plugins.serial_connector.serial_comm.os"
+            ) as patched_os:
+                patched_os.name = "nt"
+
+                def mocked_enumvalue(key, idx):
+                    if idx < 2:
+                        return ("", f"COM{idx}")
+                    raise OSError("bzzzt")
+
+                mocked_openkey = mock.MagicMock()
+                mocked_openkey.__enter__.return_value = "some_key"
+
+                mocked_winreg = mock.Mock()
+                mocked_winreg.HKEY_LOCAL_MACHINE = "HKEY_LOCAL_MACHINE"
+                mocked_winreg.OpenKey.return_value = mocked_openkey
+                mocked_winreg.EnumValue.side_effect = mocked_enumvalue
+
+                with mock.patch.dict(sys.modules, {"winreg": mocked_winreg}):
+                    # test
+                    result = serialList()
+
+                    # verify
+                    assert result == ["COM0", "COM1"]
+
+                    mocked_winreg.EnumValue.assert_has_calls(
+                        [
+                            mock.call("some_key", 0),
+                            mock.call("some_key", 1),
+                            mock.call("some_key", 2),
+                        ]
+                    )
+
+
+@pytest.mark.parametrize(
+    "baudrates, additional, blocklisted, connector, params, expected",
+    [
+        pytest.param(None, [], [], "other", {}, STANDARD_BAUDRATES, id="most basic case"),
+        pytest.param(
+            [], [], [], "other", {}, [], id="empty candidates, no defaults used"
+        ),
+        pytest.param([], [300000], [], "other", {}, [300000], id="additional baudrate"),
+        pytest.param(
+            [115200, 250000, 9600],
+            [],
+            [],
+            "serial",
+            {"baudrate": 9600},
+            [9600, 115200, 250000],
+            id="sorting changed by preferred connection",
+        ),
+        pytest.param(
+            [115200, 250000, 9600],
+            [],
+            [],
+            "serial",
+            {"baudrate": 300000},
+            [115200, 250000, 9600],
+            id="preferred connection not found in candidates",
+        ),
+        pytest.param(
+            [115200, 250000, 9600],
+            [],
+            [],
+            "serial",
+            {},
+            [115200, 250000, 9600],
+            id="preferred connection but no preferred baudrate",
+        ),
+        pytest.param(
+            [115200, 250000],
+            [],
+            [250000],
+            "other",
+            {},
+            [115200],
+            id="blocklisted baudrate",
+        ),
+        pytest.param(
+            [115200],
+            [300000],
+            [300000],
+            "other",
+            {},
+            [115200],
+            id="blocklist used *after* additional baudrates get added",
+        ),
+    ],
+)
+def test_baudrate_list(
+    baudrates,
+    additional,
+    blocklisted,
+    connector,
+    params,
+    expected,
+):
+    def settings_get(path):
+        if path == ["plugins", "serial_connector", "additionalBaudrates"]:
+            return additional
+        elif path == ["plugins", "serial_connector", "blocklistedBaudrates"]:
+            return blocklisted
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return connector
+        elif path == ["printerConnection", "preferred", "parameters"]:
+            return params
+        return None
+
+    with mock.patch(
+        "octoprint.plugins.serial_connector.serial_comm.settings"
+    ) as settings_getter:
+        patched_settings = mock.MagicMock()
+        patched_settings.get.side_effect = settings_get
+        settings_getter.return_value = patched_settings
+
+        # test
+        result = baudrateList(baudrates)
+
+        # verify
+        assert result == expected

--- a/tests/plugins/serial_connector/test_settings_migration.py
+++ b/tests/plugins/serial_connector/test_settings_migration.py
@@ -229,7 +229,7 @@ def test_migration_autorefresh_interval(plugin):
     ],
 )
 def test_migration_blocklists(plugin, current_version, config, expected):
-    """Tests migration of blocklisted{ports|Baudrates} to blacklisted{Ports|Baudrates}"""
+    """Tests migration of blacklisted{ports|Baudrates} to blocklisted{Ports|Baudrates}"""
 
     # prep
     target = 2

--- a/tests/plugins/serial_connector/test_settings_migration.py
+++ b/tests/plugins/serial_connector/test_settings_migration.py
@@ -1,0 +1,288 @@
+from unittest import mock
+
+import pytest
+
+
+@pytest.fixture()
+def plugin():
+    from octoprint.plugins.serial_connector import SerialConnectorPlugin
+
+    p = SerialConnectorPlugin()
+    p._settings = mock.MagicMock()
+    p._logger = mock.MagicMock()
+
+    return p
+
+
+@pytest.mark.parametrize("preferred_connector", [None, "serial"])
+def test_migration_serial_printer_connection(plugin, preferred_connector):
+    """
+    Tests correct migration of printer connection settings (autoconnect, port, baudrate)
+    for serial or unset preferred connector
+    """
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {
+                "port": "VIRTUAL",
+                "baudrate": 115200,
+                "autoconnect": True,
+                "log": True,
+            }
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return preferred_connector
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(
+                ["printerConnection", "preferred", "parameters"],
+                {"port": "VIRTUAL", "baudrate": 115200},
+            ),
+            mock.call(["plugins", "serial_connector"], {"log": True}, force=True),
+        ]
+    )
+    plugin._settings.global_set_boolean.assert_called_once_with(
+        [
+            "printerConnection",
+            "autoconnect",
+        ],
+        True,
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+def test_migration_serial_printer_connection_other_connector(plugin):
+    """
+    Tests deletion of printer connection settings (autoconnect, port, baudrate)
+    for unrelated default connector
+    """
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {
+                "port": "VIRTUAL",
+                "baudrate": 115200,
+                "autoconnect": True,
+                "log": True,
+            }
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(["plugins", "serial_connector"], {"log": True}, force=True),
+        ]
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+@pytest.mark.parametrize(
+    "config, expected",
+    [
+        # errorHandling
+        ({"disconnectOnErrors": True}, {"errorHandling": "disconnect"}),
+        ({"disconnectOnErrors": False}, {"errorHandling": "cancel"}),
+        ({"ignoreErrorsFromFirmware": True}, {"errorHandling": "ignore"}),
+        ({"ignoreErrorsFromFirmware": False}, {"errorHandling": "cancel"}),
+        # sendChecksum
+        ({"alwaysSendChecksum": True}, {"sendChecksum": "always"}),
+        ({"alwaysSendChecksum": False}, {"sendChecksum": "print"}),
+        ({"neverSendChecksum": True}, {"sendChecksum": "never"}),
+        ({"neverSendChecksum": False}, {"sendChecksum": "print"}),
+    ],
+)
+def test_migration_serial_behaviour(plugin, config, expected):
+    """Tests migration of serial settings to plugins.serial_connector.{errorHandling|sendChecksum}"""
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return config
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(["plugins", "serial_connector"], expected, force=True),
+        ]
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+@pytest.mark.parametrize(
+    "current_version, config, expected",
+    [
+        (None, {"blacklistedPorts": []}, {"blocklistedPorts": []}),
+        (1, {"blacklistedPorts": []}, {"blocklistedPorts": []}),
+        (None, {"blacklistedBaudrates": []}, {"blocklistedBaudrates": []}),
+        (1, {"blacklistedBaudrates": []}, {"blocklistedBaudrates": []}),
+    ],
+)
+def test_migration_blocklists(plugin, current_version, config, expected):
+    """Tests migration of blocklisted{ports|Baudrates} to blacklisted{Ports|Baudrates}"""
+
+    # prep
+    target = 2
+
+    def settings_global_get(path):
+        if path == ["plugins", "serial_connector"]:
+            return config
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(["plugins", "serial_connector"], expected, force=True),
+        ]
+    )
+
+
+def test_migration_blocklists_unmodified(plugin):
+    """Tests unnecessary blacklist migration"""
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["plugins", "serial_connector"]:
+            return {"log": True}
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_not_called()
+
+
+def test_migration_path_version_none(plugin):
+    """Tests both migrations are done"""
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {
+                "port": "VIRTUAL",
+                "baudrate": 115200,
+                "autoconnect": True,
+                "log": True,
+            }
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        elif path == ["plugins", "serial_connector"]:
+            return {"blacklistedPorts": []}
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(["plugins", "serial_connector"], {"log": True}, force=True),
+            mock.call(
+                ["plugins", "serial_connector"], {"blocklistedPorts": []}, force=True
+            ),
+        ]
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+def test_migration_path_version_1(plugin):
+    """Tests only the blocklist migration is done"""
+
+    # prep
+    target = 2
+    current_version = 1
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {
+                "port": "VIRTUAL",
+                "baudrate": 115200,
+                "autoconnect": True,
+                "log": True,
+            }
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        elif path == ["plugins", "serial_connector"]:
+            return {"blacklistedPorts": []}
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_has_calls(
+        [
+            mock.call(
+                ["plugins", "serial_connector"], {"blocklistedPorts": []}, force=True
+            ),
+        ]
+    )
+    plugin._settings.global_remove.assert_not_called()
+
+
+def test_migration_path_version_2(plugin):
+    """Tests no migration is done"""
+
+    # prep
+    target = 2
+    current_version = 2
+
+    def settings_global_get(path):
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set.assert_not_called()
+    plugin._settings.global_remove.assert_not_called()

--- a/tests/plugins/serial_connector/test_settings_migration.py
+++ b/tests/plugins/serial_connector/test_settings_migration.py
@@ -14,8 +14,35 @@ def plugin():
     return p
 
 
-@pytest.mark.parametrize("preferred_connector", [None, "serial"])
-def test_migration_serial_printer_connection(plugin, preferred_connector):
+@pytest.mark.parametrize(
+    "preferred_connector, autoconnect, parameters, expected",
+    [
+        (
+            None,
+            False,
+            {"port": "VIRTUAL", "baudrate": 115200},
+            {"port": "VIRTUAL", "baudrate": 115200},
+        ),
+        (
+            "serial",
+            False,
+            {"port": "VIRTUAL", "baudrate": 115200},
+            {"port": "VIRTUAL", "baudrate": 115200},
+        ),
+        (
+            "serial",
+            True,
+            {"port": "VIRTUAL", "baudrate": 115200},
+            {"port": "VIRTUAL", "baudrate": 115200},
+        ),
+        ("serial", True, {"port": "VIRTUAL"}, {"port": "VIRTUAL", "baudrate": None}),
+        ("serial", True, {"baudrate": 115200}, {"port": None, "baudrate": 115200}),
+        ("serial", True, {}, {"port": None, "baudrate": None}),
+    ],
+)
+def test_migration_serial_printer_connection(
+    plugin, preferred_connector, autoconnect, parameters, expected
+):
     """
     Tests correct migration of printer connection settings (autoconnect, port, baudrate)
     for serial or unset preferred connector
@@ -27,12 +54,7 @@ def test_migration_serial_printer_connection(plugin, preferred_connector):
 
     def settings_global_get(path):
         if path == ["serial"]:
-            return {
-                "port": "VIRTUAL",
-                "baudrate": 115200,
-                "autoconnect": True,
-                "log": True,
-            }
+            return dict(autoconnect=autoconnect, log=True, **parameters)
         elif path == ["printerConnection", "preferred", "connector"]:
             return preferred_connector
         return None
@@ -47,7 +69,7 @@ def test_migration_serial_printer_connection(plugin, preferred_connector):
         [
             mock.call(
                 ["printerConnection", "preferred", "parameters"],
-                {"port": "VIRTUAL", "baudrate": 115200},
+                expected,
             ),
             mock.call(["plugins", "serial_connector"], {"log": True}, force=True),
         ]
@@ -57,7 +79,7 @@ def test_migration_serial_printer_connection(plugin, preferred_connector):
             "printerConnection",
             "autoconnect",
         ],
-        True,
+        autoconnect,
     )
     plugin._settings.global_remove.assert_called_once_with(["serial"])
 
@@ -135,6 +157,64 @@ def test_migration_serial_behaviour(plugin, config, expected):
         [
             mock.call(["plugins", "serial_connector"], expected, force=True),
         ]
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+def test_migration_autorefresh(plugin):
+    """Tests migration of serial settings to printerConnection.autorefresh"""
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {"autorefresh": True}
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set_boolean.assert_called_once_with(
+        ["printerConnection", "autorefresh"], True
+    )
+    plugin._settings.global_set.assert_called_once_with(
+        ["plugins", "serial_connector"], {}, force=True
+    )
+    plugin._settings.global_remove.assert_called_once_with(["serial"])
+
+
+def test_migration_autorefresh_interval(plugin):
+    """Tests migration of serial settings to printerConnection.autorefreshInterval"""
+
+    # prep
+    target = 2
+    current_version = None
+
+    def settings_global_get(path):
+        if path == ["serial"]:
+            return {"autorefreshInterval": 5}
+        elif path == ["printerConnection", "preferred", "connector"]:
+            return "other"
+        return None
+
+    plugin._settings.global_get.side_effect = settings_global_get
+
+    # test
+    plugin.on_settings_migrate(target, current_version)
+
+    # verify
+    plugin._settings.global_set_int.assert_called_once_with(
+        ["printerConnection", "autorefreshInterval"], 5
+    )
+    plugin._settings.global_set.assert_called_once_with(
+        ["plugins", "serial_connector"], {}, force=True
     )
     plugin._settings.global_remove.assert_called_once_with(["serial"])
 


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

Solves the backwards compatibility and UX issues regarding the `autoconnect` settings.

1. `autoconnect` has been added back to `/api/connection` (under `options`)
2. Settings schema of the serial connector no longer contains `port`, `baudrate` and `autoconnect`, the initial settings migration has been adjusted to move those to `printerConnection.[autoconnect|preferred.parameters]` as needed. Unit tests have been added to fully test the migration.
3. A new settings page has been added that allows to *see* the current default connection settings and change the `autoconnect` setting. The behaviour of the auto connect checkbox on the connection sidebar has been changed to switch back to off once the connection command has been triggered, as has the "save as default" checkbox. Small wording changes.

#### How was it tested? How can it be tested by the reviewer?

1. curl
2. unit tests
3. manual testing

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

<img width="1355" height="568" alt="image" src="https://github.com/user-attachments/assets/ee5862ff-c83b-45ed-871f-455167ecade5" />

#### Further notes

Would love a review from you, @jacopotediosi!