### PR TITLE
Allow JSONC development config in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: trailing-whitespace
       - id: check-case-conflict
       - id: check-json
+        exclude: ^(\.devcontainer/.*|\.vscode/.*)\.json$
       - id: check-yaml
       - id: check-toml
       - id: check-merge-conflict
@@ -52,7 +53,7 @@ repos:
     rev: v3.6.0
     hooks:
       - id: prettier
-        files: "\\.(js|json|css|less|md|yml|yaml)$"
+        files: "\\.(js|json|jsonc|css|less|md|yml|yaml)$"
   - repo: https://github.com/pre-commit/mirrors-eslint
     rev: v9.29.0
     hooks:


### PR DESCRIPTION
﻿#### What does this PR do and why is it necessary?

Allows JSONC-style development configuration files to coexist with the pre-commit suite:

- skips strict `check-json` validation for `.vscode/*.json` and `.devcontainer/*.json`, which are JSONC-by-convention and may contain comments
- includes explicit `.jsonc` files in the Prettier hook's file matcher

This addresses #4521 without changing OctoPrint runtime behavior.

#### How was it tested? How can it be tested by the reviewer?

- `pre-commit validate-config`
- `pre-commit run check-json --files src\octoprint\static\manifest.json`
- temporary `.vscode\settings.json` and `.devcontainer\devcontainer.json` with comments: `pre-commit run check-json --files ...` skips them as intended
- temporary `.vscode\settings.json` and `jsonc_probe.jsonc` with comments: `pre-commit run prettier --files ...` passes
- `git diff --check`

#### What are the relevant tickets if any?

Closes #4521
