### PR TITLE
fix(api): fix API incompatibilities

### DIFF
--- a/docs/api/files.rst
+++ b/docs/api/files.rst
@@ -1095,6 +1095,7 @@ Retrieve a specific file's or folder's information
    :param location: The location of the file for which to retrieve the information, by default ``local`` (for OctoPrint's ``uploads``
                     folder) or ``printer`` or its deprecated alias ``sdcard`` for the printer's internal storage (if available)
    :param filename: The filename of the file for which to retrieve the information
+   :param recursive: If set to ``true``, return all files and folders recursively. Otherwise only return items on same level.
    :statuscode 200: No error
    :statuscode 404: If ``target`` is not among the registered storages (e.g. ``local``, ``printer`` or its deprecated alias ``sdcard``)
 

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -401,7 +401,7 @@ def readGcodeFile(target, filename):
 
         recursive = request.values.get("recursive", "false") in valid_boolean_trues
 
-        file = _getFileDetails(target, filename, recursive)
+        file = _getFileDetails(target, filename, recursive=recursive)
         if not file:
             abort(404)
 
@@ -417,18 +417,19 @@ def _getFileDetails(origin, path, recursive=True):
     else:
         parent = None
 
-    if not recursive:
+    if recursive:
+        data = fileManager.get_storage_entry(origin, path)
+        if not data:
+            return None
+
+        return _analyse_and_convert_recursively(origin, [data], path=parent)[0]
+
+    else:
         files = _getFileList(origin, path=parent, recursive=False, level=1)
         for f in files:
             if f.path == path:
                 return f
         return None
-
-    data = fileManager.get_storage_entry(origin, path)
-    if not data:
-        return None
-
-    return _analyse_and_convert_recursively(origin, [data], path=parent)[0]
 
 
 @time_this(

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -385,9 +385,12 @@ def readGcodeFilesForOrigin(origin):
 @with_revalidation_checking(
     etag_factory=lambda lm=None: _create_etag(
         request.path,
+        recursive=request.values.get("recursive", "false") in valid_boolean_trues,
         lm=lm,
     ),
-    lastmodified_factory=lambda: _create_lastmodified(request.path, False),
+    lastmodified_factory=lambda: _create_lastmodified(
+        request.path, request.values.get("recursive", "false") in valid_boolean_trues
+    ),
     unless=lambda: request.values.get("force", "false") in valid_boolean_trues
     or request.values.get("_refresh", "false") in valid_boolean_trues,
 )
@@ -396,7 +399,9 @@ def readGcodeFile(target, filename):
         if not _validate_filename(target, filename):
             abort(404)
 
-        file = _getFileDetails(target, filename)
+        recursive = request.values.get("recursive", "false") in valid_boolean_trues
+
+        file = _getFileDetails(target, filename, recursive)
         if not file:
             abort(404)
 
@@ -406,11 +411,18 @@ def readGcodeFile(target, filename):
         abort(404)
 
 
-def _getFileDetails(origin, path):
+def _getFileDetails(origin, path, recursive=True):
     if "/" in path:
         parent, _ = path.rsplit("/", 1)
     else:
         parent = None
+
+    if not recursive:
+        files = _getFileList(origin, path=parent, recursive=False, level=1)
+        for f in files:
+            if f.path == path:
+                return f
+        return None
 
     data = fileManager.get_storage_entry(origin, path)
     if not data:

--- a/src/octoprint/server/api/settings.py
+++ b/src/octoprint/server/api/settings.py
@@ -282,6 +282,7 @@ def getSettings():
             "autoUppercaseBlocklist"
         )
         data["server"]["pluginBlacklist"] = data["server"].pop("pluginBlocklist")
+        data["system"]["events"] = s.get(["events"])
 
     if Permissions.WEBCAM.can() or (
         settings().getBoolean(["server", "firstRun"])
@@ -840,6 +841,8 @@ def _saveSettings(data):
     if "system" in data:
         if "actions" in data["system"]:
             s.set(["system", "actions"], data["system"]["actions"])
+        if "events" in data["system"] and not api_version_matches(">=2.0.0"):
+            s.set(["events"], data["system"]["events"])
 
     if "scripts" in data:
         if "gcode" in data["scripts"] and isinstance(data["scripts"]["gcode"], dict):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes two API backward-compatibility regressions introduced in the `dev` branch compared to version 1.11.7:

1. The `/api/settings` API, for both `GET` and `POST` methods, accepted as input and returned as output the `system.events` field in 1.11.7. In `dev`, the field was missing. This PR restores it only for API version < 2.0.0. The new API will continue not using it, in line with the documented [Data Model](https://docs.octoprint.org/en/dev/api/settings.html#sec-api-settings-datamodel).

2. The `/api/files/<origin>/<path>` API accepted the `recursive` parameter in 1.11.7, whereas in `dev` it was ignored. The [endpoint documentation](https://docs.octoprint.org/en/dev/api/files.html#retrieve-a-specific-file-s-or-folder-s-information:~:text=If%20the%20targeted%20path%20is%20a%20folder%2C%20by%20default%20only%20its%20direct%20children%20will%20be%20returned.%20If%20recursive%20is%20provided%20and%20set%20to%20true%2C%20all%20sub%20folders%20and%20their%20children%20will%20be%20returned%20too.) in `dev` still stated `If recursive is provided and set to true, all sub folders and their children will be returned too`, even though the parameter had been removed. This PR restores it for both the old and new API versions.

Both bugs affect the `dev` branch only.

#### How was it tested? How can it be tested by the reviewer?

To test settings API:
```bash
curl "http://localhost:5000/api/settings" -H "X-Api-Key: YOUR_API_KEY" -H "X-OctoPrint-Api-Version: 2.0.0"
curl "http://localhost:5000/api/settings" -H "X-Api-Key: YOUR_API_KEY" -H "X-OctoPrint-Api-Version: 1.11.7"
```

To test files API:
```bash
curl "http://localhost:5000/api/files/local/foo" -H "X-Api-Key: YOUR_API_KEY"
curl "http://localhost:5000/api/files/local/foo?recursive=false" -H "X-Api-Key: YOUR_API_KEY"
curl "http://localhost:5000/api/files/local/foo?recursive=true" -H "X-Api-Key: YOUR_API_KEY"
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
