### PR TITLE
fix(pmgr): restore install from VCS URLs

### DIFF
--- a/docs/bundledplugins/pluginmanager.rst
+++ b/docs/bundledplugins/pluginmanager.rst
@@ -33,8 +33,8 @@ formats:
 
 .. note::
 
-   OctoPrint can only detect the file type (and build isolation support in case of plugin archives to be installed via `pip`) from URLs provided via `http` or `https`.
-   VCS URLs (e.g. `git+http`) will be considered plugin archives and directly provided to `pip` with the default install parameters.
+   OctoPrint can only detect the file type (and build isolation support in case of plugin archives to be installed via ``pip``) from URLs provided via ``http`` or ``https``.
+   VCS URLs (e.g. ``git+http``) will be considered plugin archives and directly provided to ``pip`` with the default install parameters.
 
 .. _fig-bundledplugins-pluginmanager-mainscreen:
 .. figure:: ../images/bundledplugins-pluginmanager-mainscreen.png

--- a/docs/bundledplugins/pluginmanager.rst
+++ b/docs/bundledplugins/pluginmanager.rst
@@ -31,6 +31,11 @@ formats:
 
   The plugin manager will feed all contained URLs to the same logic as above.
 
+.. note::
+
+   OctoPrint can only detect the file type (and build isolation support in case of plugin archives to be installed via `pip`) from URLs provided via `http` or `https`.
+   VCS URLs (e.g. `git+http`) will be considered plugin archives and directly provided to `pip` with the default install parameters.
+
 .. _fig-bundledplugins-pluginmanager-mainscreen:
 .. figure:: ../images/bundledplugins-pluginmanager-mainscreen.png
    :align: center

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -1106,7 +1106,7 @@ class PluginManagerPlugin(
 
         # NOTE: we can only check whether we need PEP517 related args if we have a path source type!
         # Consequently, packages installed from VCS URLs will not support automatic addition of those pip args!
-        if source_type != "path" and (
+        if source_type == "path" and (
             no_build_isolation or is_pre_pep517_plugin_package(path)
         ):
             pip_args += PRE_PEP517_PIP_ARGS

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -137,9 +137,8 @@ class PluginManagerPlugin(
     JSON_EXTENSIONS = (".json",)
 
     # valid pip install URL schemes according to https://pip.pypa.io/en/stable/reference/pip_install/
-    URL_SCHEMES = (
-        "http",
-        "https",
+    DOWNLOAD_SCHEMES = ("http", "https")
+    URL_SCHEMES = DOWNLOAD_SCHEMES + (
         "git",
         "git+http",
         "git+https",
@@ -918,9 +917,9 @@ class PluginManagerPlugin(
 
     def _is_vcs_url(self, url):
         scheme = urlparse(url).scheme
-        return scheme in PluginManagerPlugin.URL_SCHEMES and scheme not in (
-            "http",
-            "https",
+        return (
+            scheme in PluginManagerPlugin.URL_SCHEMES
+            and scheme not in PluginManagerPlugin.DOWNLOAD_SCHEMES
         )
 
     def command_install(
@@ -941,21 +940,19 @@ class PluginManagerPlugin(
             try:
                 source = path
                 source_type = "path"
-                is_vcs_url = False
 
                 if url is not None:
                     source = url
-                    source_type = "url"
                     if self._is_vcs_url(url):
                         path = url
-                        is_vcs_url = True
+                        source_type = "url"
                     else:
                         # fetch URL
                         folder = tempfile.TemporaryDirectory()
                         path = download_file(url, folder.name)
 
                 # determine type of path
-                if is_vcs_url or self._is_archive(path):
+                if source_type == "url" or self._is_archive(path):
                     result = self._command_install_archive(
                         path,
                         source=source,
@@ -966,7 +963,6 @@ class PluginManagerPlugin(
                         no_build_isolation=no_build_isolation,
                         partial=partial,
                         from_repo=from_repo,
-                        is_vcs_url=is_vcs_url,
                     )
 
                 elif self._is_pythonfile(path):
@@ -1051,7 +1047,6 @@ class PluginManagerPlugin(
         no_build_isolation=False,
         partial=False,
         from_repo=False,
-        is_vcs_url=False,
     ):
         throttled = self._get_throttled()
         if (
@@ -1077,22 +1072,26 @@ class PluginManagerPlugin(
 
         from urllib.parse import quote as url_quote
 
-        if is_vcs_url:
-            # VCS URL goes straight to pip
+        if source_type == "url":
+            # URL goes straight to pip
             path_url = path
             shell_quote = sarge.shell_quote
-        elif os.sep != "/":
-            # windows gets special handling
-            path = os.path.abspath(path)
-            drive, loc = os.path.splitdrive(path)
-            path_url = (
-                "file:///" + drive.lower() + url_quote(loc.replace(os.sep, "/").lower())
-            )
-            shell_quote = lambda x: x  # do not shell quote under windows, non posix shell
         else:
             path = os.path.abspath(path)
-            path_url = "file://" + url_quote(path)
-            shell_quote = sarge.shell_quote
+            if os.sep != "/":
+                # windows gets special handling
+                drive, loc = os.path.splitdrive(path)
+                path_url = (
+                    "file:///"
+                    + drive.lower()
+                    + url_quote(loc.replace(os.sep, "/").lower())
+                )
+                shell_quote = (
+                    lambda x: x
+                )  # do not shell quote under windows, non posix shell
+            else:
+                path_url = "file://" + url_quote(path)
+                shell_quote = sarge.shell_quote
 
         self._logger.info(f"Installing plugin from {source}")
         pip_args = [
@@ -1105,7 +1104,11 @@ class PluginManagerPlugin(
         if dependency_links or self._settings.get_boolean(["dependency_links"]):
             pip_args.append("--process-dependency-links")
 
-        if not is_vcs_url and (no_build_isolation or is_pre_pep517_plugin_package(path)):
+        # NOTE: we can only check whether we need PEP517 related args if we have a path source type!
+        # Consequently, packages installed from VCS URLs will not support automatic addition of those pip args!
+        if source_type != "path" and (
+            no_build_isolation or is_pre_pep517_plugin_package(path)
+        ):
             pip_args += PRE_PEP517_PIP_ARGS
 
         all_plugins_before = self._plugin_manager.find_plugins(existing={})

--- a/src/octoprint/plugins/pluginmanager/__init__.py
+++ b/src/octoprint/plugins/pluginmanager/__init__.py
@@ -12,6 +12,7 @@ import tempfile
 import threading
 import time
 from datetime import datetime
+from urllib.parse import urlparse
 
 import filetype
 import pylru
@@ -915,6 +916,13 @@ class PluginManagerPlugin(
             except Exception as exc:
                 self._logger.exception(f"Could not parse {path} as json file: {exc}")
 
+    def _is_vcs_url(self, url):
+        scheme = urlparse(url).scheme
+        return scheme in PluginManagerPlugin.URL_SCHEMES and scheme not in (
+            "http",
+            "https",
+        )
+
     def command_install(
         self,
         url=None,
@@ -933,16 +941,21 @@ class PluginManagerPlugin(
             try:
                 source = path
                 source_type = "path"
+                is_vcs_url = False
 
                 if url is not None:
-                    # fetch URL
-                    folder = tempfile.TemporaryDirectory()
-                    path = download_file(url, folder.name)
                     source = url
                     source_type = "url"
+                    if self._is_vcs_url(url):
+                        path = url
+                        is_vcs_url = True
+                    else:
+                        # fetch URL
+                        folder = tempfile.TemporaryDirectory()
+                        path = download_file(url, folder.name)
 
                 # determine type of path
-                if self._is_archive(path):
+                if is_vcs_url or self._is_archive(path):
                     result = self._command_install_archive(
                         path,
                         source=source,
@@ -953,6 +966,7 @@ class PluginManagerPlugin(
                         no_build_isolation=no_build_isolation,
                         partial=partial,
                         from_repo=from_repo,
+                        is_vcs_url=is_vcs_url,
                     )
 
                 elif self._is_pythonfile(path):
@@ -1037,6 +1051,7 @@ class PluginManagerPlugin(
         no_build_isolation=False,
         partial=False,
         from_repo=False,
+        is_vcs_url=False,
     ):
         throttled = self._get_throttled()
         if (
@@ -1062,15 +1077,20 @@ class PluginManagerPlugin(
 
         from urllib.parse import quote as url_quote
 
-        path = os.path.abspath(path)
-        if os.sep != "/":
+        if is_vcs_url:
+            # VCS URL goes straight to pip
+            path_url = path
+            shell_quote = sarge.shell_quote
+        elif os.sep != "/":
             # windows gets special handling
+            path = os.path.abspath(path)
             drive, loc = os.path.splitdrive(path)
             path_url = (
                 "file:///" + drive.lower() + url_quote(loc.replace(os.sep, "/").lower())
             )
             shell_quote = lambda x: x  # do not shell quote under windows, non posix shell
         else:
+            path = os.path.abspath(path)
             path_url = "file://" + url_quote(path)
             shell_quote = sarge.shell_quote
 
@@ -1085,7 +1105,7 @@ class PluginManagerPlugin(
         if dependency_links or self._settings.get_boolean(["dependency_links"]):
             pip_args.append("--process-dependency-links")
 
-        if no_build_isolation or is_pre_pep517_plugin_package(path):
+        if not is_vcs_url and (no_build_isolation or is_pre_pep517_plugin_package(path)):
             pip_args += PRE_PEP517_PIP_ARGS
 
         all_plugins_before = self._plugin_manager.find_plugins(existing={})


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes #5382.

Installation from VCS URLs (e.g. `git+https://...`) was originally supported by c5e7212fa (#2104), which passed such URLs straight to `pip install`.

Commit b675ec613 introduced `download_file()` to fetch URLs through `requests` before handing them to pip, in order to support single-file plugins served over HTTP. As a side effect, VCS URLs started being passed to `requests`, which doesn't understand their schemes, and installation failed with `requests.exceptions.InvalidSchema`. The `URL_SCHEMES` constant introduced for VCS support was left orphaned.

This PR restores the original behaviour for VCS URLs only: when the URL's scheme is in `URL_SCHEMES` and is not `http`/`https`, the URL is forwarded directly to `pip install`. HTTP(S) URLs continue to go through `download_file()` so single-file plugins installation keep working.

This bug affected OctoPrint since 1.4.1rc1.

#### How was it tested? How can it be tested by the reviewer?

Tested by entering the following URL in Plugin Manager's "... from URL" field:

```
git+https://github.com/rfinnie/OctoPrint-BedCooldown.git@main
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

- #5382

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
