### PR TITLE
fix(storage): fix broken has_analysis() in printer storage

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -1291,7 +1291,7 @@ class FileManager:
     def has_analysis(self, location, path):
         return self._storage(location).has_analysis(path)
 
-    def get_metadata(self, location, path):
+    def get_metadata(self, location: str, path: str) -> dict:
         return self._storage(location).get_metadata(path)
 
     @deprecated(

--- a/src/octoprint/filemanager/storage/__init__.py
+++ b/src/octoprint/filemanager/storage/__init__.py
@@ -480,7 +480,7 @@ class StorageInterface:
         """
         raise NotImplementedError()
 
-    def has_analysis(self, path) -> bool:
+    def has_analysis(self, path: str) -> bool:
         """
         Returns whether the file at path has been analysed yet
 
@@ -488,7 +488,7 @@ class StorageInterface:
         """
         raise NotImplementedError()
 
-    def get_metadata(self, path, default=None):
+    def get_metadata(self, path: str, default=None) -> dict:
         """
         Retrieves the metadata for the file ``path``.
 

--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -779,11 +779,11 @@ class LocalFileStorage(StorageInterface):
 
         return self.path_in_storage(destination_data["fullpath"])
 
-    def has_analysis(self, path):
+    def has_analysis(self, path: str) -> bool:
         metadata = self.get_metadata(path)
         return metadata and "analysis" in metadata
 
-    def get_metadata(self, path, default=None):
+    def get_metadata(self, path: str, default=None) -> dict:
         path, name = self.sanitize(path)
         return self._get_metadata_entry(path, name, default=default)
 
@@ -1579,7 +1579,7 @@ class LocalFileStorage(StorageInterface):
 
         return entry_data
 
-    def _get_metadata_entry(self, path, name, default=None):
+    def _get_metadata_entry(self, path: str, name: str, default=None) -> dict:
         with self._get_metadata_lock(path):
             metadata = self._get_metadata(path)
             return metadata.get(name, default)
@@ -1715,7 +1715,7 @@ class LocalFileStorage(StorageInterface):
                 except Exception:
                     self._logger.exception(f"Error copying/moving {src} to {dst}")
 
-    def _get_metadata(self, path, force=False):
+    def _get_metadata(self, path: str, force=False) -> dict:
         import json
 
         if not force:

--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -450,7 +450,7 @@ class PrinterFileStorage(StorageInterface):
         metadata = self.get_metadata(path)
         return metadata and "analysis" in metadata
 
-    def get_metadata(self, path, default=None):
+    def get_metadata(self, path: str, default=None) -> dict:
         if not self.capabilities.metadata:
             return None
 

--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -448,7 +448,7 @@ class PrinterFileStorage(StorageInterface):
 
     def has_analysis(self, path):
         metadata = self.get_metadata(path)
-        return metadata and metadata.analysis
+        return metadata and "analysis" in metadata
 
     def get_metadata(self, path, default=None):
         if not self.capabilities.metadata:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the `PrinterFileStorage.has_analysis()` method:

https://github.com/OctoPrint/OctoPrint/blob/e8fa6b48f0e658105298910dbee9925c763ed027/src/octoprint/filemanager/storage/printer.py#L449-L451

As shown, the return value is incorrect. `metadata` is a `dict` so it cannot be used like that.

The fix in this PR matches `LocalFileStorage`, which already had the correct return:

https://github.com/OctoPrint/OctoPrint/blob/e8fa6b48f0e658105298910dbee9925c763ed027/src/octoprint/filemanager/storage/local.py#L782-L784

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

1. Upload a file named `a.gco` to the printer storage

2. Create the following file in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import octoprint.plugin
from octoprint.filemanager.destinations import FileDestinations


class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.EventHandlerPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")
        result = self._file_manager.has_analysis(FileDestinations.PRINTER, "a.gco")
        self._logger.info(f"has_analysis('a.gco') = {result}")


__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Before this PR, an `AttributeError` exception is thrown in logs:
```stacktrace
2026-03-29 15:26:07,741 - octoprint.plugin - ERROR - Error while calling plugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 11, in on_after_startup
    result = self._file_manager.has_analysis(FileDestinations.PRINTER, "a.gco")
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/__init__.py", line 1292, in has_analysis
    return self._storage(location).has_analysis(path)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/printer.py", line 451, in has_analysis
    return metadata and metadata.analysis
                        ^^^^^^^^^^^^^^^^^
AttributeError: 'dict' object has no attribute 'analysis'
```

After this PR:
```stacktrace
2026-03-29 15:29:30,382 - octoprint.plugins.bug_repro - INFO - has_analysis('a.gco') = True
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
