### PR TITLE
fix(storage): reject NaN & Inf when saving file metadata

### DIFF
--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -1410,18 +1410,11 @@ class FileManager:
     def set_additional_metadata(
         self, location, path, key, data, overwrite=False, merge=False
     ):
-        if not self.validate_additional_metadata(location, data):
-            raise StorageError(
-                f"Additional metadata for {path} and {key} is invalid: {data!r}",
-                code=StorageError.INVALID_METADATA,
-            )
         self._storage(location).set_additional_metadata(
             path, key, data, overwrite=overwrite, merge=merge
         )
 
     def validate_additional_metadata(self, location, data):
-        if not isinstance(data, dict):
-            return False
         return self._storage(location).validate_additional_metadata(data)
 
     def remove_additional_metadata(self, location, path, key):

--- a/src/octoprint/filemanager/__init__.py
+++ b/src/octoprint/filemanager/__init__.py
@@ -1410,9 +1410,19 @@ class FileManager:
     def set_additional_metadata(
         self, location, path, key, data, overwrite=False, merge=False
     ):
+        if not self.validate_additional_metadata(location, data):
+            raise StorageError(
+                f"Additional metadata for {path} and {key} is invalid: {data!r}",
+                code=StorageError.INVALID_METADATA,
+            )
         self._storage(location).set_additional_metadata(
             path, key, data, overwrite=overwrite, merge=merge
         )
+
+    def validate_additional_metadata(self, location, data):
+        if not isinstance(data, dict):
+            return False
+        return self._storage(location).validate_additional_metadata(data)
 
     def remove_additional_metadata(self, location, path, key):
         self._storage(location).remove_additional_metadata(path, key)

--- a/src/octoprint/filemanager/storage/common.py
+++ b/src/octoprint/filemanager/storage/common.py
@@ -589,6 +589,9 @@ class StorageInterface:
 
         The default implementation always returns ``True``.
 
+        Args:
+            data: metadata to check
+
         Returns:
             (bool) ``True`` if the data is considered valid, ``False`` otherwise
 

--- a/src/octoprint/filemanager/storage/common.py
+++ b/src/octoprint/filemanager/storage/common.py
@@ -540,16 +540,27 @@ class StorageInterface:
     ) -> bool:
         raise NotImplementedError()
 
-    def get_additional_metadata(self, path, key):
+    def get_additional_metadata(self, path: str, key: str) -> Optional[dict[str, Any]]:
         """
         Fetches additional metadata at ``key`` from the metadata of ``path``.
 
-        :param path: the virtual path to the file for which to fetch additional metadata
-        :param key: key of metadata to fetch
+        Args:
+            path(str): the virtual path to the file for which to fetch additional metadata
+            key(str): key of metadata to fetch
+
+        Raises:
+            StorageError: if the underlying storage doesn't support metadata
         """
         raise NotImplementedError()
 
-    def set_additional_metadata(self, path, key, data, overwrite=False, merge=False):
+    def set_additional_metadata(
+        self,
+        path: str,
+        key: str,
+        data: dict[str, Any],
+        overwrite: bool = False,
+        merge: bool = False,
+    ):
         """
         Adds additional metadata to the metadata of ``path``. Metadata in ``data`` will be saved under ``key``.
 
@@ -558,21 +569,44 @@ class StorageInterface:
         If ``merge`` is set and ``key`` already exists and both ``data`` and the existing data under ``key`` are dictionaries,
         the two dictionaries will be merged recursively.
 
-        :param path: the virtual path to the file for which to add additional metadata
-        :param key: key of metadata to add
-        :param data: metadata to add
-        :param overwrite: if True and ``key`` already exists, it will be overwritten
-        :param merge: if True and ``key`` already exists and both ``data`` and the existing data are dictionaries, they
-                      will be merged
+        Args:
+            path (str): the virtual path to the file for which to add additional metadata
+            key (str): key of metadata to add
+            data (dict): metadata to add
+            overwrite (bool): if True and ``key`` already exists, it will be overwritten
+            merge (bool): if True and ``key`` already exists and both ``data`` and the existing data are dictionaries, they
+                will be merged
+
+        Raises:
+            StorageError: if the underlying storage doesn't support metadata, or if the provided ``data`` contains invalid values
+                (e.g. positive or negative infinity, NaN)
         """
         raise NotImplementedError()
 
-    def remove_additional_metadata(self, path, key):
+    def validate_additional_metadata(self, data: dict[str, Any]) -> bool:
+        """
+        Checks whether the provided ``data`` is considered valid as additional metadata.
+
+        The default implementation always returns ``True``.
+
+        Returns:
+            (bool) ``True`` if the data is considered valid, ``False`` otherwise
+
+        Raises:
+            StorageError: if the underlying storage doesn't support metadata
+        """
+        return True
+
+    def remove_additional_metadata(self, path: str, key: str):
         """
         Removes additional metadata under ``key`` for ``name`` on ``path``
 
-        :param path: the virtual path to the file for which to remove the metadata under ``key``
-        :param key: the key to remove
+        Args:
+            path(str): the virtual path to the file for which to remove the metadata under ``key``
+            key(str): the key to remove
+
+        Raises:
+            StorageError: if the underlying storage doesn't support metadata
         """
         raise NotImplementedError()
 
@@ -765,6 +799,7 @@ class StorageError(Exception):
     INVALID_FILE = "invalid_file"
     INVALID_SOURCE = "invalid_source"
     INVALID_DESTINATION = "invalid_destination"
+    INVALID_METADATA = "invalid_metadata"
     DOES_NOT_EXIST = "does_not_exist"
     ALREADY_EXISTS = "already_exists"
     SOURCE_EQUALS_DESTINATION = "source_equals_destination"

--- a/src/octoprint/filemanager/storage/common.py
+++ b/src/octoprint/filemanager/storage/common.py
@@ -557,7 +557,7 @@ class StorageInterface:
         self,
         path: str,
         key: str,
-        data: dict[str, Any],
+        data: Any,
         overwrite: bool = False,
         merge: bool = False,
     ):
@@ -572,18 +572,18 @@ class StorageInterface:
         Args:
             path (str): the virtual path to the file for which to add additional metadata
             key (str): key of metadata to add
-            data (dict): metadata to add
+            data: metadata to add
             overwrite (bool): if True and ``key`` already exists, it will be overwritten
             merge (bool): if True and ``key`` already exists and both ``data`` and the existing data are dictionaries, they
                 will be merged
 
         Raises:
-            StorageError: if the underlying storage doesn't support metadata, or if the provided ``data`` contains invalid values
-                (e.g. positive or negative infinity, NaN)
+            StorageError: if the underlying storage doesn't support metadata (code ``unsupported``), or if the provided ``data`` contains invalid values
+                (e.g. positive or negative infinity, NaN; code ``invalid_metadata``)
         """
         raise NotImplementedError()
 
-    def validate_additional_metadata(self, data: dict[str, Any]) -> bool:
+    def validate_additional_metadata(self, data: Any) -> bool:
         """
         Checks whether the provided ``data`` is considered valid as additional metadata.
 
@@ -593,7 +593,7 @@ class StorageInterface:
             (bool) ``True`` if the data is considered valid, ``False`` otherwise
 
         Raises:
-            StorageError: if the underlying storage doesn't support metadata
+            StorageError: if the underlying storage doesn't support metadata (code ``unsupported``)
         """
         return True
 

--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -1782,6 +1782,10 @@ class LocalFileStorage(StorageInterface):
     def _save_metadata(self, path, metadata):
         import json
 
+        serialized = json.dumps(
+            metadata, indent=2, separators=(",", ": "), allow_nan=False
+        )
+
         with self._get_metadata_lock(path):
             self._metadata_cache[path] = metadata
 
@@ -1789,9 +1793,7 @@ class LocalFileStorage(StorageInterface):
             metadata_path = os.path.join(path, ".metadata.json")
             try:
                 with atomic_write(metadata_path, mode="wb") as f:
-                    f.write(
-                        to_bytes(json.dumps(metadata, indent=2, separators=(",", ": ")))
-                    )
+                    f.write(to_bytes(serialized))
                 self._update_last_activity()
             except Exception:
                 self._logger.exception(f"Error while writing .metadata.json to {path}")

--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -903,6 +903,12 @@ class LocalFileStorage(StorageInterface):
         return metadata[name].get(key)
 
     def set_additional_metadata(self, path, key, data, overwrite=False, merge=False):
+        if not self.validate_additional_metadata(data):
+            raise StorageError(
+                f"Additional metadata at {key} for {path} contains invalid values (positive or negative infinity, NaN, unserializable json)",
+                code=StorageError.INVALID_METADATA,
+            )
+
         path, name = self.sanitize(path)
         metadata = self._get_metadata(path)
         metadata_dirty = False
@@ -930,6 +936,9 @@ class LocalFileStorage(StorageInterface):
 
         if metadata_dirty:
             self._save_metadata(path, metadata)
+
+    def validate_additional_metadata(self, data):
+        return self._valid_json(data)
 
     def remove_additional_metadata(self, path, key):
         path, name = self.sanitize(path)
@@ -1751,19 +1760,9 @@ class LocalFileStorage(StorageInterface):
                             f"Error while reading .metadata.json from {path}"
                         )
 
-        def valid_json(value):
-            try:
-                json.dumps(value, allow_nan=False)
-                return True
-            except Exception:
-                return False
-
         if isinstance(metadata, dict):
             old_size = len(metadata)
-            metadata = {k: v for k, v in metadata.items() if valid_json(v)}
-            metadata = {
-                k: v for k, v in metadata.items() if os.path.exists(os.path.join(path, k))
-            }
+            metadata = self._sanitized_metadata(path, metadata)
             new_size = len(metadata)
             if new_size != old_size:
                 self._logger.info(
@@ -1781,6 +1780,14 @@ class LocalFileStorage(StorageInterface):
 
     def _save_metadata(self, path, metadata):
         import json
+
+        old_keys = metadata.keys()
+        metadata = self._sanitized_metadata(path, metadata, must_exist=False)
+        if len(metadata.keys()) != len(old_keys):
+            missing_keys = [key for key in old_keys if key not in metadata]
+            raise ValueError(
+                f"Invalid data detected in metadata for {path} and keys {missing_keys!r}, refusing to save"
+            )
 
         serialized = json.dumps(
             metadata, indent=2, separators=(",", ": "), allow_nan=False
@@ -1821,6 +1828,33 @@ class LocalFileStorage(StorageInterface):
         metadata = copy.copy(metadata)
         metadata[name] = copy.deepcopy(metadata.get(name, {}))
         return metadata
+
+    @staticmethod
+    def _valid_json(value):
+        import json
+
+        try:
+            json.dumps(value, allow_nan=False)
+            return True
+        except Exception:
+            return False
+
+    @classmethod
+    def _sanitized_metadata(clz, path, metadata, must_exist=True):
+        if not isinstance(metadata, dict):
+            return {}
+
+        if isinstance(metadata, dict):
+            metadata = {k: v for k, v in metadata.items() if clz._valid_json(v)}
+            if must_exist:
+                metadata = {
+                    k: v
+                    for k, v in metadata.items()
+                    if os.path.exists(os.path.join(path, k))
+                }
+            return metadata
+        else:
+            return {}
 
     def _migrate_metadata(self, path):
         # we switched to json in 1.3.9 - if we still have yaml here, migrate it now

--- a/src/octoprint/filemanager/storage/local.py
+++ b/src/octoprint/filemanager/storage/local.py
@@ -905,7 +905,7 @@ class LocalFileStorage(StorageInterface):
     def set_additional_metadata(self, path, key, data, overwrite=False, merge=False):
         if not self.validate_additional_metadata(data):
             raise StorageError(
-                f"Additional metadata at {key} for {path} contains invalid values (positive or negative infinity, NaN, unserializable json)",
+                f"Additional metadata for {path} with {key} is invalid (e.g. contains +/-inf or NaN): {data!r}",
                 code=StorageError.INVALID_METADATA,
             )
 

--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -507,7 +507,7 @@ class PrinterFileStorage(StorageInterface):
 
         if not self.validate_additional_metadata(data):
             raise StorageError(
-                f"Additional metadata for {path} and {key} is invalid: {data!r}",
+                f"Additional metadata for {path} with {key} is invalid: {data!r}",
                 code=StorageError.INVALID_METADATA,
             )
 
@@ -522,7 +522,11 @@ class PrinterFileStorage(StorageInterface):
             if not overwrite:
                 return
 
-            if merge:
+            if (
+                merge
+                and isinstance(metadata.additional[key], dict)
+                and isinstance(data, dict)
+            ):
                 import octoprint.util
 
                 data = octoprint.util.dict_merge(metadata.additional[key], data)

--- a/src/octoprint/filemanager/storage/printer.py
+++ b/src/octoprint/filemanager/storage/printer.py
@@ -505,6 +505,12 @@ class PrinterFileStorage(StorageInterface):
                 code=StorageError.UNSUPPORTED,
             )
 
+        if not self.validate_additional_metadata(data):
+            raise StorageError(
+                f"Additional metadata for {path} and {key} is invalid: {data!r}",
+                code=StorageError.INVALID_METADATA,
+            )
+
         metadata = self._connection.get_printer_file_metadata(path)
         if metadata is None:
             metadata = MetadataEntry()
@@ -524,6 +530,15 @@ class PrinterFileStorage(StorageInterface):
         metadata.additional[key] = data
         self._connection.set_printer_file_metadata(path, metadata)
         self._update_last_activity()
+
+    def validate_additional_metadata(self, data):
+        if not self.capabilities.metadata:
+            raise StorageError(
+                "Printer does not support storing additional metadata",
+                code=StorageError.UNSUPPORTED,
+            )
+
+        return self._connection.validate_printer_file_additional_metadata(data)
 
     def remove_additional_metadata(self, path, key):
         if not self.capabilities.metadata:

--- a/src/octoprint/printer/__init__.py
+++ b/src/octoprint/printer/__init__.py
@@ -28,7 +28,7 @@ __copyright__ = "Copyright (C) 2014 The OctoPrint Project - Released under terms
 
 import datetime
 import re
-from typing import IO, TYPE_CHECKING, Optional, Union
+from typing import IO, TYPE_CHECKING, Any, Optional, Union
 
 from pydantic import computed_field
 
@@ -711,6 +711,11 @@ class PrinterFilesMixin:
         self, path: str, metadata: MetadataEntry, *args, **kwargs
     ) -> None:
         pass
+
+    def validate_printer_file_additional_metadata(
+        self, data: dict[str, Any], *args, **kwargs
+    ) -> bool:
+        return True
 
     def has_thumbnail(self, path: str, *args, **kwargs) -> bool:
         return False

--- a/src/octoprint/server/api/files.py
+++ b/src/octoprint/server/api/files.py
@@ -738,13 +738,17 @@ def uploadGcodeFile(target):
 
             # Store any additional user data the caller may have passed.
             userdata = None
-            if "userdata" in request.values:
+            if "userdata" in request.values and fileManager.capabilities(target).metadata:
                 import json
 
                 try:
                     userdata = json.loads(request.values["userdata"])
                 except Exception:
                     abort(400, description="userdata contains invalid JSON")
+
+                # make sure the target storage actually supports the provided userdata as additional metadata
+                if not fileManager.validate_additional_metadata(target, userdata):
+                    abort(400, description="userdata is invalid additional metadata")
 
             # evaluate select and print parameter and if set check permissions & preconditions
             # and adjust as necessary
@@ -854,9 +858,15 @@ def uploadGcodeFile(target):
 
             if userdata is not None:
                 # upload included userdata, add this now to the metadata
-                fileManager.set_additional_metadata(
-                    target, added_file, "userdata", userdata
-                )
+                try:
+                    fileManager.set_additional_metadata(
+                        target, added_file, "userdata", userdata
+                    )
+                except StorageError:
+                    # this should never happen as we already checked whether the storage
+                    # supports metadata and whether the provided userdata is valid, but
+                    # just in case...
+                    pass
 
             payload = {
                 "name": futureFilename,

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -916,7 +916,7 @@ class FileManagerTest(unittest.TestCase):
         # assert that the temporary file was deleted
         mocked_os.assert_called_once_with("tmp.file")
 
-    def test_add_additional_metadata(self):
+    def test_validate_additional_metadata(self):
         self.local_storage.validate_additional_metadata.return_value = True
 
         self.assertTrue(
@@ -925,16 +925,7 @@ class FileManagerTest(unittest.TestCase):
             )
         )
 
-    def test_add_additional_metadata_invalid_value(self):
-        self.local_storage.validate_additional_metadata.return_value = True
-
-        self.assertFalse(
-            self.file_manager.validate_additional_metadata(
-                octoprint.filemanager.FileDestinations.LOCAL, "value"
-            )
-        )
-
-    def test_add_additional_metadata_storage_validation_fails(self):
+    def test_validate_additional_metadata_invalid(self):
         self.local_storage.validate_additional_metadata.return_value = False
 
         self.assertFalse(

--- a/tests/filemanager/test_filemanager.py
+++ b/tests/filemanager/test_filemanager.py
@@ -915,3 +915,30 @@ class FileManagerTest(unittest.TestCase):
 
         # assert that the temporary file was deleted
         mocked_os.assert_called_once_with("tmp.file")
+
+    def test_add_additional_metadata(self):
+        self.local_storage.validate_additional_metadata.return_value = True
+
+        self.assertTrue(
+            self.file_manager.validate_additional_metadata(
+                octoprint.filemanager.FileDestinations.LOCAL, {"foo": "bar"}
+            )
+        )
+
+    def test_add_additional_metadata_invalid_value(self):
+        self.local_storage.validate_additional_metadata.return_value = True
+
+        self.assertFalse(
+            self.file_manager.validate_additional_metadata(
+                octoprint.filemanager.FileDestinations.LOCAL, "value"
+            )
+        )
+
+    def test_add_additional_metadata_storage_validation_fails(self):
+        self.local_storage.validate_additional_metadata.return_value = False
+
+        self.assertFalse(
+            self.file_manager.validate_additional_metadata(
+                octoprint.filemanager.FileDestinations.LOCAL, {"foo": "bar"}
+            )
+        )

--- a/tests/filemanager/test_localstorage.py
+++ b/tests/filemanager/test_localstorage.py
@@ -809,12 +809,12 @@ class LocalStorageTest(unittest.TestCase):
         data = {"foo": "bar"}
         self.assertTrue(self.storage.validate_additional_metadata(data))
 
-    @data({"foo": float("inf")}, {"foo": float("-inf")}, {"foo": float("nan")})
+    @data(float("inf"), float("-inf"), float("nan"))
     def test_validate_additional_metadata_invalid(self, data):
         self.assertFalse(self.storage.validate_additional_metadata(data))
 
-    @data({"foo": float("inf")}, {"foo": float("-inf")}, {"foo": float("nan")})
-    def test_set_additional_metadata(self, data):
+    @data(float("inf"), float("-inf"), float("nan"))
+    def test_set_additional_metadata_invalid(self, data):
         try:
             self.storage.set_additional_metadata("bp_case.gcode", "unittest", data)
             self.fail("Expected StorageError")

--- a/tests/filemanager/test_localstorage.py
+++ b/tests/filemanager/test_localstorage.py
@@ -805,6 +805,24 @@ class LocalStorageTest(unittest.TestCase):
             json_metadata = json.load(f)
         self.assertDictEqual(metadata, json_metadata)
 
+    def test_validate_additional_metadata(self):
+        data = {"foo": "bar"}
+        self.assertTrue(self.storage.validate_additional_metadata(data))
+
+    @data({"foo": float("inf")}, {"foo": float("-inf")}, {"foo": float("nan")})
+    def test_validate_additional_metadata_invalid(self, data):
+        self.assertFalse(self.storage.validate_additional_metadata(data))
+
+    @data({"foo": float("inf")}, {"foo": float("-inf")}, {"foo": float("nan")})
+    def test_set_additional_metadata(self, data):
+        try:
+            self.storage.set_additional_metadata("bp_case.gcode", "unittest", data)
+            self.fail("Expected StorageError")
+        except StorageError as exc:
+            self.assertEqual(exc.code, StorageError.INVALID_METADATA)
+        except Exception:
+            self.fail("Expected StorageError")
+
     def _add_file(
         self, path, file_object, overwrite=False, display=None, progress_callback=None
     ):

--- a/tests/filemanager/test_printerstorage.py
+++ b/tests/filemanager/test_printerstorage.py
@@ -124,7 +124,7 @@ def test_set_additional_metadata():
     printer_storage = PrinterFileStorage(connection)
     printer_storage.set_additional_metadata(path, key, data)
 
-    assert meta.additional.get("unittest") == data
+    assert meta.additional.get(key) == data
     connection.set_printer_file_metadata.assert_called_with(path, meta)
 
 
@@ -153,7 +153,7 @@ def test_set_additional_metadata_unsupported():
         printer_storage.set_additional_metadata(path, key, data)
 
     assert exc.value.code == StorageError.UNSUPPORTED
-    assert meta.additional.get("unittest") is None
+    assert meta.additional.get(key) is None
     connection.set_printer_file_metadata.assert_not_called()
 
 
@@ -182,7 +182,7 @@ def test_set_additional_metadata_invalid():
         printer_storage.set_additional_metadata(path, key, data)
 
     assert exc.value.code == StorageError.INVALID_METADATA
-    assert meta.additional.get("unittest") is None
+    assert meta.additional.get(key) is None
     connection.set_printer_file_metadata.assert_not_called()
 
 

--- a/tests/filemanager/test_printerstorage.py
+++ b/tests/filemanager/test_printerstorage.py
@@ -102,6 +102,100 @@ def test_list_storage_entries(path, filters, recursive, level, expected):
     assert actual == expected
 
 
+def test_set_additional_metadata():
+    from octoprint.filemanager.storage import MetadataEntry
+    from octoprint.filemanager.storage.printer import (
+        PrinterFileStorage,
+        StorageCapabilities,
+    )
+
+    capabilities = StorageCapabilities(metadata=True)
+    meta = MetadataEntry()
+
+    path = "test/foo.gcode"
+    key = "unittest"
+    data = {"foo": "bar"}
+
+    connection = mock.MagicMock(PrinterFilesMixin)
+    connection.current_storage_capabilities = capabilities
+    connection.validate_printer_file_additional_metadata.return_value = True
+    connection.get_printer_file_metadata.return_value = meta
+
+    printer_storage = PrinterFileStorage(connection)
+    printer_storage.set_additional_metadata(path, key, data)
+
+    assert meta.additional.get("unittest") == data
+    connection.set_printer_file_metadata.assert_called_with(path, meta)
+
+
+def test_set_additional_metadata_unsupported():
+    from octoprint.filemanager.storage import MetadataEntry
+    from octoprint.filemanager.storage.printer import (
+        PrinterFileStorage,
+        StorageCapabilities,
+        StorageError,
+    )
+
+    capabilities = StorageCapabilities()
+    meta = MetadataEntry()
+
+    path = "test/foo.gcode"
+    key = "unittest"
+    data = {"foo": "bar"}
+
+    connection = mock.MagicMock(PrinterFilesMixin)
+    connection.current_storage_capabilities = capabilities
+    connection.validate_printer_file_additional_metadata.return_value = True
+    connection.get_printer_file_metadata.return_value = meta
+
+    printer_storage = PrinterFileStorage(connection)
+    with pytest.raises(StorageError) as exc:
+        printer_storage.set_additional_metadata(path, key, data)
+
+    assert exc.value.code == StorageError.UNSUPPORTED
+    assert meta.additional.get("unittest") is None
+    connection.set_printer_file_metadata.assert_not_called()
+
+
+def test_set_additional_metadata_invalid():
+    from octoprint.filemanager.storage import MetadataEntry
+    from octoprint.filemanager.storage.printer import (
+        PrinterFileStorage,
+        StorageCapabilities,
+        StorageError,
+    )
+
+    capabilities = StorageCapabilities(metadata=True)
+    meta = MetadataEntry()
+
+    path = "test/foo.gcode"
+    key = "unittest"
+    data = {"foo": "bar"}
+
+    connection = mock.MagicMock(PrinterFilesMixin)
+    connection.current_storage_capabilities = capabilities
+    connection.validate_printer_file_additional_metadata.return_value = False
+    connection.get_printer_file_metadata.return_value = meta
+
+    printer_storage = PrinterFileStorage(connection)
+    with pytest.raises(StorageError) as exc:
+        printer_storage.set_additional_metadata(path, key, data)
+
+    assert exc.value.code == StorageError.INVALID_METADATA
+    assert meta.additional.get("unittest") is None
+    connection.set_printer_file_metadata.assert_not_called()
+
+
+def test_validate_additional_metadata():
+    from octoprint.filemanager.storage.printer import PrinterFileStorage
+
+    connection = mock.MagicMock(PrinterFilesMixin)
+    connection.validate_printer_file_additional_metadata.return_value = True
+
+    printer_storage = PrinterFileStorage(connection)
+    printer_storage.validate_additional_metadata({"foo": "bar"})
+
+
 def _extract_paths_from_files(nodes: dict[str, dict]) -> list[str]:
     result = []
 


### PR DESCRIPTION
<!--
Thank you for your interest in contributing to OctoPrint, it's
highly appreciated!

Please make sure you have read the "guidelines for contributing" as
linked just above this form, there's a section on Pull Requests in there
as well which contains important information.

As a summary, please make sure you have ticked all points on this
checklist:
-->

- [x] You have read through `CONTRIBUTING.md`
- [x] Your changes are not possible to do through a plugin and relevant
  to a large audience (ideally all users of OctoPrint)
- [ ] If your changes are large or otherwise disruptive: You have
  made sure your changes don't interfere with current development by
  talking it through with the maintainers, e.g. through a
  Brainstorming ticket
- [ ] Your PR targets OctoPrint's `dev` branch
- [x] Your PR was opened from a custom branch on your repository
  (no PRs from your version of `main`, `bugfix`, `next` or `dev`
  please), e.g. `wip/my_new_feature` or `wip/my_bugfix`
- [x] Your PR only contains relevant changes: no unrelated files,
  no dead code, ideally only one commit - rebase and squash your PR
  if necessary!
- [ ] If your changes include style sheets: You have modified the
  `.less` source files, not the `.css` files (those are generated
  with `lessc`)
- [x] You have tested your changes (please state how!) - ideally you
  have added unit tests
- [x] You have run the existing unit tests against your changes and
  nothing broke (`pytest`)
- [x] You have run the included `pre-commit` suite against your changes
  and nothing broke (`pre-commit run --all-files`)
- [x] You have added yourself to the `AUTHORS.md` file :)

<!--
Describe your PR further using the template provided below. The more
details the better!
-->

#### What does this PR do and why is it necessary?

While working on migrating the PrintTimeGenius plugin to OctoPrint 2.0.0, I noticed that when it analyzed corrupted or invalid gcode files that I had in the uploads folder, due to a bug it sometimes tried to save the values `Inf` and `NaN` into the metadata.

This caused every call to `/api/files` to crash until OctoPrint was restarted:

<details>
<summary>Stacktrace</summary>

```stacktrace
2026-08-26 00:10:53,694 - octoprint - ERROR - Exception on /api/files [GET]
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 1511, in wsgi_app
    response = self.full_dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 919, in full_dispatch_request
    rv = self.handle_user_exception(e)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 917, in full_dispatch_request
    rv = self.dispatch_request()
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/app.py", line 902, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 2084, in __call__
    return handler(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/vendor/flask_principal.py", line 196, in _decorated
    rv = f(*args, **kw)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 1395, in decorated_function
    response = f(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/api/files.py", line 264, in readGcodeFiles_post_2_0_0
    return jsonify(**{k: v.model_dump(by_alias=True) for k, v in storages.items()})
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/json/__init__.py", line 170, in jsonify
    return current_app.json.response(*args, **kwargs)  # type: ignore[return-value]
           ~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/json/provider.py", line 214, in response
    f"{self.dumps(obj, **dump_args)}\n", mimetype=self.mimetype
       ~~~~~~~~~~^^^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/server/util/flask.py", line 2008, in dumps
    return super().dumps(obj, **kwargs)
           ~~~~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/venv/lib/python3.14/site-packages/flask/json/provider.py", line 179, in dumps
    return json.dumps(obj, **kwargs)
           ~~~~~~~~~~^^^^^^^^^^^^^^^
  File "/usr/lib/python3.14/json/__init__.py", line 242, in dumps
    **kw).encode(obj)
          ~~~~~~^^^^^
  File "/usr/lib/python3.14/json/encoder.py", line 202, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.14/json/encoder.py", line 263, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant: inf
when serializing dict item 'badvalue'
when serializing dict item 'bug_repro'
when serializing list item 1
when serializing dict item 'children'
when serializing list item 1
when serializing dict item 'children'
when serializing list item 15
when serializing dict item 'files'
when serializing dict item 'local'
2026-08-26 00:10:53,697 - tornado.access - ERROR - 500 GET /api/files?recursive=true (127.0.0.1) 39.00ms
 
```

</details>

Commits b79fc94a4 and 4cb67fe72 had added filters to `_get_metadata` to prevent reading `NaN` and `Inf`, but they forgot to filter `_save_metadata` as well. This PR adds the filter to `_save_metadata` too.

I believe this bug has affected OctoPrint at least since 1.9.0, maybe even earlier.

#### How was it tested? How can it be tested by the reviewer?

Place the following script, which adds an `Inf` field to the metadata of uploaded files, in /home/user/.octoprint/plugins/bug_repro.py and restart OctoPrint:

```py
import octoprint.plugin
from octoprint.events import Events


class BugReproPlugin(
    octoprint.plugin.StartupPlugin,
    octoprint.plugin.EventHandlerPlugin,
):
    def on_after_startup(self):
        self._logger.info("=== BUG REPRO plugin loaded ===")

    def on_event(self, event, payload):
        if event != Events.FILE_ADDED:
            return

        storage = payload.get("storage")
        path = payload.get("path")

        self._logger.info(
            f"Poisoning metadata of {storage}:{path} with a non-finite float"
        )

        self._file_manager.set_additional_metadata(
            storage,
            path,
            "bug_repro",
            {"badvalue": float("inf")},
            overwrite=True,
        )

        self._logger.info(
            "Metadata poisoned, /api/files should now be broken for the whole storage"
        )


__plugin_name__ = "Bug Repro"
__plugin_pythoncompat__ = ">=3.7,<4"
__plugin_implementation__ = BugReproPlugin()
```

Then upload a file. From that point on, until OctoPrint is restarted, calls to `/api/files` fail with a 500 error:

```bash
curl -s "127.0.0.1:5000/api/files" -H "X-Api-Key: $APIKEY"
```

After the fix in this PR, the API no longer crashes, and the plugin trying to save an invalid value correctly gets a `ValueError`:

<details>
<summary>Stacktrace</summary>

```stacktrace
2026-08-26 00:18:32,738 - octoprint.plugin - ERROR - Error while calling plugin bug_repro
Traceback (most recent call last):
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/plugin/__init__.py", line 285, in call_plugin
    result = getattr(plugin, method)(*args, **kwargs)
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/util/__init__.py", line 1691, in wrapper
    return f(*args, **kwargs)
  File "/home/user/.octoprint/plugins/bug_repro.py", line 23, in on_event
    self._file_manager.set_additional_metadata(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        storage,
        ^^^^^^^^
    ...<3 lines>...
        overwrite=True,
        ^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/__init__.py", line 1413, in set_additional_metadata
    self._storage(location).set_additional_metadata(
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^
        path, key, data, overwrite=overwrite, merge=merge
        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    )
    ^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/local.py", line 932, in set_additional_metadata
    self._save_metadata(path, metadata)
    ~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^
  File "/home/user/Desktop/OctoPrint/OctoPrint-upstream/src/octoprint/filemanager/storage/local.py", line 1785, in _save_metadata
    serialized = json.dumps(
        metadata, indent=2, separators=(",", ": "), allow_nan=False
    )
  File "/usr/lib/python3.14/json/__init__.py", line 242, in dumps
    **kw).encode(obj)
          ~~~~~~^^^^^
  File "/usr/lib/python3.14/json/encoder.py", line 202, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.14/json/encoder.py", line 263, in iterencode
    return _iterencode(o, 0)
ValueError: Out of range float values are not JSON compliant: inf
```

</details>

It may be necessary to add to the documentation that the `set_additional_metadata` can now raise a `ValueError`.

#### Was any kind of genAI (ChatGPT, Copilot etc) involved in creating this PR? Which one and how?

No.

#### Any background context you want to provide?

To be honest, I'm not 100% sure if my fix is the right approach. The idea is to align `_save_metadata` with the same filters as `_get_metadata`, but it may be better to just fix the API crash instead.

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

<!--
Be advised that your PR will be checked automatically by CI. Should any of the CI
checks fail, you will be expected to fix them before your PR will be reviewed, so
keep an eye on it!
-->
