### PR TITLE
fix: fix template permission checks

### DIFF
--- a/src/octoprint/plugins/classicwebcam/static/js/classicwebcam.js
+++ b/src/octoprint/plugins/classicwebcam/static/js/classicwebcam.js
@@ -7,6 +7,7 @@ $(function () {
 
         self.loginState = parameters[0];
         self.settings = parameters[1];
+        self.access = parameters[2];
         self.webcamStreamVisible = false;
 
         self.webcamDisableTimeout = undefined;
@@ -375,7 +376,11 @@ $(function () {
 
     OCTOPRINT_VIEWMODELS.push({
         construct: ClassicWebcamViewModel,
-        dependencies: ["loginStateViewModel", "classicWebcamSettingsViewModel"],
+        dependencies: [
+            "loginStateViewModel",
+            "classicWebcamSettingsViewModel",
+            "accessViewModel"
+        ],
         elements: ["#classicwebcam_container"]
     });
 });

--- a/src/octoprint/plugins/classicwebcam/templates/classicwebcam_webcam.jinja2
+++ b/src/octoprint/plugins/classicwebcam/templates/classicwebcam_webcam.jinja2
@@ -62,15 +62,15 @@
                 <p>
                     <strong>{{ _("Webcam stream not loaded") }}</strong>
                 </p>
-                <p data-bind="visible: !loginState.isAdmin()">
+                <p data-bind="visible: !loginState.hasPermissionKo(access.permissions.SETTINGS)()">
                     <small>{{ _("It might not be configured correctly or require authentication. To have this fixed, get in touch with an administrator of this OctoPrint instance.") }}</small>
                 </p>
-                <p data-bind="visible: loginState.isAdmin">
+                <p data-bind="visible: loginState.hasPermissionKo(access.permissions.SETTINGS)">
                     <small>{% trans %}
                         It might not be configured correctly or require authentication. You can change the URL of the stream under "Settings" > "Classic Webcam" > "Stream URL". If you don't have a webcam you can also just disable webcam support there.
                     {% endtrans %}</small>
                 </p>
-                <p data-bind="visible: loginState.isUser">
+                <p>
                     <small>{{ _("Currently configured stream URL") }}: <a target="_blank"
     rel="noreferrer"
     data-bind="attr: {href: settings.streamUrl}, text: settings.streamUrl"></a></small>

--- a/src/octoprint/plugins/classicwebcam/templates/classicwebcam_webcam.jinja2
+++ b/src/octoprint/plugins/classicwebcam/templates/classicwebcam_webcam.jinja2
@@ -70,7 +70,7 @@
                         It might not be configured correctly or require authentication. You can change the URL of the stream under "Settings" > "Classic Webcam" > "Stream URL". If you don't have a webcam you can also just disable webcam support there.
                     {% endtrans %}</small>
                 </p>
-                <p>
+                <p data-bind="visible: loginState.loggedIn">
                     <small>{{ _("Currently configured stream URL") }}: <a target="_blank"
     rel="noreferrer"
     data-bind="attr: {href: settings.streamUrl}, text: settings.streamUrl"></a></small>

--- a/src/octoprint/static/js/app/viewmodels/access.js
+++ b/src/octoprint/static/js/app/viewmodels/access.js
@@ -173,7 +173,7 @@ $(function () {
             });
 
             self.requestData = function () {
-                if (!access.loginState.hasPermissionKo(access.permissions.ADMIN)) return;
+                if (!access.loginState.hasPermission(access.permissions.ADMIN)) return;
 
                 return OctoPrint.access.users.list().done(self.fromResponse);
             };
@@ -416,7 +416,7 @@ $(function () {
                 if (!user) {
                     throw OctoPrint.InvalidArgumentError("user must be set");
                 }
-                if (!access.loginState.hasPermissionKo(access.permissions.ADMIN)) {
+                if (!access.loginState.hasPermission(access.permissions.ADMIN)) {
                     return $.Deferred()
                         .reject("You are not authorized to perform this action")
                         .promise();
@@ -434,7 +434,7 @@ $(function () {
                 if (!user) {
                     throw OctoPrint.InvalidArgumentError("user must be set");
                 }
-                if (!access.loginState.hasPermissionKo(access.permissions.ADMIN)) {
+                if (!access.loginState.hasPermission(access.permissions.ADMIN)) {
                     return $.Deferred()
                         .reject("You are not authorized to perform this action")
                         .promise();

--- a/src/octoprint/templates/sidebar/files/files.jinja2
+++ b/src/octoprint/templates/sidebar/files/files.jinja2
@@ -45,7 +45,7 @@
             <div class="btn btn-mini toggleAdditionalData" data-bind="click: function() { if ($root.enableAdditionalData($data)) { $root.toggleAdditionalData($data); } else { return; } }, css: { disabled: !$root.enableAdditionalData($data) }" title="{{ _('Additional data')|edq }}"><i class="fas fa-chevron-down"></i></div>
         </div>
         <div class="file-entry-content" data-bind="style: { 'flex-direction': $root.contentFlexDirection() }">
-            <div class="file-entry-thumbnail clickable" data-bind="style: { width: $root.thumbnailsContainerWidth, 'text-align': $root.thumbnailsAlignment, display: ($root.thumbnailLink($data) && $root.loginState.hasPermissionKo($root.access.permissions.FILES_DOWNLOAD) && $root.thumbnailsEnabled()) ? 'block' : 'none' }">
+            <div class="file-entry-thumbnail clickable" data-bind="style: { width: $root.thumbnailsContainerWidth, 'text-align': $root.thumbnailsAlignment, display: ($root.thumbnailLink($data) && $root.loginState.hasPermissionKo($root.access.permissions.FILES_DOWNLOAD)() && $root.thumbnailsEnabled()) ? 'block' : 'none' }">
                 <img loading="lazy" data-bind="attr: { src: $root.thumbnailLink($data) }, style: { 'max-width': $root.thumbnailsWidth }, popover: { placement: 'right', title: '{{ _("Preview") | esq }}', html: true, content: $root.thumbnailPopover($data), container: 'body', trigger: $root.thumbnailPopoverTrigger }">
             </div>
             <div class="file-entry-meta">
@@ -73,7 +73,7 @@
             <div class="title muted" data-bind="text: display, attr: { title: display }"></div>
         </div>
         <div class="file-entry-content" data-bind="style: { 'flex-direction': $root.contentFlexDirection() }">
-            <div class="file-entry-thumbnail" data-bind="style: { width: $root.thumbnailsContainerWidth, 'text-align': $root.thumbnailsAlignment, display: ($root.thumbnailLink($data) && $root.loginState.hasPermissionKo($root.access.permissions.FILES_DOWNLOAD) && $root.thumbnailsEnabled()) ? 'block' : 'none' }, class: $root.thumbnailsContainerClass">
+            <div class="file-entry-thumbnail" data-bind="style: { width: $root.thumbnailsContainerWidth, 'text-align': $root.thumbnailsAlignment, display: ($root.thumbnailLink($data) && $root.loginState.hasPermissionKo($root.access.permissions.FILES_DOWNLOAD)() && $root.thumbnailsEnabled()) ? 'block' : 'none' }, class: $root.thumbnailsContainerClass">
                 <img loading="lazy" data-bind="attr: { src: $root.thumbnailLink($data) }, style: { 'max-width': $root.thumbnailsWidth }, popover: { placement: 'right', title: '{{ _("Preview") | esq }}', html: true, content: $root.thumbnailPopover($data), container: 'body', trigger: $root.thumbnailPopoverTrigger }">
             </div>
             <div class="file-entry-meta">
@@ -115,7 +115,7 @@
     </script>
 </div>
 <div class="text-right muted"
-     data-bind="attr: {title: diskusageString}, css: {'text-error': diskusageCritical}, style: {'font-weight': diskusageCritical() || diskusageWarning() ? 'bold' : 'normal'}, visible: $root.loginState.hasPermissionKo($root.access.permissions.FILES_LIST) && $root.currentStorageHasUsage()">
+     data-bind="attr: {title: diskusageString}, css: {'text-error': diskusageCritical}, style: {'font-weight': diskusageCritical() || diskusageWarning() ? 'bold' : 'normal'}, visible: $root.loginState.hasPermissionKo($root.access.permissions.FILES_LIST)() && $root.currentStorageHasUsage()">
     <small>{{ _("Free") }}: <span data-bind="text: freeSpaceString"></span> / {{ _("Total") }}: <span data-bind="text: totalSpaceString"></span> <i class="fas fa-exclamation-triangle"
     data-bind="visible: diskusageWarning"
     style="display: none"></i></small>

--- a/src/octoprint/templates/tabs/terminal.jinja2
+++ b/src/octoprint/templates/tabs/terminal.jinja2
@@ -12,11 +12,11 @@
         <div class="input-block-level input-append">
             <input type="text"
                    id="terminal-command"
-                   data-bind="value: command, event: { keyup: function(d,e) { return handleKeyUp(e); }, keydown: function(d,e) { return handleKeyDown(e); } }, enable: isOperational() && loginState.isUser()"
+                   data-bind="value: command, event: { keyup: function(d,e) { return handleKeyUp(e); }, keydown: function(d,e) { return handleKeyDown(e); } }, enable: isOperational() && loginState.hasPermissionKo(access.permissions.CONTROL)()"
                    autocomplete="off">
             <a class="btn add-on"
                id="terminal-send"
-               data-bind="click: sendCommand, enable: isOperational() && loginState.isUser()">{{ _("Send") }}</a>
+               data-bind="click: sendCommand, enable: isOperational() && loginState.hasPermissionKo(access.permissions.CONTROL)()">{{ _("Send") }}</a>
         </div>
     </div>
     <small id="terminal-autoscroll-panel"

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -142,13 +142,13 @@
         <p>
             <strong>{{ _("Timelapse not fully configured") }}</strong>
         </p>
-        <p data-bind="visible: !loginState.isAdmin()">
+        <p data-bind="visible: !loginState.hasPermissionKo(access.permissions.SETTINGS)()">
             {{ _("A working snapshot setup and/or the path to FFMPEG are missing. To have this fixed, get in touch with an administrator of this OctoPrint instance.") }}
         </p>
-        <p data-bind="visible: loginState.isAdmin">
+        <p data-bind="visible: loginState.hasPermissionKo(access.permissions.SETTINGS)">
             {{ _("A working snapshot setup and/or the path to FFMPEG are missing. You can change both under \"Settings\" > \"Webcam & Timelapse\" and in the settings of your chosen webcam plugin. If you don't have a webcam or don't want to enable timelapse support you can also just disable it there.") }}
         </p>
-        <p data-bind="visible: loginState.isUser">
+        <p>
             <small>
                 <!-- ko if: canSnapshot -->
                 <!-- ko if: snapshotDisplay -->

--- a/src/octoprint/templates/tabs/timelapse.jinja2
+++ b/src/octoprint/templates/tabs/timelapse.jinja2
@@ -148,7 +148,7 @@
         <p data-bind="visible: loginState.hasPermissionKo(access.permissions.SETTINGS)">
             {{ _("A working snapshot setup and/or the path to FFMPEG are missing. You can change both under \"Settings\" > \"Webcam & Timelapse\" and in the settings of your chosen webcam plugin. If you don't have a webcam or don't want to enable timelapse support you can also just disable it there.") }}
         </p>
-        <p>
+        <p data-bind="visible: loginState.loggedIn">
             <small>
                 <!-- ko if: canSnapshot -->
                 <!-- ko if: snapshotDisplay -->


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug [reported](https://discord.com/channels/704958479194128507/705047010641838211/1500664412371943475) by a user on Discord: users with the `CONTROL` permission who don't belong to the `user` group could not send commands through the terminal tab because the input was disabled.

This happened because in `terminal.jinja2`, `loginState.isUser()` was erroneously checked instead of `loginState.hasPermissionKo(access.permissions.CONTROL)`.

I took the opportunity to check whether the same mistake had been made elsewhere and to review permission checks across all templates in general, and I found the following additional issues:
- In `webcam.jinja2` and `timelapse.jinja2`, `loginState.isAdmin()` was checked instead of `loginState.hasPermissionKo(access.permissions.SETTINGS)()` to decide which error message to show based on whether the user could change the settings. Additionally, `loginState.isAdmin` and `loginState.isUser` were used without parentheses, so they were always truthy.
- In `access.js`, `loginState.hasPermissionKo()` was used instead of `loginState.hasPermission()`, which returns a Knockout pureComputed (a function) and therefore always evaluated to true.
- In `files.jinja2`, `loginState.hasPermissionKo()` was called without the trailing parentheses `()`, always evaluating to true inside `&&` chains.

This PR fixes all these issues.

#### How was it tested? How can it be tested by the reviewer?

Use the terminal tab with a user who has the `CONTROL` permission but is not in the `user` group.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
