### PR TITLE
fix(discovery): re-expose discovery data to users via settings

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -192,6 +192,7 @@ date of first contribution):
   * [Emmanuel Ferdman](https://github.com/emmanuel-ferdman)
   * [Will Schlitzer](https://github.com/willschlitzer)
   * [John Brady](https://github.com/bradyjoh)
+  * [Sanjay Govind](https://github.com/sanjay900)
 
 OctoPrint started off as a fork of [Cura](https://github.com/daid/Cura) by
 [Daid Braam](https://github.com/daid). Parts of its communication layer and

--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -19,6 +19,7 @@ from flask_babel import gettext
 
 import octoprint.plugin
 import octoprint.util
+from octoprint.access.permissions import Permissions
 
 
 def __plugin_load__():
@@ -95,9 +96,20 @@ class DiscoveryPlugin(
         }
 
     def get_settings_restricted_paths(self):
-        keys = self.get_settings_defaults().keys()
-
-        return {"never": [[key] for key in keys]}
+        return {
+            Permissions.SETTINGS_READ: [["zeroConf"], ["model"], ["upnpUuid"]],
+            "never": [
+                ["publicHost"],
+                ["publicPort"],
+                ["pathPrefix"],
+                ["addresses"],
+                ["ignoredAddresses"],
+                ["interfaces"],
+                ["ignoredInterfaces"],
+                ["httpUsername"],
+                ["httpPassword"],
+            ],
+        }
 
     ##~~ BlueprintPlugin API -- used for providing the SSDP device descriptor XML
 

--- a/src/octoprint/plugins/discovery/__init__.py
+++ b/src/octoprint/plugins/discovery/__init__.py
@@ -19,7 +19,6 @@ from flask_babel import gettext
 
 import octoprint.plugin
 import octoprint.util
-from octoprint.access.permissions import Permissions
 
 
 def __plugin_load__():
@@ -96,19 +95,25 @@ class DiscoveryPlugin(
         }
 
     def get_settings_restricted_paths(self):
+        # The data from these keys is accessible through discovery on the LAN, so we allow authenticated users
+        # access too. Home Assistant also needs at least upnpUuid for the config flow, see #5445.
+        #
+        # Anything else is config.yaml only
+        ALLOWED_KEYS = (
+            "publicHost",
+            "publicPort",
+            "pathPrefix",
+            "httpUsername",
+            "httpPassword",
+            "upnpUuid",
+            "model",
+        )
+
+        keys = self.get_settings_defaults().keys()
+
         return {
-            Permissions.SETTINGS_READ: [["zeroConf"], ["model"], ["upnpUuid"]],
-            "never": [
-                ["publicHost"],
-                ["publicPort"],
-                ["pathPrefix"],
-                ["addresses"],
-                ["ignoredAddresses"],
-                ["interfaces"],
-                ["ignoredInterfaces"],
-                ["httpUsername"],
-                ["httpPassword"],
-            ],
+            "user": [[key] for key in ALLOWED_KEYS],
+            "never": [[key] for key in keys if key not in ALLOWED_KEYS],
         }
 
     ##~~ BlueprintPlugin API -- used for providing the SSDP device descriptor XML

--- a/tests/http_api/test_settings_api.py
+++ b/tests/http_api/test_settings_api.py
@@ -62,6 +62,18 @@ def test_user(base_url, user_credentials):
         {"log": _not_none, "ignoreEmptyPorts": _not_none},
     )
 
+    # discovery
+    _verify_tree_restricted(
+        data["plugins"]["discovery"],
+        {
+            key: _not_none
+            for key in (
+                "upnpUuid",
+                "model",
+            )
+        },
+    )
+
     # API version 2.0.0
     assert "printerConnection" in data
     assert "serial" not in data


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [x] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [ ] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?
Recently, [this commit](https://github.com/OctoPrint/OctoPrint/commit/7e948d3021b03a40c38e62c4f0049a1a7225d347) added some restrictions to fetching settings via the API. 
However, it was overly restrictive on the discovery plugin, and it looks like it broke home assistant, which tries to fetch the upnpUuid via the settings API endpoint in order to match up devices and figure out if it has already seen them or not.

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?
no

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
