### PR TITLE
fix(coreui): fix move/rename dialog regressions from #5399

### DIFF
--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -953,7 +953,7 @@ $(function () {
             var slashPos = entry.path.lastIndexOf("/");
             var current;
             if (slashPos >= 0) {
-                current = "/" + entry.path.substr(0, slashPos);
+                current = "/" + entry.path.substr(0, slashPos) + "/";
             } else {
                 current = "/";
             }

--- a/src/octoprint/static/js/app/viewmodels/files.js
+++ b/src/octoprint/static/js/app/viewmodels/files.js
@@ -53,7 +53,7 @@ $(function () {
         self.moveDestinationFullpath = ko.pureComputed(function () {
             // Join the paths for renaming
             if (self.moveSourceFilename() !== self.moveDestinationFilename()) {
-                if (self.moveDestination() === "/") {
+                if (self.moveDestination().endsWith("/")) {
                     return self.moveDestination() + self.moveDestinationFilename();
                 } else {
                     return self.moveDestination() + "/" + self.moveDestinationFilename();


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

The trailing slash added to the folder list options in #5399 was not propagated to `showMoveDialog` and `moveDestinationFullpath` functions. As a result, the source folder was no longer preselected in the destination dropdown and renaming into a non-root folder produced paths with a double slash (e.g. `/foo//bar.gco`).

#### How was it tested? How can it be tested by the reviewer?

1. Create a folder (e.g. `foo`) and upload a file into it (e.g. `bar.gcode`).
2. Click the move/rename button on the file. The destination dropdown should preselect `/foo/` (the current folder). Before this PR, it incorrectly preselects `/`.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

This was spotted while reviewing 73cff7387.

#### What are the relevant tickets if any?

Fixes regressions introduced by #5399.

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
