### PR TITLE
fix(serial): stop firing Error event twice

### DIFF
--- a/src/octoprint/plugins/serial_connector/serial_comm.py
+++ b/src/octoprint/plugins/serial_connector/serial_comm.py
@@ -4238,7 +4238,6 @@ class MachineCom:
             faq=payload.get("faq"),
             logs=payload.get("logs"),
         )
-        eventManager().fire(Events.ERROR, payload)
 
         if close:
             if trigger_m112:


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

I noticed the `Error` event is fired twice: [here](https://github.com/OctoPrint/OctoPrint/blob/1c01dc3c0fd39553931706cc9001be7bf1c35392/src/octoprint/plugins/serial_connector/serial_comm.py#L4241) and [here](https://github.com/OctoPrint/OctoPrint/blob/1c01dc3c0fd39553931706cc9001be7bf1c35392/src/octoprint/printer/connection.py#L310). This bug happens only in OctoPrint 2.x. This could be the reason why analytics collect more errors than usual (I saw your post in https://github.com/OctoPrint/OctoPrint/issues/5434).

The cause of this bug is the commit https://github.com/OctoPrint/OctoPrint/commit/d55a51133, which moved the `ERROR` and `FIRMWARE_DATA` events from `serial_comm.py` to `connection.py` but forgot to remove the old fire for the `ERROR` event only.

#### How was it tested? How can it be tested by the reviewer?

Place the following script in `/home/user/.octoprint/plugins/bug_repro.py` and restart OctoPrint:

```py
import octoprint.plugin

class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.EventHandlerPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")

    def on_event(self, event, payload): 
        self._logger.info(f"Received event {event} with payload {payload}")

__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Connect to the virtual printer, go to the Terminal tab and insert the following command: `!!DEBUG:send Error:something`.

Before this PR, in OctoPrint logs, the `Error` event is fired twice:

```stacktrace
2026-08-20 00:23:15,636 - octoprint.plugins.bug_repro - INFO - Received event Error with payload {'error': 'something', 'reason': 'firmware', 'consequence': 'emergency', 'logs': ['<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '>>> !!DEBUG:send Error:something', '<<< Error:something', 'Changing monitoring state from "Operational" to "Error"'], 'connector': 'serial'}
2026-08-20 00:23:15,637 - octoprint.plugins.bug_repro - INFO - Received event Error with payload {'error': 'something', 'reason': 'firmware', 'connector': 'serial', 'consequence': 'emergency', 'logs': ['<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '<<< Not SD printing', '<<< wait', '<<< T:21.30/ 0.00 B:21.30/ 0.00 C:21.30/ 0.00 @:64', '<<< Not SD printing', '<<< wait', '>>> !!DEBUG:send Error:something', '<<< Error:something', 'Changing monitoring state from "Operational" to "Error"']}
 ```

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
