### PR TITLE
docs: fix building warnings

### DIFF
--- a/docs/api/datamodel.rst
+++ b/docs/api/datamodel.rst
@@ -54,7 +54,7 @@ Printer State
      - 1
      - Boolean
      - ``true`` if the printer's SD card is available and initialized, ``false`` otherwise. This is redundant information
-       to :ref:`the SD State <sec-api-printer-datamodel-sdstate>`.
+       to :ref:`the Storage State <sec-api-printer-datamodel-storagestate>`.
    * - ``flags.error``
      - 1
      - Boolean

--- a/docs/api/push.rst
+++ b/docs/api/push.rst
@@ -229,11 +229,11 @@ Data model
      - Information about the current machine state
    * - ``job``
      - 1
-     - :ref:`Job information <sec-api-datamodel-jobs-job>`
+     - :ref:`Job information <sec-api-job-datamodel-response>`
      - Information about the currently active print job
    * - ``progress``
      - 1
-     - :ref:`Progress information <sec-api-datamodel-jobs-progress>`
+     - :ref:`Progress information <sec-api-job-datamodel-response>`
      - Information about the current print/streaming progress
    * - ``currentZ``
      - 0..1

--- a/docs/gettingstarted.md
+++ b/docs/gettingstarted.md
@@ -47,6 +47,7 @@ OctoPrint via `pip`.
 
 OctoPrint currently supports Python 3.9, 3.10, 3.11, 3.12 and 3.13.
 
+(usage)=
 ## Usage
 
 Running the pip install via

--- a/docs/jsclientlib/access.rst
+++ b/docs/jsclientlib/access.rst
@@ -1,7 +1,7 @@
 .. _sec-jsclientlib-access:
 
 :mod:`OctoPrintClient.access`
-----------------------------
+-----------------------------
 
 .. note::
 
@@ -132,7 +132,7 @@
 .. _sec-jsclientlib-access-groups:
 
 :mod:`OctoPrintClient.access.groups`
-..............................
+....................................
 
 .. js:function:: OctoPrintClient.access.groups.list(opts)
 

--- a/docs/jsclientlib/base.rst
+++ b/docs/jsclientlib/base.rst
@@ -97,7 +97,7 @@
      * ``maxage``: ``;max-age=<opts.maxage>``
      * ``secure``: ``;secure`` if ``true`` (automatically set if the current connection goes via https)
 
-   For infos on these parameters please refer to :ref:`document.cookie <https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie>`_.
+   For infos on these parameters please refer to `document.cookie <https://developer.mozilla.org/en-US/docs/Web/API/Document/cookie>`_.
 
    :param string name: Name of the cookie to set
    :param string value: Value to set the cookie to

--- a/docs/modules/util.rst
+++ b/docs/modules/util.rst
@@ -14,6 +14,15 @@ octoprint.util.commandline
 .. automodule:: octoprint.util.commandline
    :members:
 
+.. _sec-modules-util-json:
+
+octoprint.util.json
+-------------------
+
+.. automodule:: octoprint.util.json
+   :members:
+   :imported-members:
+
 .. _sec-modules-util-platform:
 
 octoprint.util.platform

--- a/docs/plugins/deprecations.md
+++ b/docs/plugins/deprecations.md
@@ -27,14 +27,14 @@ Look for two things in your code:
 
 1. Imports of other plugin templates in your own plugin's templates, e.g.
 
-   ``` jinja2
+   ``` jinja
    {% include "snippets/my_snippet.jinja2" %}
    ```
 
    will only be resolved relatively to the current plugin, and thus need
    to be prefixed referencing the target plugin going forward:
 
-   ``` jinja2
+   ``` jinja
    {% include "plugin_some_other_plugin/snippets/my_snippet.jinja2" %}
    ```
 2. Templates rendered by your plugin. e.g. in a custom route created through the [`BlueprintPlugin` mixin](#sec-plugins-mixins-blueprintplugin) need to be prefixed as well. Example:

--- a/docs/plugins/migration_2_0_0.md
+++ b/docs/plugins/migration_2_0_0.md
@@ -220,7 +220,7 @@ The long deprecated `octoprint.printer.profile.BedTypes` type has been removed. 
 (sec-plugins-octo_2_0_0-server-server)=
 ### Server
 
-(sec-plugins-octo_2_0_0-server-server-validator)
+(sec-plugins-octo_2_0_0-server-server-validator)=
 #### `octoprint.server.util.flask.(admin|user)_validator` removed
 
 Both `octoprint.server.util.flask.admin_validator` and `octoprint.server.util.flask.user_validator` have been removed in favor of `octoprint.server.util.flask.permissions_validator`
@@ -382,7 +382,7 @@ new signature. Refer to the documentation of [`OctoPrintClient.deprecatedVariabl
 (sec-plugins-octo_2_0_0-api-global_api_key)=
 ### Global API Key
 
-The Global API Key has been deprecated for a while, with 2.0.0 it is no longer automatically generated at startup and may thus be empty! [It will be removed entirely in 2.1.0](#sec-plugins-octo_2_0_0-upcoming-global_apikey).
+The Global API Key has been deprecated for a while, with 2.0.0 it is no longer automatically generated at startup and may thus be empty! [It will be removed entirely in 2.1.0](#sec-plugins-deprecations-2_1_0-global_apikey).
 
 Instead of utilizing this key to talk to OctoPrint's API endpoints from plugin code, plugins
 should instead use [`self.plugin_apikey`](#octoprint.plugin.types.OctoPrintPlugin.plugin_apikey). Example:

--- a/docs/sphinxext/pydanticext.py
+++ b/docs/sphinxext/pydanticext.py
@@ -75,6 +75,9 @@ class PydanticModelInspector:
         def token_comma(scanner, token):
             return "COMMA", token
 
+        def token_pipe(scanner, token):
+            return "PIPE", token
+
         def token_whitespace(scanner, token):
             return "WHITESPACE", token
 
@@ -84,6 +87,7 @@ class PydanticModelInspector:
                 (r"\[", token_lbracket),
                 (r"\]", token_rbracket),
                 (r",", token_comma),
+                (r"\|", token_pipe),
                 (r"\s+", token_whitespace),
             ]
         )

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -278,7 +278,7 @@ class CommonPrinterMixin:
         Arguments:
             amount (int, float): The amount of material to extrude in mm
             speed (int, None): Speed at which to extrude (F parameter). If set to ``None`` (or left out)
-            the maximum speed of E axis from the printer profile will be used.
+                the maximum speed of E axis from the printer profile will be used.
             tags (set of str): An optional set of tags to attach to the command(s) throughout their lifecycle
         """
 

--- a/src/octoprint/server/util/flask.py
+++ b/src/octoprint/server/util/flask.py
@@ -1537,7 +1537,7 @@ def permission_validator(request, permission):
     Must be executed in an existing Flask request context!
 
     :param request: The Flask request object
-    :param request: The required permission
+    :param permission: The required permission
     """
 
     user = get_flask_user_from_request(request)
@@ -1553,7 +1553,7 @@ def permission_and_fresh_credentials_validator(request, permission):
     Must be executed in an existing Flask request context!
 
     :param request: The Flask request object
-    :param request: The required permission
+    :param permission: The required permission
     """
 
     permission_validator(request, permission)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that building the docs with `task docs-build` produces a number of warnings.

This PR fixes some of them. It would be great to reach a point where no warnings remain, so we can enable CI enforcement.

Unfortunately, the following warnings are still present - they relate to name mismatches between classes and subclasses, which I cannot resolve on my own as I'm not in a position to assess which parameter should be changed (parent vs. child class):

<details>
  <summary>Remaining warnings</summary>

```
./docs/modules/filemanager.rst:36: WARNING: Parameter name 'data' does not match any of the parameters defined in the signature: ['path', 'file_obj', 'allow_overwrite', 'display', 'user', 'progress_callback', 'args', 'kwargs']
./docs/modules/filemanager.rst:44: WARNING: Parameter name 'data' does not match any of the parameters defined in the signature: ['path', 'file_object', 'allow_overwrite', 'progress_callback', 'args', 'kwargs']
./docs/modules/filemanager.rst:44: WARNING: Parameter name 'display' does not match any of the parameters defined in the signature: ['path', 'file_object', 'allow_overwrite', 'progress_callback', 'args', 'kwargs']
./docs/modules/filemanager.rst:44: WARNING: Parameter name 'user' does not match any of the parameters defined in the signature: ['path', 'file_object', 'allow_overwrite', 'progress_callback', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'secure' does not match any of the parameters defined in the signature: ['key', 'path', 'domain']
./docs/modules/server.rst:20: WARNING: Parameter name 'httponly' does not match any of the parameters defined in the signature: ['key', 'path', 'domain']
./docs/modules/server.rst:20: WARNING: Parameter name 'samesite' does not match any of the parameters defined in the signature: ['key', 'path', 'domain']
./docs/modules/server.rst:20: WARNING: Parameter name 'partitioned' does not match any of the parameters defined in the signature: ['key', 'path', 'domain']
./docs/modules/server.rst:20: WARNING: Parameter name 'max_age' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'expires' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'path' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'domain' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'secure' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'httponly' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'samesite' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:20: WARNING: Parameter name 'partitioned' does not match any of the parameters defined in the signature: ['key', 'value', 'args', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'url' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'generator' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'content_type' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'as_attachment' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'access_validation' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'path' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'default_filename' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'as_attachment' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'allow_client_caching' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'access_validation' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'path_validation' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'etag_generator' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'name_generator' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'mime_type_guesser' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'is_pre_compressed' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'data' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'content_type' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'url' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'as_attachment' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'basename' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'access_validation' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'as_attachment' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
./docs/modules/server.rst:36: WARNING: Parameter name 'access_validation' does not match any of the parameters defined in the signature: ['application', 'request', 'kwargs']
```

</details>

#### How was it tested? How can it be tested by the reviewer?

```bash
task docs-build
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

I'm on Python 3.14.3

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
