### PR TITLE
fix(swu): apply codeberg_release alias consistently in _populated_check

### DIFF
--- a/src/octoprint/plugins/softwareupdate/__init__.py
+++ b/src/octoprint/plugins/softwareupdate/__init__.py
@@ -2347,7 +2347,7 @@ class SoftwareUpdatePlugin(
 
         result = dict(check)
 
-        if result.get("type") == "codeberg_release":
+        if check.get("type") == "codeberg_release":
             result["type"] = "forgejo_release"
             result["forge"] = "codeberg"
 
@@ -2366,7 +2366,7 @@ class SoftwareUpdatePlugin(
 
             result["released_version"] = is_released_octoprint_version()
 
-            if check["type"] in self.COMMIT_TRACKING_TYPES:
+            if result["type"] in self.COMMIT_TRACKING_TYPES:
                 result["current"] = REVISION if REVISION else "unknown"
             else:
                 result["current"] = VERSION
@@ -2404,7 +2404,7 @@ class SoftwareUpdatePlugin(
                 # displayVersion AND current missing or None
                 result["displayVersion"] = "unknown"
 
-            if check["type"] in self.CURRENT_TRACKING_TYPES:
+            if result["type"] in self.CURRENT_TRACKING_TYPES:
                 result["current"] = check.get("current", None)
             else:
                 result["current"] = check.get(
@@ -2412,7 +2412,7 @@ class SoftwareUpdatePlugin(
                 )
 
         if (
-            check["type"] in self.RELEASE_TRACKING_TYPES
+            result["type"] in self.RELEASE_TRACKING_TYPES
             and result["current"]
             and (check.get("prerelease", None) or not is_stable(result["current"]))
         ):


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed a bug in the `SoftwareUpdatePlugin._populated_check` function:

the `codeberg_release` type is supposed to be an alias for `forgejo_release`, so it was correctly converted with `result["type"] = "forgejo_release"` (line 2351), but some subsequent checks were checking on `check["type"]` (which could still contains `codeberg_release`) instead of `result["type"]` (the correctly aliased value).

This PR aligns the behavior for the whole `_populated_check` function: we always want to use `check["type"]` to read the pre-aliasing input, and `result["type"]` post-aliasing.

#### How was it tested? How can it be tested by the reviewer?

Not (yet?) really tested, sorry! I don't have (yet?) a forgejo/codeberg environment ready to test this one.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

This was spotted while reviewing the recent commit f72717a92c259587de5383e62c9eec9927cd423d.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
