### PR TITLE
fix(printer): a typo again in get_connection_options deprecation message

### DIFF
--- a/docs/plugins/deprecations.md
+++ b/docs/plugins/deprecations.md
@@ -290,7 +290,7 @@ If your plugin or other client is still issuing requests against `POST /api/syst
 
 ### Removal of deprecated methods on `octoprint.printer.standard.Printer`, also known as `self._printer`
 
-- `get_connection_options` -> use `ConnectedPrinter.all()` in combination with `get_connection_options` on the returned `ConnectedPrinter` instances instead
+- `get_connection_options` -> use `ConnectedPrinter.all()` in combination with `connection_options` on the returned `ConnectedPrinter` instances instead
 - `select_file` -> `set_job`
 - `unselect_file` -> `set_job` with `None`
 - `fake_ack` -> `repair_communication`

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -842,7 +842,7 @@ class PrinterMixin(CommonPrinterMixin):
 
     @classmethod
     @deprecated(
-        message="get_connection_options has been deprecated and will be removed in a future version. Please use ConnectedPrinter.all() in combination with get_connection_options on the returned ConnectedPrinter instances instead.",
+        message="get_connection_options has been deprecated and will be removed in a future version. Please use ConnectedPrinter.all() in combination with connection_options on the returned ConnectedPrinter instances instead.",
         since="2.0.0",
     )
     def get_connection_options(cls, *args, **kwargs):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a typo in the `get_connection_options` deprecation message.

I know this is the third time we're fixing this deprecation message (over the past month, in two of my PRs, I also corrected `ConnectPrinter` -> `ConnectedPrinter` and `get_connection_option` -> `get_connection_options`), hopefully this one will be the right one!

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
