### PR TITLE
fix(printer): fix AttributeError in error_info setter

### DIFF
--- a/src/octoprint/printer/connection.py
+++ b/src/octoprint/printer/connection.py
@@ -303,8 +303,8 @@ class ConnectedPrinter(ConnectedPrinterMixin, metaclass=ConnectedPrinterRegistra
         self._error_info = value
         if self._error_info:
             payload = self._error_info.model_dump(exclude_none=True)
-            if self._connection and self._connection.connector:
-                payload["connector"] = self._connection.connector
+            if self.connector:
+                payload["connector"] = self.connector
             else:
                 payload["connector"] = "unknown"
             eventManager().fire(Events.ERROR, payload=payload)


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes a bug introduced by 64f43e8.

In `connection.py` the correct attribute is `self.connector`, and `self._connection.connector` does not exist.

This caused an `AttributeError` crash when the printer closed the connection on error.

#### How was it tested? How can it be tested by the reviewer?

Connect to the virtual printer and send the following command: `!!DEBUG:send Error:something`.

Before merging this PR, a crash occurs with the following stacktrace:

```stacktrace
2026-06-06 18:50:17,163 - octoprint.plugins.serial_connector.serial_comm - ERROR - Something crashed inside the serial connection loop, please report this in OctoPrint's bug tracker:
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 2575, in _monitor
    line = self._handle_errors(line)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 4183, in _handle_errors
    self._trigger_error(stripped_error, "firmware")
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/serial_comm.py", line 4231, in _trigger_error
    self._callback.on_comm_error(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        text,
        ^^^^^
    ...<3 lines>...
        logs=payload.get("logs"),
        ^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugins/serial_connector/connector.py", line 684, in on_comm_error
    self.error_info = ErrorInformation(
    ^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/printer/connection.py", line 306, in error_info
    if self._connection and self._connection.connector:
       ^^^^^^^^^^^^^^^^
AttributeError: 'ConnectedSerialPrinter' object has no attribute '_connection'. Did you mean: 'connector'?
```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
