### PR TITLE
fix(printer): allow deselecting current job

### DIFF
--- a/src/octoprint/plugins/serial_connector/connector.py
+++ b/src/octoprint/plugins/serial_connector/connector.py
@@ -701,10 +701,12 @@ class ConnectedSerialPrinter(ConnectedPrinter, PrinterFilesMixin):
         self._listener.on_printer_files_refreshed(files)
 
     def on_comm_file_selected(self, full_path, size, sd, user=None, data=None):
-        storage = FileDestinations.PRINTER if sd else FileDestinations.LOCAL
-
-        path = self._file_manager.path_in_storage(storage, full_path)
-        job = self._file_manager.create_job(storage, path, owner=user)
+        if full_path is None:
+            job = None
+        else:
+            storage = FileDestinations.PRINTER if sd else FileDestinations.LOCAL
+            path = self._file_manager.path_in_storage(storage, full_path)
+            job = self._file_manager.create_job(storage, path, owner=user)
 
         super().set_job(job)
         self._listener.on_printer_job_changed(job, user=user, data=data)

--- a/src/octoprint/printer/standard.py
+++ b/src/octoprint/printer/standard.py
@@ -827,7 +827,14 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
             self._logger.info("Cannot load job: printer not connected or currently busy")
             return
 
+        if tags is None:
+            tags = set()
+        tags |= {"trigger:printer.set_job"}
+
         if job is None:
+            super().set_job(None, tags=tags, user=user)
+            self._connection.set_job(None, tags=tags, user=user)
+            self._update_progress_data()
             return
 
         # canonicalize
@@ -838,10 +845,6 @@ class Printer(PrinterMixin, ConnectedPrinterListenerMixin):
         if not self._connection.supports_job(job):
             self._logger.info("Cannot load job: printer doesn't support it")
             return
-
-        if tags is None:
-            tags = set()
-        tags |= {"trigger:printer.set_job"}
 
         try:
             recovery_data = self._file_manager.get_recovery_data()


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes file unselection, which was not working at all.

This bug got introduced by the giant comm refactor, thus it affected only the `dev` branch (included the current 2.0.0 RC1).

#### How was it tested? How can it be tested by the reviewer?

1. Select a file, e.g. `foo.gcode`

2. Send the following API request:
   ```bash
   curl -X POST http://localhost:5000/api/files/local/foo.gcode \
   -H "Content-Type: application/json" \
   -H "X-Api-Key: YOUR_API_KEY" \
   -d '{"command": "unselect"}'
   ```

Before this PR the file was not unselected.

After this PR the file gets correctly unselected.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

This bug was discovered while replacing the [deprecated](https://docs.octoprint.org/en/dev/plugins/deprecations.html#removal-of-deprecated-methods-on-octoprint-printer-standard-printer-also-known-as-self-printer) `unselect_file` method in a plugin.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
