### PR TITLE
fix(api): allow None filament weight in /api/job response

### DIFF
--- a/src/octoprint/schema/api/job.py
+++ b/src/octoprint/schema/api/job.py
@@ -25,7 +25,7 @@ class ApiJobInfo(BaseModel):
     """File being printed"""
     estimatedPrintTime: Optional[float] = None
     """Estimated print time in seconds, if known"""
-    filament: Optional[dict[str, Optional[dict[str, float]]]] = None
+    filament: Optional[dict[str, Optional[dict[str, Optional[float]]]]] = None
     """Filament usage information as mapping from printer profile to mappings from tool to used length, if known"""
     user: Optional[str] = None
     """The user who started the job, if known"""


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a crash in the `/api/job` API that occurs when calling the API while the selected file does not have the filament weight metadata.

`weight` is correctly set as `Optional` in the `AnalysisFilamentUse` schema:

https://github.com/OctoPrint/OctoPrint/blob/43f75b4f3d65faa82e0d5e0956cb789995cf661d/src/octoprint/filemanager/storage/common.py#L74-L77

However, it is not correctly marked as `Optional` in the `ApiJobInfo` schema:

https://github.com/OctoPrint/OctoPrint/blob/43f75b4f3d65faa82e0d5e0956cb789995cf661d/src/octoprint/schema/api/job.py#L28-L29

This bug affected only the `dev` branch (included the current 2.0.0 RC1).

#### How was it tested? How can it be tested by the reviewer?

1. Select a file which has no `filament.tool0.weight` metadata

2. Call the following API:
    ```bash
    curl http://127.0.0.1:5000/api/job -H "X-Api-Key: YOUR_API_KEY"
    ```

Before this PR, it happens a crash with the following stacktrace:

<details>
  <summary>Stacktrace</summary>

```stacktrace
2026-04-29 01:44:40,616 - octoprint - ERROR - Exception on /api/job [GET]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 2084, in __call__
    return handler(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/vendor/flask_principal.py", line 196, in _decorated
    rv = f(*args, **kw)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/job.py", line 80, in jobState
    response = _get_api_job_response()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/job.py", line 123, in _get_api_job_response
    job = apischema.ApiJobInfo(
        file=file,
    ...<2 lines>...
        user=job_data.get("user"),
    )
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 1 validation error for ApiJobInfo
filament.tool0.weight
  Input should be a valid number [type=float_type, input_value=None, input_type=NoneType]
    For further information visit https://errors.pydantic.dev/2.12/v/float_type
```

</details>

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
