### PR TITLE
fix(coreui): fix unable to move from root

### DIFF
--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -1352,6 +1352,11 @@ def gcodeFileCommand(storage, path=""):
                 sanitized_source = fileManager.path_in_storage(storage, path)
 
                 destination = data["destination"]
+                if fileManager.folder_exists(
+                    dst_storage, destination
+                ) and not destination.endswith("/"):
+                    destination += "/"  # ensure target folders end on /, see #5393
+
                 dst_path, dst_name = fileManager.split_path(dst_storage, destination)
                 if not dst_name:
                     dst_name = name

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -134,7 +134,7 @@ $(function () {
                 let result = [];
                 entries.forEach((entry) => {
                     if (entry.type !== "folder") return;
-                    result.push("/" + entry.path);
+                    result.push("/" + entry.path + "/");
 
                     if (entry.children) {
                         result = result.concat(createFolderList(entry.children));


### PR DESCRIPTION
- [X] You have read through `CONTRIBUTING.md`
- [X] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [X] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [X] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [X] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [ ] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [X] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [X] You have added yourself to the `AUTHORS.md` file :)

#### What does this PR do and why is it necessary?

appends trailing slash to folder list in copy move dialog of file list to fix erroring API calls

#### How was it tested? How can it be tested by the reviewer?

manually tested by making the changes in locally and moving files from root to sub-folder.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#5393

#### Screenshots (if appropriate)

#### Further notes
