### PR TITLE
fix(settings): fix "blacklist" compat layer

### DIFF
--- a/src/octoprint/__init__.py
+++ b/src/octoprint/__init__.py
@@ -649,7 +649,7 @@ def init_blocklist_compat_overlay(settings):
             key="blocklist_compat",
             at_end=True,
             deprecated=(
-                '"Blacklist" in settings keys has been changed to "blocklist".'
+                '"Blacklist" in settings keys has been changed to "blocklist". '
                 "This compatibility layer will be removed in a future "
                 "release."
             ),
@@ -660,8 +660,8 @@ def init_blocklist_compat_overlay(settings):
         set_overlay()
 
     set_overlay()
-    settings.add_path_update_callback(["feature", "autoUppercaseBlacklist"], callback)
-    settings.add_path_update_callback(["server", "pluginBlacklist"], callback)
+    settings.add_path_update_callback(["feature", "autoUppercaseBlocklist"], callback)
+    settings.add_path_update_callback(["server", "pluginBlocklist"], callback)
 
 
 def init_webcam_compat_overlay(settings, plugin_manager):

--- a/src/octoprint/server/__init__.py
+++ b/src/octoprint/server/__init__.py
@@ -1033,6 +1033,7 @@ class Server:
 
     def _setup_plugin_manager(self, components):
         from octoprint import (
+            init_blocklist_compat_overlay,
             init_custom_events,
             init_serial_compat_overlay,
             init_settings_plugin_config_migration_and_cleanup,
@@ -1054,6 +1055,7 @@ class Server:
 
         init_settings_plugin_config_migration_and_cleanup(self._plugin_manager)
         init_serial_compat_overlay(self._settings)
+        init_blocklist_compat_overlay(self._settings)
         init_webcam_compat_overlay(self._settings, self._plugin_manager)
 
         self._plugin_manager.log_all_plugins()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the "blacklist" compat layer.

- A space was missing in deprecation message
- The update callbacks were applied to the old (now non-existent) path instead of the new one
- The whole "blacklist" compat overlay was applied only for cli and not for server

#### How was it tested? How can it be tested by the reviewer?

Place the following script in `~/.octoprint/plugins/bug_repro.py` and restart OctoPrint:
```python
import octoprint.plugin

class BugReproPlugin(octoprint.plugin.StartupPlugin, octoprint.plugin.SettingsPlugin):
    def on_after_startup(self):
        self._logger.warning("== BugReproPlugin loaded ==")
        new_path = self._settings.global_get(["feature", "autoUppercaseBlocklist"])
        old_path = self._settings.global_get(["feature", "autoUppercaseBlacklist"])
        self._logger.warning(f"Blocklist (new path): {new_path}")
        self._logger.warning(f"Blacklist (old path): {old_path}")

__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()

```

Before this PR, the old settings path returns `None`:
```
2026-04-15 17:38:35,380 - octoprint.plugins.bug_repro - WARNING - == BugReproPlugin loaded ==
2026-04-15 17:38:35,381 - octoprint.plugins.bug_repro - WARNING - Blocklist (new path): ['M117', 'M118', 'M707', 'M708']
2026-04-15 17:38:35,381 - octoprint.plugins.bug_repro - WARNING - Blacklist (old path): None
```

After this PR, the old settings path correctly returns the value from the new one:
```
2026-04-15 17:37:54,944 - octoprint.plugins.bug_repro - WARNING - == BugReproPlugin loaded ==
2026-04-15 17:37:54,944 - octoprint.settings - WARNING - DeprecationWarning: Detected access to deprecated settings path ['feature', 'autoUppercaseBlacklist'], returned value is derived from compatibility overlay. "Blacklist" in settings keys has been changed to "blocklist". This compatibility layer will be removed in a future release.
2026-04-15 17:37:54,944 - octoprint.plugins.bug_repro - WARNING - Blocklist (new path): ['M117', 'M118', 'M707', 'M708']
2026-04-15 17:37:54,944 - octoprint.plugins.bug_repro - WARNING - Blacklist (old path): ['M117', 'M118', 'M707', 'M708']
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
