### PR TITLE
fix: add None guards to prevent crashes

### DIFF
--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -487,6 +487,9 @@ class PrinterFileStorage(StorageInterface):
             return None
 
         metadata = self._connection.get_printer_file_metadata(path)
+        if metadata is None or metadata.model_extra is None:
+            return None
+
         return metadata.model_extra.get(key)
 
     def set_additional_metadata(self, path, key, data, overwrite=False, merge=False):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -1209,15 +1209,23 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
                     if self._selected_job is not None:
                         payload = self._payload_for_print_job_event()
                         if payload:
-                            job_progress = self._connection.job_progress
-                            error_info = self._connection.error_info
+                            job_progress = (
+                                self._connection.job_progress
+                                if self._connection
+                                else None
+                            )
+                            error_info = (
+                                self._connection.error_info if self._connection else None
+                            )
 
                             payload["reason"] = "error"
                             payload["error"] = (
                                 error_info.error if error_info else "unknown"
                             )
-                            payload["time"] = job_progress.elapsed
-                            payload["progress"] = job_progress.progress
+                            payload["time"] = job_progress.elapsed if job_progress else 0
+                            payload["progress"] = (
+                                job_progress.progress if job_progress else 0
+                            )
 
                             def finalize():
                                 self._file_manager.log_print(
@@ -1410,8 +1418,8 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
 
         payload = self._payload_for_print_job_event()
         if payload:
-            job_progress = self._connection.job_progress
-            payload["time"] = job_progress.elapsed
+            job_progress = self._connection.job_progress if self._connection else None
+            payload["time"] = job_progress.elapsed if job_progress else 0
             eventManager().fire(
                 Events.CHART_MARKED,
                 {"type": "done", "label": "Done"},
@@ -1490,7 +1498,7 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             action_user=user,
         )
         if payload:
-            payload["time"] = job_progress.elapsed
+            payload["time"] = job_progress.elapsed if job_progress else 0
 
             eventManager().fire(Events.PRINT_CANCELLED, payload)
             eventManager().fire(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds guards to prevent attribute access on values that could potentially be `None`, which would cause an `AttributeError`.

While the bug in `printer.py` is real (a plugin could call `PrinterFileStorage.get_additional_metadata()` on a non-existent path, triggering a crash), the changes in `standard.py` might be superfluous. Still, it felt off seeing potential `NoneType` attribute access while reviewing the code, and since `if self._connection else None` guards were already present in many other points in the same file, it seemed correct to add them where they were missing.

These bugs affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

1. Upload a file named `a.gco` to the printer storage

2. Create the following file in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```py
import octoprint.plugin
from octoprint.filemanager.destinations import FileDestinations


class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.EventHandlerPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")
        result = self._file_manager.get_additional_metadata(
            FileDestinations.PRINTER, "a.gco", "some_key"
        )
        self._logger.info(f"get_additional_metadata('a.gco', 'some_key') = {result}")


__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Before this PR, an `AttributeError` exception is thrown in logs:
```stacktrace
2026-03-29 15:35:03,492 - octoprint.plugin - ERROR - Error while calling plugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1738, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 11, in on_after_startup
    result = self._file_manager.get_additional_metadata(
        FileDestinations.PRINTER, "a.gco", "some_key"
    )
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/__init__.py", line 1402, in get_additional_metadata
    return self._storage(location).get_additional_metadata(path, key)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/printer.py", line 490, in get_additional_metadata
    return metadata.model_extra.get(key)
           ^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```

After this PR:
```stacktrace
2026-03-29 15:37:12,501 - octoprint.plugins.bug_repro - INFO - get_additional_metadata('a.gco', 'some_key') = None
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
