### PR TITLE
perf(gcv): stop decompressing the model twice to count layers

### DIFF
--- a/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
+++ b/src/octoprint/plugins/gcodeviewer/static/js/viewer/worker.js
@@ -159,24 +159,6 @@ const sendAnalyzeDone = () => {
     });
 };
 
-const purgeLayers = () => {
-    let purge = true;
-    model.forEach((cmds) => {
-        purge = true;
-        if (!cmds) {
-            purge = true;
-        } else {
-            if (cmds instanceof Uint8Array) cmds = decompress(cmds);
-            cmds.forEach((cmd) => {
-                if (cmd.extrude) purge = false;
-            });
-        }
-        if (!purge) {
-            layerCnt++;
-        }
-    });
-};
-
 const bedBounds = () => {
     if (!bed) {
         return {xMin: 0, xMax: 0, yMin: 0, yMax: 0};
@@ -307,13 +289,14 @@ const analyzeModel = () => {
             }
         });
 
-        if (!layerExtrude) {
+        if (layerExtrude) {
+            layerCnt++;
+        } else {
             emptyLayers[i] = true;
         }
 
         sendSizeProgress((i / model.length) * 100);
     });
-    purgeLayers();
 
     modelSize.x = Math.abs(max.x - min.x);
     modelSize.y = Math.abs(max.y - min.y);


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

While reading the gcodeviewer code, I noticed that right after the gcode analysis (the `analyzeModel()` function) a separate `purgeLayers()` function was invoked in order to count the number of extruding layers. This could be done directly during model analysis, especially since `layerExtrude`, the variable needed to tell whether a layer extrudes at least once, was already there.

This optimization not only simplifies the code, it also speeds up the parsing of compressed gcode files (i.e. the ones above 200MB), since `decompress()` no longer has to be called a second time. The parsing time of a 350MB gcode on my laptop went from 130 to 110 seconds: 20 seconds less.

#### How was it tested? How can it be tested by the reviewer?

Load a big gcode and measure the parsing time. I can't attach the gcode I tested with, because even compressed it exceeds GitHub's 25MB limit, but I can provide it on a separate channel if needed.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

I was reviewing gcodeviewer's performance to see whether any of the optimizations I recently came up with while developing the gcode parsing in my plugin [PrettyGCode](https://plugins.octoprint.org/plugins/prettygcode/) were applicable. It turned out that basically none of them were.
There would probably be a performance gain (cpu/ram) in using JavaScript's native binary arrays (e.g. [`Float32Array`](https://caniuse.com/mdn-javascript_builtins_float32array)) instead of JSON, but it would require too extensive a rewrite of the code and I wouldn't recommend it at this time.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
