### PR TITLE
fix(api): printerprofiles should throw 404 if profile not found

### DIFF
--- a/docs/api/printerprofiles.rst
+++ b/docs/api/printerprofiles.rst
@@ -332,6 +332,9 @@ Update an existing printer profile
 
    Requires the ``SETTINGS`` permission.
 
+   :statuscode 200: No error
+   :statuscode 404: The profile does not exist
+
    **Example**
 
    .. sourcecode:: http
@@ -417,6 +420,10 @@ Remove an existing printer profile
    Returns a :http:statuscode:`204` and an empty body upon success.
 
    Requires the ``SETTINGS`` permission.
+
+   :statuscode 204: No error
+   :statuscode 404: The profile does not exist
+   :statuscode 409: The profile is the currently selected or default profile
 
    **Example**
 

--- a/src/octoprint/server/api/printer_profiles.py
+++ b/src/octoprint/server/api/printer_profiles.py
@@ -114,6 +114,10 @@ def printerProfilesGet(identifier):
 @no_firstrun_access
 @Permissions.SETTINGS.require(403)
 def printerProfilesDelete(identifier):
+    profile = printerProfileManager.get(identifier)
+    if profile is None:
+        abort(404)
+
     current_profile = printerProfileManager.get_current()
     if current_profile and current_profile["id"] == identifier:
         abort(409, description="Cannot delete currently selected profile")
@@ -137,7 +141,7 @@ def printerProfilesUpdate(identifier):
 
     profile = printerProfileManager.get(identifier)
     if profile is None:
-        profile = printerProfileManager.get_default()
+        abort(404)
 
     new_profile = json_data["profile"]
     merged_profile = dict_merge(profile, new_profile)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR changes the behavior of the `printerprofiles` API to return 404 when attempting to PATCH or DELETE a profile with a non-existent identifier.

Before this PR, PATCH would modify (unexpectedly, in my opinion) the default profile, and DELETE would return 204.

This PR is bugfix release relevant.

#### How was it tested? How can it be tested by the reviewer?

Run the following command:

```bash
curl -s -X PATCH http://localhost:5000/api/printerprofiles/nonexistent -H "X-Api-Key: YOUR_API_KEY" -H "Content-Type: application/json" -d '{"profile": {"name": "NewName"}}'
```
Before this PR, the default profile was edited even if the specified identifier referred to a non-existent profile.

After this PR, it returns 404.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
