### PR TITLE
feat: track job's plate & add plate param to thumbnail api

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -1385,13 +1385,19 @@ class FileManager:
     def has_thumbnail(self, location, path) -> bool:
         return self._storage(location).has_thumbnail(path)
 
-    def get_thumbnail(self, location, path, sizehint=None) -> Optional[StorageThumbnail]:
-        return self._storage(location).get_thumbnail(path, sizehint=sizehint)
+    def get_thumbnail(
+        self, location, path, platehint: int = None, sizehint: str = None
+    ) -> Optional[StorageThumbnail]:
+        return self._storage(location).get_thumbnail(
+            path, platehint=platehint, sizehint=sizehint
+        )
 
     def read_thumbnail(
-        self, location, path, sizehint=None
+        self, location, path, platehint: int = None, sizehint: str = None
     ) -> tuple[StorageThumbnail, IO]:
-        return self._storage(location).read_thumbnail(path, sizehint=sizehint)
+        return self._storage(location).read_thumbnail(
+            path, platehint=platehint, sizehint=sizehint
+        )
 
     def refresh_thumbnails(
         self, location, path, force: bool = False, recursive: bool = False

--- a/src/octoprint/filemanager/storage/__init__.py
+++ b/src/octoprint/filemanager/storage/__init__.py
@@ -129,6 +129,7 @@ class StorageThumbnail(BaseModel):
     name: str
     printable: str
     sizehint: str
+    plate: int = 1
     mime: str = "application/octet-stream"
     last_modified: Optional[datetime.datetime] = None
     size: int = -1
@@ -525,11 +526,13 @@ class StorageInterface:
         raise NotImplementedError()
 
     def get_thumbnail(
-        self, path: str, sizehint: str = None
+        self, path: str, platehint: int = None, sizehint: str = None
     ) -> Optional[StorageThumbnail]:
         raise NotImplementedError()
 
-    def read_thumbnail(self, path: str, sizehint: str = None) -> Optional[IO]:
+    def read_thumbnail(
+        self, path: str, platehint: int = None, sizehint: str = None
+    ) -> Optional[IO]:
         raise NotImplementedError()
 
     def refresh_thumbnails(

--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -804,14 +804,18 @@ class LocalFileStorage(StorageInterface):
         thumbnails = self._get_thumbnails(path, name)
         return thumbnails and len(thumbnails) > 0
 
-    def get_thumbnail(self, path, sizehint=None) -> StorageThumbnail:
+    def get_thumbnail(self, path, platehint=None, sizehint=None) -> StorageThumbnail:
+        # platehint is currently not supported on local storage
         sh, thumb = self._thumbnail_from_sizehint(path, sizehint=sizehint)
         if not thumb:
             return None
 
         return self._to_thumbnail_info(thumb, sh, path)
 
-    def read_thumbnail(self, path, sizehint=None) -> tuple[StorageThumbnail, typing.IO]:
+    def read_thumbnail(
+        self, path, platehint=None, sizehint=None
+    ) -> tuple[StorageThumbnail, typing.IO]:
+        # platehint is currently not supported on local storage
         sh, thumb = self._thumbnail_from_sizehint(path, sizehint=sizehint)
         if not thumb:
             return None

--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -463,13 +463,19 @@ class PrinterFileStorage(StorageInterface):
     def has_thumbnail(self, path) -> bool:
         return self._connection.has_thumbnail(path)
 
-    def get_thumbnail(self, path, sizehint=None) -> Optional[StorageThumbnail]:
-        return self._connection.get_thumbnail(path, sizehint=sizehint)
+    def get_thumbnail(
+        self, path, platehint=None, sizehint=None
+    ) -> Optional[StorageThumbnail]:
+        return self._connection.get_thumbnail(
+            path, platehint=platehint, sizehint=sizehint
+        )
 
     def read_thumbnail(
-        self, path, sizehint=None
+        self, path, platehint=None, sizehint=None
     ) -> Optional[tuple[StorageThumbnail, IO]]:
-        return self._connection.download_thumbnail(path, sizehint=sizehint)
+        return self._connection.download_thumbnail(
+            path, platehint=platehint, sizehint=sizehint
+        )
 
     def refresh_thumbnails(
         self, path, force: bool = False, recursive: bool = False

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -711,12 +711,12 @@ class PrinterFilesMixin:
         return False
 
     def get_thumbnail(
-        self, path: str, sizehint: str = None, *args, **kwargs
+        self, path: str, platehint: int = None, sizehint: str = None, *args, **kwargs
     ) -> Optional[StorageThumbnail]:
         return None
 
     def download_thumbnail(
-        self, path: str, sizehint: str = None, *args, **kwargs
+        self, path: str, platehint: int = None, sizehint: str = None, *args, **kwargs
     ) -> Optional[tuple[StorageThumbnail, IO]]:
         return None
 

--- a/src/octoprint/printer/job.py
+++ b/src/octoprint/printer/job.py
@@ -18,6 +18,7 @@ class FilamentEstimate(BaseModel):
 class PrintJob(BaseModel):
     storage: str
     path: str
+    plate: int = 1
     display: str
     size: int = 0
     date: Optional[datetime.datetime] = None

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1834,6 +1834,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                             size=None,
                             date=None,
                             upload=None,
+                            plate=None,
                         ),
                         estimatedPrintTime=None,
                         filament=None,
@@ -1873,6 +1874,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                         if job.date
                         else None,
                         upload=isinstance(job, UploadJob),
+                        plate=job.plate,
                     ),
                     estimatedPrintTime=estimatedPrintTime,
                     filament=filament,

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1834,11 +1834,11 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                             size=None,
                             date=None,
                             upload=None,
-                            plate=None,
                         ),
                         estimatedPrintTime=None,
                         filament=None,
                         user=None,
+                        plate=None,
                     )
                 )
                 return
@@ -1874,11 +1874,11 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                         if job.date
                         else None,
                         upload=isinstance(job, UploadJob),
-                        plate=job.plate,
                     ),
                     estimatedPrintTime=estimatedPrintTime,
                     filament=filament,
                     user=user,
+                    plate=job.plate,
                 )
             )
             self._selected_job = job

--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -1468,11 +1468,18 @@ class StorageThumbnailDownloadHandler(
             if not self.SIZEHINT_PATTERN.fullmatch(sizehint):
                 sizehint = None
 
+        platehint = self.request.arguments.get("plate")
+        if platehint:
+            try:
+                platehint = int(platehint[0].decode("utf-8"))
+            except ValueError:
+                platehint = None
+
         if include_body:
             handle = None
             try:
                 thumbnail = self._file_manager.read_thumbnail(
-                    storage, path, sizehint=sizehint
+                    storage, path, platehint=platehint, sizehint=sizehint
                 )
                 if thumbnail is None:
                     raise tornado.web.HTTPError(404)
@@ -1498,7 +1505,9 @@ class StorageThumbnailDownloadHandler(
         else:
             assert self.request.method == "HEAD"
 
-            meta = self._file_manager.get_thumbnail(storage, path, sizehint=sizehint)
+            meta = self._file_manager.get_thumbnail(
+                storage, path, platehint=platehint, sizehint=sizehint
+            )
             if not meta:
                 raise tornado.web.HTTPError(404)
 

--- a/src/octoprint/static/js/app/viewmodels/printerstate.js
+++ b/src/octoprint/static/js/app/viewmodels/printerstate.js
@@ -79,6 +79,8 @@ $(function () {
         self.filedata = ko.observable(undefined);
         self.filepos = ko.observable(undefined);
 
+        self.plate = ko.observable(undefined);
+
         self.filename = ko.pureComputed(() => {
             return self.filedata() ? self.filedata()["name"] : undefined;
         });
@@ -106,7 +108,10 @@ $(function () {
         self.thumbnailLink = ko.pureComputed(() => {
             const data = self.filedata();
             if (data && data.refs && data.refs.thumbnail) {
-                return data.refs.thumbnail;
+                const plate = self.plate();
+                const url = new URL(data.refs.thumbnail);
+                url.searchParams.set("plate", plate || 1);
+                return url.toString();
             } else {
                 return false;
             }
@@ -467,6 +472,8 @@ $(function () {
             self.filament(result);
 
             self.user(data.user);
+
+            self.plate(data.plate);
         };
 
         self._processProgressData = function (data) {


### PR DESCRIPTION
#### What does this PR do and why is it necessary?

This PR introduces a new `platehint` parameter on the thumbnail related methods of filemanager, storages and printer connectors that allows to specify the plate for which to fetch the thumbnail, adds a `plate` parameter to the print job that also gets pushed to the UI through the current job data and can then be used there to fetch the plate specific thumbnail in the printer/job state panel.

#### How was it tested? How can it be tested by the reviewer?

I haven't yet adjusted any connectors, so for now I only tested whether thumbnails still work and the printer state attaches the expected `plate` query parameter.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

This is related to OctoPrint/OctoPrint-BambuConnector#2

#### What are the relevant tickets if any?

OctoPrint/OctoPrint-BambuConnector#2

#### Screenshots (if appropriate)

#### Further notes

Would love some feedback on this from you, @jneilliii, especially whether it would actually solve the issue in question - you are currently deeper in the plugin than me.

The idea would be to set the `plate` parameter when creating the print job in the connector, and adjusting `get_thumbnail` and `read_thumbnail` to support plate specific ones, and then things should work automatically.
