### PR TITLE
fix(printer): can_modify_file is False in idle

### DIFF
--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -1002,8 +1002,8 @@ class PrinterMixin(CommonPrinterMixin):
         since="2.0.0",
     )
     def can_modify_file(self, path, sd, *args, **kwargs):
-        return not self.is_current_file(path, sd) and (
-            self.is_printing() or self.is_paused()
+        return not (
+            self.is_current_file(path, sd) and (self.is_printing() or self.is_paused())
         )
 
     @deprecated(


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug in the deprecated `Printer.can_modify_file()` method.

The [original condition](https://github.com/OctoPrint/OctoPrint/commit/59f49f39#diff-bb2f9b06a8feee90eba7468b77f6cfb64a97ef0d00e7fddca597f644e2062080R255) in 59f49f39 was:

```py
return not (self.is_current_file(path, sd) and (self.is_printing() or self.is_paused()))
```

It was later removed in 0b12b949 and it has been recently reintroduced by ab7dc6af.

However, the reintroducing commit erroneously removed the parentheses after `not` in the condition, causing the function to always return `False` when not printing:

https://github.com/OctoPrint/OctoPrint/blob/ab7dc6af2b8a1be4ebc7273ef9775913147626ba/src/octoprint/printer/__init__.py#L1004-L1007

This PR restores the parentheses to their original form.

This bug affected only the `dev` branch.

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
