### PR TITLE
fix(printer): pass job_status_interval only if supported by estimator

### DIFF
--- a/docs/plugins/hooks.rst
+++ b/docs/plugins/hooks.rst
@@ -1320,10 +1320,16 @@ octoprint.printer.estimation.factory
    .. versionadded:: 1.3.9
 
    Return a :class:`~octoprint.printer.estimation.PrintTimeEstimator` subclass (or factory) to use for print time
-   estimation. This will be called on each start of a print or streaming job with a single parameter ``job_type``
+   estimation. This will be called on each start of a print or streaming job with the parameter ``job_type``
    denoting the type of job that was just started: ``local`` meaning a print of a local file through the serial connection,
    ``sdcard`` a print of a file stored on the printer's SD card, ``stream`` the streaming of a local file to the
    printer's SD card.
+
+   .. versionchanged:: 2.0.0
+
+   Starting with OctoPrint 2.0.0, if the factory declares a ``job_status_interval`` (a ``float``) parameter in its
+   signature, it will receive it as a keyword argument indicating the interval in seconds at which the active
+   connector reports job progress. This is used by the default estimator to size its rolling window.
 
    This is useful for plugins wishing to provide alternative methods of live print time estimation.
 
@@ -1340,7 +1346,7 @@ octoprint.printer.estimation.factory
       from octoprint.printer.estimation import PrintTimeEstimator
 
       class CustomPrintTimeEstimator(PrintTimeEstimator):
-          def __init__(self, job_type):
+          def __init__(self, job_type, job_status_interval):
               pass
 
           def estimate(self, progress, printTime, cleanedPrintTime, statisticalTotalPrintTime, statisticalTotalPrintTimeType):

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -7,6 +7,7 @@ __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms of the AGPLv3 License"
 
 import copy
+import inspect
 import logging
 import threading
 import time
@@ -226,9 +227,10 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
 
                 job_type = self._selected_job.storage
 
-        self._estimator = self._estimator_factory(
-            job_type, job_status_interval=self._connection.job_status_interval
-        )
+        kwargs = {}
+        if "job_status_interval" in inspect.signature(self._estimator_factory).parameters:
+            kwargs["job_status_interval"] = self._connection.job_status_interval
+        self._estimator = self._estimator_factory(job_type, **kwargs)
 
     @property
     def firmware_info(self):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

The commit 04451ca5d739b4618c6442b64b314e5ad2ca9684 added the `job_status_interval` parameter to `PrintTimeEstimator`.

This caused plugins implementing the [`octoprint.printer.estimation.factory`](https://docs.octoprint.org/en/dev/plugins/hooks.html#octoprint-printer-estimation-factory) hook to crash, because the new argument was being passed to them even if their signature did not include it.

This PR implements `inspect` to pass the new argument only if the estimator explicitly declares it in its signature. This should prevent all 6 current plugins in the plugins repository that implement the estimation factory from crashing.

This PR also updates the hook documentation about the new parameter.

#### How was it tested? How can it be tested by the reviewer?

Tested printing with PrintTimeGenius plugin.
Before this PR it crashed. After this PR it just works.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
