### PR TITLE
fix: normalize boolean values consistently

### DIFF
--- a/src/octoprint/plugins/tracking/__init__.py
+++ b/src/octoprint/plugins/tracking/__init__.py
@@ -81,11 +81,11 @@ class TrackingPlugin(
         }
 
     def on_settings_save(self, data):
-        enabled = self._settings.get(["enabled"])
+        enabled = self._settings.get_boolean(["enabled"])
 
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
 
-        if enabled is None and self._settings.get(["enabled"]):
+        if enabled is None and self._settings.get_boolean(["enabled"]):
             # tracking was just enabled, let's start up tracking
             self._start_tracking()
 

--- a/src/octoprint/printer/profile.py
+++ b/src/octoprint/printer/profile.py
@@ -151,7 +151,7 @@ import copy
 import logging
 import os
 
-from octoprint.settings import settings
+from octoprint.settings import settings, valid_boolean_trues
 from octoprint.util import (
     dict_contains_keys,
     dict_merge,
@@ -702,10 +702,13 @@ class PrinterProfileManager:
             ("axes", "x", "inverted"),
             ("axes", "y", "inverted"),
             ("axes", "z", "inverted"),
+            ("axes", "e", "inverted"),
             ("extruder", "sharedNozzle"),
+            ("heatedBed",),
+            ("heatedChamber",),
         ):
             try:
-                convert_value(profile, path, bool)
+                convert_value(profile, path, lambda v: v in valid_boolean_trues)
             except Exception as e:
                 self._logger.warning(
                     "Profile has invalid value for path {path!r}: {msg}".format(

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -180,8 +180,8 @@ def _create_etag(path, filter=None, recursive=False, lm=None):
     lastmodified_factory=lambda: _create_lastmodified(
         request.path, request.values.get("recursive", False)
     ),
-    unless=lambda: request.values.get("force", False)
-    or request.values.get("_refresh", False),
+    unless=lambda: request.values.get("force", "false") in valid_boolean_trues
+    or request.values.get("_refresh", "false") in valid_boolean_trues,
 )
 def readGcodeFiles():  # pre 2.0.0
     filter = request.values.get("filter", False)
@@ -224,8 +224,8 @@ def readGcodeFiles():  # pre 2.0.0
     lastmodified_factory=lambda: _create_lastmodified(
         request.path, request.values.get("recursive", False)
     ),
-    unless=lambda: request.values.get("force", False)
-    or request.values.get("_refresh", False),
+    unless=lambda: request.values.get("force", "false") in valid_boolean_trues
+    or request.values.get("_refresh", "false") in valid_boolean_trues,
 )
 def readGcodeFiles_post_2_0_0():  # 2.0.0+
     filter = request.values.get("filter", False)
@@ -336,8 +336,8 @@ def runFilesTest():
     lastmodified_factory=lambda: _create_lastmodified(
         request.path, request.values.get("recursive", False)
     ),
-    unless=lambda: request.values.get("force", False)
-    or request.values.get("_refresh", False),
+    unless=lambda: request.values.get("force", "false") in valid_boolean_trues
+    or request.values.get("_refresh", "false") in valid_boolean_trues,
 )
 def readGcodeFilesForOrigin(origin):
     try:
@@ -388,8 +388,8 @@ def readGcodeFilesForOrigin(origin):
         lm=lm,
     ),
     lastmodified_factory=lambda: _create_lastmodified(request.path, False),
-    unless=lambda: request.values.get("force", False)
-    or request.values.get("_refresh", False),
+    unless=lambda: request.values.get("force", "false") in valid_boolean_trues
+    or request.values.get("_refresh", "false") in valid_boolean_trues,
 )
 def readGcodeFile(target, filename):
     try:

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -503,9 +503,9 @@ def index():
 
     enable_timelapse = settings().getBoolean(["webcam", "timelapseEnabled"])
     enable_loading_animation = settings().getBoolean(["devel", "showLoadingAnimation"])
-    enable_sd_support = settings().get(["feature", "sdSupport"])
+    enable_sd_support = settings().getBoolean(["feature", "sdSupport"])
     enable_webcam = settings().getBoolean(["webcam", "webcamEnabled"])
-    enable_temperature_graph = settings().get(["feature", "temperatureGraph"])
+    enable_temperature_graph = settings().getBoolean(["feature", "temperatureGraph"])
     sockjs_connect_timeout = settings().getInt(["devel", "sockJsConnectTimeout"])
     reauthentication_timeout = settings().getInt(
         ["accessControl", "defaultReauthenticationTimeout"]

--- a/src/octoprint/server/views.py
+++ b/src/octoprint/server/views.py
@@ -48,7 +48,7 @@ from octoprint.server.util import (
 )
 from octoprint.server.util.csrf import add_csrf_cookie
 from octoprint.server.util.flask import credentials_checked_recently
-from octoprint.settings import settings
+from octoprint.settings import settings, valid_boolean_trues
 from octoprint.util import sv, to_bytes, to_unicode
 from octoprint.util.version import get_octoprint_version, get_python_version_string
 
@@ -447,7 +447,7 @@ def reverse_proxy_test_redirect():
 def reverse_proxy_test():
     from octoprint.server.util.flask import get_reverse_proxy_info
 
-    authenticated = request.args.get("authenticated", False) is not False
+    authenticated = request.args.get("authenticated", "false") in valid_boolean_trues
     if authenticated:
         response = require_fresh_login_with(permissions=[Permissions.ADMIN])
         if response:

--- a/src/octoprint/templates/dialogs/settings.jinja2
+++ b/src/octoprint/templates/dialogs/settings.jinja2
@@ -67,7 +67,7 @@
             data-bind="visible: $root.loginState.hasPermissionKo($root.access.permissions.SYSTEM), click: function() { about.show('about_systeminfo') }">
         <i class="fas fa-flag-checkered"></i> {{ _("System info") }}
     </button>
-    <a href="{{ url_for('reverse_proxy_test', authenticated='') }}"
+    <a href="{{ url_for('reverse_proxy_test', authenticated='true') }}"
        class="btn reverseproxylink"
        target="_blank"
        rel="noopener noreferrer"><i class="fas fa-check-double"></i> {{ _("Reverse Proxy Test") }}</a>

--- a/src/octoprint/templates/reverse_proxy_test.jinja2
+++ b/src/octoprint/templates/reverse_proxy_test.jinja2
@@ -171,7 +171,7 @@
             {% else %}
                 <p>
                     To receive more information about the request headers that OctoPrint received, please
-                    <a href="{{ url_for('reverse_proxy_test', authenticated='') }}">request the authenticated version of this page</a>.
+                    <a href="{{ url_for('reverse_proxy_test', authenticated='true') }}">request the authenticated version of this page</a>.
                     Note that this will only work if the above settings are reporting green across the board.
                 </p>
             {% endif %}


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I found that in some parts of the codebase, boolean values were not being obtained/validated/converted checking against `valid_boolean_trues`. This could lead to interpreting the string `false` as `True`, for example when retrieved from `config.yaml` or from user-provided inputs.

This PR fixes all such occurrences.

#### How was it tested? How can it be tested by the reviewer?

Go to `http://127.0.0.1:5000/reverse_proxy_test/?authenticated=false`
Before this PR, it showed the authenticated version of the reverse proxy test page, even if the `authenticated` parameter was `false`.
After this PR, it correctly shows the unauthenticated version of the page.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
