### PR TITLE
fix(settings): add serial compat overlay

### DIFF
--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -562,8 +562,8 @@ def init_serial_compat_overlay(settings):
             settings.remove_overlay("serial_compat")
             return
 
-        send_checksum = serial_connector.get("sendChecksum")
-        error_handling = serial_connector.get("errorHandling")
+        send_checksum = serial_connector.pop("sendChecksum", None)
+        error_handling = serial_connector.pop("errorHandling", None)
 
         serial_compat = {
             # Connection params (moved to printerConnection.*)

--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -551,6 +551,78 @@ def init_settings_plugin_config_migration_and_cleanup(plugin_manager):
     ]
 
 
+def init_serial_compat_overlay(settings):
+    import logging
+
+    logger = logging.getLogger(__name__)
+
+    def set_overlay():
+        serial_connector = settings.get(["plugins", "serial_connector"])
+        if serial_connector is None:
+            settings.remove_overlay("serial_compat")
+            return
+
+        send_checksum = serial_connector.get("sendChecksum")
+        error_handling = serial_connector.get("errorHandling")
+
+        serial_compat = {
+            # Connection params (moved to printerConnection.*)
+            "port": settings.get(
+                ["printerConnection", "preferred", "parameters", "port"]
+            ),
+            "baudrate": settings.get(
+                ["printerConnection", "preferred", "parameters", "baudrate"]
+            ),
+            "autoconnect": settings.getBoolean(["printerConnection", "autoconnect"]),
+            "autorefresh": settings.getBoolean(["printerConnection", "autorefresh"]),
+            "autorefreshInterval": settings.getInt(
+                ["printerConnection", "autorefreshInterval"]
+            ),
+            # Moved to feature.*
+            "notifySuppressedCommands": settings.get(
+                ["feature", "notifySuppressedCommands"]
+            ),
+            # Old boolean keys derived from new enums
+            "alwaysSendChecksum": send_checksum == "always",
+            "neverSendChecksum": send_checksum == "never",
+            "disconnectOnErrors": error_handling == "disconnect",
+            "ignoreErrorsFromFirmware": error_handling == "ignore",
+            # Old names (blacklisted -> blocklisted)
+            "blacklistedPorts": serial_connector.get("blocklistedPorts"),
+            "blacklistedBaudrates": serial_connector.get("blocklistedBaudrates"),
+        }
+
+        for key, value in serial_connector.items():
+            if key not in serial_compat:
+                serial_compat[key] = value
+
+        overlay = {"serial": serial_compat}
+
+        logger.info(
+            "Installing serial compat overlay for deprecated serial.* settings path"
+        )
+        settings.add_overlay(
+            overlay,
+            key="serial_compat",
+            at_end=True,
+            deprecated=(
+                "Serial settings have been moved. Use plugins.serial_connector.*, "
+                "printerConnection.*, or feature.notifySuppressedCommands as "
+                "appropriate. This compatibility layer will be removed in a future "
+                "release."
+            ),
+            replace=True,
+        )
+
+    def callback(path, current_value, new_value):
+        set_overlay()
+
+    set_overlay()
+    settings.add_path_update_callback(["plugins", "serial_connector"], callback)
+    settings.add_path_update_callback(["printerConnection"], callback)
+    settings.add_path_update_callback(["feature", "notifySuppressedCommands"], callback)
+
+
 def init_webcam_compat_overlay(settings, plugin_manager):
     import logging
 

--- a/src/octoprint/cli/__init__.py
+++ b/src/octoprint/cli/__init__.py
@@ -52,6 +52,7 @@ def init_platform_for_cli(ctx):
     from octoprint import (
         init_custom_events,
         init_platform,
+        init_serial_compat_overlay,
         init_settings_plugin_config_migration_and_cleanup,
         init_webcam_compat_overlay,
     )
@@ -95,6 +96,7 @@ def init_platform_for_cli(ctx):
     plugin_manager.initialize_implementations()
 
     init_settings_plugin_config_migration_and_cleanup(plugin_manager)
+    init_serial_compat_overlay(settings)
     init_webcam_compat_overlay(settings, plugin_manager)
 
     return components

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -1033,6 +1033,7 @@ class Server:
     def _setup_plugin_manager(self, components):
         from octoprint import (
             init_custom_events,
+            init_serial_compat_overlay,
             init_settings_plugin_config_migration_and_cleanup,
             init_webcam_compat_overlay,
         )
@@ -1051,6 +1052,7 @@ class Server:
         self._plugin_manager.initialize_implementations()
 
         init_settings_plugin_config_migration_and_cleanup(self._plugin_manager)
+        init_serial_compat_overlay(self._settings)
         init_webcam_compat_overlay(self._settings, self._plugin_manager)
 
         self._plugin_manager.log_all_plugins()

--- a/src/octoprint/settings/__init__.py
+++ b/src/octoprint/settings/__init__.py
@@ -791,16 +791,17 @@ class Settings:
             return False
 
     def _path_modified(self, path, current_value, new_value):
-        callbacks = self._path_update_callbacks.get(tuple(path))
-        if callbacks:
-            for callback in callbacks:
-                try:
-                    if callable(callback):
-                        callback(path, current_value, new_value)
-                except Exception:
-                    self._logger.exception(
-                        f"Error while executing callback {callback} for path {path}"
-                    )
+        for i in range(len(path), 0, -1):
+            callbacks = self._path_update_callbacks.get(tuple(path[:i]))
+            if callbacks:
+                for callback in callbacks:
+                    try:
+                        if callable(callback):
+                            callback(path, current_value, new_value)
+                    except Exception:
+                        self._logger.exception(
+                            f"Error while executing callback {callback} for path {path}"
+                        )
 
     def _get_default_folder(self, type):
         folder = default_settings["folder"][type]

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -657,6 +657,17 @@ class SettingsTest(unittest.TestCase):
             # verify callback was not called again
             callback.assert_called_once_with(["api", "key"], "test", "newkey")
 
+    def test_update_callback_child_write(self):
+        with self.settings() as settings:
+            callback = unittest.mock.Mock()
+            settings.add_path_update_callback(["server"], callback)
+
+            # set a child value
+            settings.set(["server", "host"], "new")
+
+            # verify callback was called
+            callback.assert_called_once()
+
     ##~~ test overlays
 
     def test_overlay_add_and_remove(self):

--- a/tests/settings/test_settings.py
+++ b/tests/settings/test_settings.py
@@ -702,6 +702,72 @@ class SettingsTest(unittest.TestCase):
             self.assertEqual(settings.get(["server", "host"]), "0.0.0.0")
             self.assertFalse(settings._is_deprecated_path(["server", "host"]))
 
+    ##~~ test compat overlays
+
+    @ddt.data(
+        # settings moved from serial to serial_connector as they were
+        ("log", False),
+        ("blocklistedPorts", ["foo"]),
+        ("blocklistedBaudrates", [9600]),
+        # connection params, moved from serial to printerConnection
+        ("port", "/dev/ttyUSB0"),
+        ("baudrate", 115200),
+        ("autoconnect", True),
+        ("autorefresh", False),
+        ("autorefreshInterval", 5),
+        # settings that were booleans and now are enums
+        ("alwaysSendChecksum", False),
+        ("neverSendChecksum", False),
+        ("disconnectOnErrors", True),
+        ("ignoreErrorsFromFirmware", False),
+        # old "blacklisted" settings, now renamed to "blocklisted"
+        ("blacklistedPorts", ["foo"]),
+        ("blacklistedBaudrates", [9600]),
+        # notifySuppressedCommands, moved to feature
+        ("notifySuppressedCommands", "never"),
+    )
+    @ddt.unpack
+    def test_serial_compat_overlay(self, serial_key, expected):
+        with self.serial_compat_settings() as settings:
+            self.assertEqual(settings.get(["serial", serial_key]), expected)
+            self.assertTrue(settings._is_deprecated_path(["serial", serial_key]))
+
+    @ddt.data(
+        (["plugins", "serial_connector", "log"], True, "log"),
+        (["printerConnection", "autoconnect"], False, "autoconnect"),
+        (["feature", "notifySuppressedCommands"], "log", "notifySuppressedCommands"),
+    )
+    @ddt.unpack
+    def test_serial_compat_overlay_updates(self, source_path, new_value, serial_key):
+        with self.serial_compat_settings() as settings:
+            settings.set(source_path, new_value, force=True)
+            self.assertEqual(settings.get(["serial", serial_key]), new_value)
+
+    def test_webcam_compat_overlay(self):
+        from octoprint.schema.webcam import Webcam, WebcamCompatibility
+
+        with self.mocked_basedir():
+            settings = octoprint.settings.Settings()
+
+            compat = WebcamCompatibility(
+                stream="http://cam/stream", snapshot="http://cam/snap"
+            )
+            webcam = Webcam(
+                name="test", displayName="Test", snapshotDisplay="", compat=compat
+            )
+            provided = unittest.mock.Mock()
+            provided.config = webcam
+
+            with unittest.mock.patch(
+                "octoprint.webcams.get_default_webcam", return_value=provided
+            ):
+                from octoprint import init_webcam_compat_overlay
+
+                init_webcam_compat_overlay(settings, unittest.mock.Mock())
+
+            self.assertEqual(settings.get(["webcam", "stream"]), "http://cam/stream")
+            self.assertTrue(settings._is_deprecated_path(["webcam", "stream"]))
+
     ##~~ test save
 
     def test_save(self):
@@ -832,6 +898,46 @@ class SettingsTest(unittest.TestCase):
         with self.mocked_config():
             settings = octoprint.settings.Settings()
             settings.add_overlay(self.overlay, key="overlay")
+            yield settings
+
+    @contextlib.contextmanager
+    def serial_compat_settings(self):
+        from octoprint import init_serial_compat_overlay
+
+        with self.mocked_basedir():
+            settings = octoprint.settings.Settings()
+            settings.set(
+                ["plugins", "serial_connector"],
+                {
+                    "log": False,
+                    "sendChecksum": "print",
+                    "errorHandling": "disconnect",
+                    "blocklistedPorts": ["foo"],
+                    "blocklistedBaudrates": [9600],
+                },
+                force=True,
+            )
+            settings.set(
+                ["printerConnection"],
+                {
+                    "preferred": {
+                        "parameters": {
+                            "port": "/dev/ttyUSB0",
+                            "baudrate": 115200,
+                        }
+                    },
+                    "autoconnect": True,
+                    "autorefresh": False,
+                    "autorefreshInterval": 5,
+                },
+                force=True,
+            )
+            settings.set(
+                ["feature"],
+                {"notifySuppressedCommands": "never"},
+                force=True,
+            )
+            init_serial_compat_overlay(settings)
             yield settings
 
     @contextlib.contextmanager


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR adds a compat overlay to the `["serial"]` global settings path, so that any plugins that were accessing that path can still do so, causing a deprecation message to appear in the logs and giving them some time to migrate to the new paths instead of crashing or getting always `None`.

This is necessary, since several plugins were accessing that global path. To my knowledge, at least the following: `bettergrblsupport, Chituboard, FlashForge, klipper, meatpack, portlister, portretry, siocontrol, telegram`.

Please note that this PR also includes a fix for path update callbacks: when a path update callback was registered, it was not called if a subpath was updated. Without this fix, it would have been necessary, in the serial compat overlay, to subscribe callbacks for all subpaths of `["plugins", "serial_connector"]`, one by one. I believe it is instead a desired behavior that when a child is modified, the update callback is also called for all ancestors.

#### How was it tested? How can it be tested by the reviewer?

This PR also includes new unit tests for the serial compat overlay and for the webcam compat overlay. They can be run with the following command:

```bash
python -m pytest tests/settings/test_settings.py
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
