### PR TITLE
fix: add missing capabilities to serial_connector and virtualprinter

### DIFF
--- a/src/octoprint/plugins/serial_connector/config_schema.py
+++ b/src/octoprint/plugins/serial_connector/config_schema.py
@@ -95,6 +95,9 @@ class SerialCapabilities(BaseModel):
     busy_protocol: bool = True
     """Whether to shorten the communication timeout if the firmware seems to support the busy protocol."""
 
+    chamber_temp: bool = True
+    """Whether to process chamber temperature data from the firmware if its support is detected."""
+
     emergency_parser: bool = True
     """Whether to send emergency commands out of band if the firmware seems to support the emergency parser."""
 

--- a/src/octoprint/plugins/virtual_printer/__init__.py
+++ b/src/octoprint/plugins/virtual_printer/__init__.py
@@ -57,6 +57,8 @@ class VirtualPrinterPlugin(
                 "AUTOREPORT_TEMP": True,
                 "AUTOREPORT_SD_STATUS": True,
                 "AUTOREPORT_POS": False,
+                "BUSY_PROTOCOL": False,
+                "CHAMBER_TEMPERATURE": False,
                 "EMERGENCY_PARSER": True,
                 "EXTENDED_M20": False,
                 "LFN_WRITE": False,


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

In `serial_comm.py`, the supported capabilities are listed as follows:

https://github.com/OctoPrint/OctoPrint/blob/e8fa6b48f0e658105298910dbee9925c763ed027/src/octoprint/plugins/serial_connector/serial_comm.py#L644-L669

Of these, `chamber_temp` was missing from the serial connector's config schema, and `BUSY_PROTOCOL` and `CHAMBER_TEMPERATURE` were missing from the virtual printer. This PR adds them.

#### How was it tested? How can it be tested by the reviewer?

Nothing to test. I don't think these changes have any visible impact.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
