### PR TITLE
fix(coreui): repair "Update User" button in access settings

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/access.js
+++ b/src/octoprint/static/js/app/viewmodels/access.js
@@ -253,7 +253,7 @@ $(function () {
                 };
 
                 access.loginState.reauthenticateIfNecessary(() => {
-                    OctoPrint.users
+                    OctoPrint.access.users
                         .get(user.name)
                         .done(function (data) {
                             process(data);


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a spot in the code where `OctoPrint.users` was still being used (instead of `OctoPrint.access.users`), which was removed in c4a6be0ba.

This bug prevented the use of the "Update User" button in OctoPrint settings -> Access Control in OctoPrint 2.0.0rc1.

#### How was it tested? How can it be tested by the reviewer?

OctoPrint Settings -> Access Control -> Click on the "Update User" button (the one with the pencil icon)  on any user.

Before this PR, it crashed with the following JS stacktrace:
```stacktrace
packed_core.js?ead5a01e:55 Uncaught TypeError: Cannot read properties of undefined (reading 'get')
at packed_core.js?ead5a01e:55:1663
at LoginStateViewModel.self.reauthenticateIfNecessary (packed_core.js?ead5a01e:268:1095)
at AccessViewModel.access.users.self.showEditUserDialog (packed_core.js?ead5a01e:55:1616)
at Object.eval (eval at b (packed_libs.js?465b8bae:131:1951), <anonymous>:1:125)
at HTMLAnchorElement.<anonymous> (packed_libs.js?465b8bae:133:4377)
at HTMLAnchorElement.dispatch (packed_libs.js?465b8bae:13:43090)
at v.handle (packed_libs.js?465b8bae:13:41074)
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
