### PR TITLE
fix(tornado): fix download filenames containing a comma

### DIFF
--- a/src/octoprint/server/util/tornado.py
+++ b/src/octoprint/server/util/tornado.py
@@ -1401,9 +1401,10 @@ class StorageFileDownloadHandler(
         if content_type:
             self.set_header("Content-Type", content_type)
 
+        escaped_filename = tornado.escape.url_escape(filename, plus=False)
         self.set_header(
             "Content-Disposition",
-            f"attachment; filename=\"{filename}\"; filename*=UTF-8''{filename}",
+            f"attachment; filename=\"{escaped_filename}\"; filename*=UTF-8''{escaped_filename}",
         )
 
         # FIXME implement cache control via ETag and/or last modified, if possible for storage


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed that in OctoPrint 2.0.0rc2 the GCode Viewer failed to load the preview of files whose name contains a comma.
In the JS console I found the following error:
```stacktrace
Uncaught (in promise) TypeError: Failed to fetch
    at gCodeLineGenerator (worker.js:328:28)
    at gCodeLineGenerator.next (<anonymous>)
    at doParse (worker.js:453:37)
    at async parseGCode (worker.js:907:5)
```
And in the Network tab I saw that the request `GET http://127.0.0.1:5000/downloads/files/local/a%2Cb.gcode` failed with the error `(failed)net::ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION`.

After that, I noticed that it was in fact impossible to download those very files; even the download button led to a Chrome error page.

After a brief investigation, I traced the bug back to commit 97b3db3e9ddec4948378ea6efefcf33029fab6a7, which introduced the new `StorageFileDownloadHandler` class where, compared to the old `LargeResponseHandler`, the filename was not urlescaped in the `Content-Disposition` header.

This PR adds the missing escape, restoring correct download behavior for filenames containing a comma.

This bug affected only the `next` branch, while 1.11.7 works correctly.

#### How was it tested? How can it be tested by the reviewer?

1. Upload a file with filename `a,b.gcode`.
2. Try to download it with Chrome and notice that before this PR the `ERR_RESPONSE_HEADERS_MULTIPLE_CONTENT_DISPOSITION` error page appears. After this PR, it downloads correctly.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
