### PR TITLE
docs: fix FileDestinations.SDCARD notes in 2.0.0 migration guide

### DIFF
--- a/docs/plugins/migration_2_0_0.md
+++ b/docs/plugins/migration_2_0_0.md
@@ -100,10 +100,10 @@ However, it is *strongly* recommended to think whether some more granular (and p
 (sec-plugins-octo_2_0_0-server-storage-sdcard_value)=
 #### Changed value of `octoprint.filemanager.FileDestinations.SDCARD`
 
-The value of `FileDestinations.SDCARD` has changed from `printer` to `sdcard`. Any plugins that compared it against the hardcoded string will fail the comparison. Switch your code to using `FileDestinations.PRINTER` for all required checks! Example:
+The value of `FileDestinations.SDCARD` has changed from `sdcard` to `printer`. Any plugins that compared it against the hardcoded string will fail the comparison. Switch your code to using `FileDestinations.PRINTER` for all required checks! Example:
 
 ``` python
-from octoprint.storage import FileDestinations
+from octoprint.filemanager.destinations import FileDestinations
 
 if storage == FileDestinations.PRINTER:  # preferred!
     # do something


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [ ] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

This PR fixes the chapter "Changed value of `octoprint.filemanager.FileDestinations.SDCARD`" in 2.0.0 migration guide: the value change was inverted and the import path in example code was broken.

#### How was it tested? How can it be tested by the reviewer?

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

I noticed this one while migrating a plugin

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
