### PR TITLE
fix: update stale GitHub links from master to dev branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ in any way to make it better instead of just complaining about it -- this is an 
 after all :)
 
 For information about how to go about submitting bug reports or pull requests, please see the project's
-[Contribution Guidelines](https://github.com/OctoPrint/OctoPrint/blob/master/CONTRIBUTING.md).
+[Contribution Guidelines](https://github.com/OctoPrint/OctoPrint/blob/dev/CONTRIBUTING.md).
 
 ## Installation
 

--- a/docs/development/environment.rst
+++ b/docs/development/environment.rst
@@ -99,7 +99,7 @@ Then:
 .. todo::
 
    Using a Linux distribution that doesn't use ``apt``? Please send a
-   `Pull Request <https://github.com/OctoPrint/OctoPrint/blob/master/CONTRIBUTING.md#pull-requests>`_ to get the necessary
+   `Pull Request <https://github.com/OctoPrint/OctoPrint/blob/dev/CONTRIBUTING.md#pull-requests>`_ to get the necessary
    steps into this guide!
 
 .. _sec-development-environment-windows:
@@ -225,7 +225,7 @@ IDE Setup
 .. todo::
 
    Using another IDE than the ones below? Please send a
-   `Pull Request <https://github.com/OctoPrint/OctoPrint/blob/master/CONTRIBUTING.md#pull-requests>`_ to get the necessary
+   `Pull Request <https://github.com/OctoPrint/OctoPrint/blob/dev/CONTRIBUTING.md#pull-requests>`_ to get the necessary
    steps into this guide!
 
 Visual Studio Code (vscode)

--- a/docs/development/index.rst
+++ b/docs/development/index.rst
@@ -14,4 +14,4 @@ Development
    request-profiling.rst
 
 If you are interested in contributing code to OctoPrint, first of all: Thank you! Please make sure to read the
-`Contribution Guidelines <https://github.com/OctoPrint/OctoPrint/blob/master/CONTRIBUTING.md>`_!
+`Contribution Guidelines <https://github.com/OctoPrint/OctoPrint/blob/dev/CONTRIBUTING.md>`_!

--- a/docs/plugins/viewmodels.rst
+++ b/docs/plugins/viewmodels.rst
@@ -460,7 +460,7 @@ Web interface reconnect
 
 .. seealso::
 
-   `OctoPrint's core viewmodels <https://github.com/OctoPrint/OctoPrint/tree/master/src/octoprint/static/js/app/viewmodels>`_
+   `OctoPrint's core viewmodels <https://github.com/OctoPrint/OctoPrint/tree/dev/src/octoprint/static/js/app/viewmodels>`_
       OctoPrint's own view models use the same mechanisms for interacting with each other and the web application as
       plugins. Their source code is therefore a good point of reference on how to achieve certain things.
    `KnockoutJS documentation <http://knockoutjs.com/documentation/introduction.html>`_

--- a/src/octoprint/plugins/tracking/static/js/usage.js
+++ b/src/octoprint/plugins/tracking/static/js/usage.js
@@ -102,7 +102,7 @@ $(function () {
                         title: gettext("Something went wrong"),
                         text: _.sprintf(message, {
                             bugreport:
-                                "https://github.com/OctoPrint/OctoPrint/blob/master/CONTRIBUTING.md#how-to-file-a-bug-report",
+                                "https://github.com/OctoPrint/OctoPrint/blob/dev/CONTRIBUTING.md#how-to-file-a-bug-report",
                             jsconsole: "https://webmasters.stackexchange.com/a/77337"
                         }),
                         type: "error",


### PR DESCRIPTION
## What does this PR do?

Updates 6 stale GitHub URLs across 5 files that still referenced the `master` branch instead of the current default branch `dev`.

## Files changed

- `README.md` — contribution guidelines link
- `docs/development/environment.rst` — 2 pull request links
- `docs/development/index.rst` — contribution guidelines link
- `docs/plugins/viewmodels.rst` — core viewmodels link
- `src/octoprint/plugins/tracking/static/js/usage.js` — bug report link in error message

## Why

The OctoPrint/OctoPrint repository uses `dev` as its default branch. The old `master` branch links (using `blob/master` or `tree/master`) lead to GitHub 404s or incorrectly redirect to the default branch, making them unreliable. Updating to `dev` ensures these links point to the correct branch explicitly.

## Type of change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change
- [x] Documentation fix